### PR TITLE
Release new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "blowfish",
  "crypto-mac",
@@ -227,7 +227,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pbkdf2"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "base64",
  "crypto-mac",
@@ -327,7 +327,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "base64",
  "hmac",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-18)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#58])
+- Bump `pbkdf2` dependency to v0.10 ([#61])
+
+[#61]: https://github.com/RustCrypto/password-hashing/pull/61
+[#58]: https://github.com/RustCrypto/password-hashing/pull/58
+
 ## 0.3.0 (2020-08-18)
 ### Changed
 - Bump `crypto-mac` dependency to v0.9, `blowfish` to v0.6, and `pbkdf2` to v0.5 ([#46])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bcrypt-pbkdf"
 description = "bcrypt-pbkdf password-based key derivation function"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"
 keywords = ["crypto", "password", "hashing"]
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 blowfish = { version = "0.7", features = ["bcrypt"] }
 crypto-mac = "0.10"
-pbkdf2 = { version = "0.6.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.6.0", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-18)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#58])
+- Bump `hmac` dependency to v0.10 ([#58])
+
+[#58]: https://github.com/RustCrypto/password-hashing/pull/58
+
 ## 0.5.0 (2020-08-18)
 ### Changed
 - Bump `crypto-mac` dependency to v0.9 ([#44])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-18)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#58])
+- Use `salsa20`crate to implement Salsa20/8 ([#60])
+
+[#60]: https://github.com/RustCrypto/password-hashing/pull/60
+[#58]: https://github.com/RustCrypto/password-hashing/pull/58
+
 ## 0.4.1 (2020-08-24)
 ### Changed
 - Minor documentation update ([#50])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.5.0-pre"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64 = { version = "0.13", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
-pbkdf2 = { version = "0.6.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.6.0", default-features = false, path = "../pbkdf2" }
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"], optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 salsa20 = { version = "0.7.1", default-features = false, features = ["expose-core"] }


### PR DESCRIPTION
Cuts the following new releases which include an upgrade to `crypto-mac` v0.10 (#58):

- `bcrypt-pbkdf` v0.4.0
- `pbkdf2` v0.6.0
- `scrypt` v0.5.0