### PR TITLE
docs (scrypt): use ScryptParams::recommended() in usage example

### DIFF
--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -17,9 +17,8 @@
 //! # fn main() {
 //! use scrypt::{ScryptParams, scrypt_simple, scrypt_check};
 //!
-//! // First setup the ScryptParams arguments with:
-//! // r = 8, p = 1, n = 32768 (log2(n) = 15)
-//! let params = ScryptParams::new(15, 8, 1).unwrap();
+//! // First setup the ScryptParams arguments with the recommended defaults
+//! let params = ScryptParams::recommended();
 //! // Hash the password for storage
 //! let hashed_password = scrypt_simple("Not so secure password", &params)
 //!     .expect("OS RNG should not fail");


### PR DESCRIPTION
This PR changes the example in `scrypt` to generate the `params` using `ScryptParams::recommended()`, per discussion in #49.

Confirmed it's working by running doc tests.
```bash
❯ cargo test --doc
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
   Doc-tests scrypt

running 1 test
test src/lib.rs -  (line 13) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```