### PR TITLE
pbkdf2 v0.4.0

### DIFF
--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 (2020-06-10)
+### Changed
+- Code improvements ([#33])
+- Bump `rand` dependency to v0.7 ([#31])
+- Bump `hmac` to v0.8 ([#30])
+- Bump `sha2` to v0.9 ([#30])
+- Bump `subtle` to v2 ([#13])
+- MSRV 1.41+ ([#30])
+- Upgrade to Rust 2018 edition ([#24])
+
+[#33]: https://github.com/RustCrypto/password-hashing/pull/33
+[#31]: https://github.com/RustCrypto/password-hashing/pull/31
+[#30]: https://github.com/RustCrypto/password-hashing/pull/30
+[#24]: https://github.com/RustCrypto/password-hashing/pull/24
+[#13]: https://github.com/RustCrypto/password-hashing/pull/13
+
+## 0.3.0 (2018-10-08)
+
+## 0.2.3 (2018-08-30)
+
+## 0.2.2 (2018-08-15)
+
+## 0.2.1 (2018-08-06)
+
+## 0.2.0 (2018-03-30)
+
+## 0.1.0 (2017-08-16)

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 hmac = "0.8"
-pbkdf2 = { version = "= 0.4.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.4", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 
 base64 = { version = "0.12", default-features = false, optional = true }


### PR DESCRIPTION
### Changed
- Code improvements ([#33])
- Bump `rand` dependency to v0.7 ([#31])
- Bump `hmac` to v0.8 ([#30])
- Bump `sha2` to v0.9 ([#30])
- Bump `subtle` to v2 ([#13])
- MSRV 1.41+ ([#30])
- Upgrade to Rust 2018 edition ([#24])

[#33]: https://github.com/RustCrypto/password-hashing/pull/33
[#31]: https://github.com/RustCrypto/password-hashing/pull/31
[#30]: https://github.com/RustCrypto/password-hashing/pull/30
[#24]: https://github.com/RustCrypto/password-hashing/pull/24
[#13]: https://github.com/RustCrypto/password-hashing/pull/13