### PR TITLE
Release pbkdf2 v0.5.0 + scrypt v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.2.1"
 dependencies = [
  "blowfish",
  "crypto-mac 0.8.0",
- "pbkdf2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pbkdf2 0.4.0",
  "sha2",
  "zeroize",
 ]
@@ -245,6 +245,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pbkdf2"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac 0.8.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.5.0"
 dependencies = [
  "base64",
  "crypto-mac 0.9.1",
@@ -255,15 +264,6 @@ dependencies = [
  "sha-1",
  "sha2",
  "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac 0.8.0",
 ]
 
 [[package]]
@@ -344,11 +344,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hmac",
- "pbkdf2 0.4.0",
+ "pbkdf2 0.5.0",
  "rand",
  "rand_core",
  "sha2",

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-08-18)
+### Changed
+- Bump `crypto-mac` dependency to v0.9 ([#44])
+
+[#44]: https://github.com/RustCrypto/password-hashing/pull/44
+
 ## 0.4.0 (2020-06-10)
 ### Changed
 - Code improvements ([#33])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-08-18)
+### Changed
+- Bump `pbkdf2` dependency to v0.5 ([#45])
+
+[#45]: https://github.com/RustCrypto/password-hashing/pull/45
+
 ## 0.3.1 (2020-07-03)
 ### Fixed
 - Enable `alloc` feature for `base64`. ([#38])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 hmac = "0.9"
-pbkdf2 = { version = "0.4", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.5", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 
 base64 = { version = "0.12", default-features = false, features = ["alloc"], optional = true }


### PR DESCRIPTION
## pbkdf2 0.5.0 (2020-08-18)
### Changed
- Bump `crypto-mac` dependency to v0.9 ([#44])

[#44]: https://github.com/RustCrypto/password-hashing/pull/44

## scrypt 0.4.0 (2020-08-18)
### Changed
- Bump `pbkdf2` dependency to v0.5 ([#45])

[#45]: https://github.com/RustCrypto/password-hashing/pull/45