### PR TITLE
Remove superflous main() in documentation

### DIFF
--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -27,6 +27,7 @@
 //! assert!(scrypt_check("Not so secure password", &hashed_password).is_ok());
 //! # }
 //! # #[cfg(not(feature="include_simple"))]
+//! # fn main() {}
 //! ```
 //!
 //! # References

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -27,7 +27,6 @@
 //! assert!(scrypt_check("Not so secure password", &hashed_password).is_ok());
 //! # }
 //! # #[cfg(not(feature="include_simple"))]
-//! fn main() {}
 //! ```
 //!
 //! # References


### PR DESCRIPTION
The current documentation has an unneeded `fn main() {}` in the *Usage* section. This commit removes the line; alternatively, the code example could be wrapped in `main`.