### PR TITLE
sha-crypt: CI config and documentation boilerplate

### DIFF
--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -1,0 +1,57 @@
+name: sha-crypt
+
+on:
+  pull_request:
+    paths:
+      - "sha-crypt/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: sha-crypt
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+# TODO(tarcieri): no_std
+#  build:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        rust:
+#          - 1.41.0 # MSRV
+#          - stable
+#        target:
+#          - thumbv7em-none-eabi
+#          - wasm32-unknown-unknown
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.41.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      # TODO(tarcieri): doesn't pass yet
+      #- run: cargo test --release --no-default-features
+      - run: cargo test --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "constant_time_eq",
  "rand",

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "sha-crypt"
-version = "0.1.0"
+version = "0.0.0"
+description = """
+Pure Rust implementation of the SHA-crypt password hash based on SHA-512
+as implemented by the POSIX crypt C library
+"""
 authors = ["RustCrypto Developers"]
-description = "sha-crypt password hashing"
 documentation = "https://docs.rs/sha-crypt"
-repository = "https://github.com/RustCrypto/password-hashing"
+repository = "https://github.com/RustCrypto/password-hashes/tree/master/sha-crypt"
 keywords = ["crypto", "password", "hashing"]
 edition = "2018"
 categories = ["cryptography"]
+readme = "README.md"
 
 [dependencies]
 sha2 = "0.9"
@@ -17,6 +21,3 @@ constant_time_eq = { version = "0.1", optional = true }
 [features]
 default = [ "include_simple" ]
 include_simple = [ "rand", "constant_time_eq" ]
-
-[badges]
-travis-ci = { repository = "RustCrypto/password-hashing" }

--- a/sha-crypt/README.md
+++ b/sha-crypt/README.md
@@ -1,0 +1,62 @@
+# RustCrypto: SHA-crypt password hash
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+[![Build Status][build-image]][build-link]
+
+Pure Rust implementation of the [SHA-crypt password hash based on SHA-512][1],
+a legacy password hashing scheme supported by the [POSIX crypt C library][2].
+
+Password hashes using this algorithm start with `$6$` when encoded using the
+[PHC string format][3].
+
+[Documentation][docs-link]
+
+## Minimum Supported Rust Version
+
+Rust **1.41** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
+
+## SemVer Policy
+
+- All on-by-default features of this library are covered by SemVer
+- MSRV is considered exempt from SemVer as noted above
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/sha-crypt.svg
+[crate-link]: https://crates.io/crates/sha-crypt
+[docs-image]: https://docs.rs/sha-crypt/badge.svg
+[docs-link]: https://docs.rs/sha-crypt/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
+[build-image]: https://github.com/RustCrypto/password-hashes/workflows/sha-crypt/badge.svg?branch=master&event=push
+[build-link]: https://github.com/RustCrypto/password-hashes/actions?query=workflow%3Asha-crypt
+
+[//]: # (general links)
+
+[1]: https://www.akkadia.org/drepper/SHA-crypt.txt
+[2]: https://en.wikipedia.org/wiki/Crypt_(C)
+[3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -1,16 +1,12 @@
-//! This crate implements the UNIX crypt using SHA-512 password hashing based
-//! on \[1\].
+//! Pure Rust implementation of the [`SHA-crypt` password hash based on SHA-512][1],
+//! a legacy password hashing scheme supported by the [POSIX crypt C library][2].
 //!
-//! ```toml
-//! [dependencies]
-//! sha-crypt = { version = "0.1", default-features = false }
-//! ```
+//! Password hashes using this algorithm start with `$6$` when encoded using the
+//! [PHC string format][3].
+//!
 //! # Usage
 //!
 //! ```
-//! extern crate sha_crypt;
-//!
-//! # fn main() {
 //! use sha_crypt::{Sha512Params, sha512_simple, sha512_check};
 //!
 //! // First setup the Sha512Params arguments with:
@@ -21,13 +17,12 @@
 //!     .expect("Should not fail");
 //! // Verifying a stored password
 //! assert!(sha512_check("Not so secure password", &hashed_password).is_ok());
-//! # }
 //! ```
 //!
-//! # References
-//! \[1\] - [Ulrich Drepper et.al. Unix crypt using SHA-256 and SHA-512]
-//! (https://www.akkadia.org/drepper/SHA-crypt.txt)
-//!
+//! [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
+//! [2]: https://en.wikipedia.org/wiki/Crypt_(C)
+//! [3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
+
 #[cfg(feature = "include_simple")]
 use constant_time_eq::constant_time_eq;
 #[cfg(feature = "include_simple")]
@@ -261,9 +256,9 @@ pub fn sha512_crypt_b64(
 ///
 ///  `$<ID>$<SALT>$<HASH>`
 ///
-/// # Return
-/// `Ok(String)` containing the full SHA512 password hash format, or
-/// Err(CryptError) if something went wrong.
+/// # Returns
+/// - `Ok(String)` containing the full SHA512 password hash format on success
+/// - `Err(CryptError)` if something went wrong.
 #[cfg(feature = "include_simple")]
 pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, CryptError> {
     let rng = thread_rng();
@@ -298,6 +293,8 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, Cr
 /// # Return
 /// `OK(())` if password matches otherwise Err(CheckError) in case of invalid
 /// format or password mismatch.
+///
+/// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
 #[cfg(feature = "include_simple")]
 pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let mut iter = hashed_value.split('$');


### PR DESCRIPTION
Adds a GitHub Actions workflow for `sha-crypt` as well as the standard README.md boilerplate we use for other crates in this repo.