### PR TITLE
scrypt: enable alloc feature for base64

### DIFF
--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -15,7 +15,7 @@ hmac = "0.8"
 pbkdf2 = { version = "0.4", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 
-base64 = { version = "0.12", default-features = false, optional = true }
+base64 = { version = "0.12", default-features = false, features = ["alloc"], optional = true }
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"], optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 subtle = { version = "2", default-features = false, optional = true }

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -5,7 +5,6 @@ use crate::ScryptParams;
 use core::convert::TryInto;
 use alloc::string::String;
 use subtle::ConstantTimeEq;
-use base64;
 use rand_core::RngCore;
 
 #[cfg(not(features = "thread_rng"))]


### PR DESCRIPTION
It looks like the error has not been catched by CI due to the feature unification with `pbkdf2`. :/ Another reason to start working on #35.