### PR TITLE
sha-crypt: rename `simple` feature + doc_cfg

### DIFF
--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -32,11 +32,11 @@ jobs:
 #      - uses: actions/checkout@v1
 #      - uses: actions-rs/toolchain@v1
 #        with:
-#          profile: minimal
 #          toolchain: ${{ matrix.rust }}
 #          target: ${{ matrix.target }}
+#          profile: minimal
 #          override: true
-#      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+#      - run: cargo build --release --target ${{ matrix.target }}
 
   test:
     runs-on: ubuntu-latest
@@ -49,8 +49,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test --release --no-default-features
+          profile: minimal
       - run: cargo test --release
+      - run: cargo test --release --all-features

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: password hashing ![Rust Version][rustc-image] [![Project Chat][chat-image]][chat-link]
+# RustCrypto: password hashes ![Rust Version][rustc-image] [![Project Chat][chat-image]][chat-link]
 
 Collection of password hashing algorithms, otherwise known as password-based key
 derivation functions, written in pure Rust.
@@ -7,10 +7,10 @@ derivation functions, written in pure Rust.
 
 | Name      | Crates.io  | Documentation  |
 | --------- |:----------:| :-----:|
+| [bcrypt-pbkdf](https://flak.tedunangst.com/post/bcrypt-pbkdf) | [![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) |
 | [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2)  | [![crates.io](https://img.shields.io/crates/v/pbkdf2.svg)](https://crates.io/crates/pbkdf2) | [![Documentation](https://docs.rs/pbkdf2/badge.svg)](https://docs.rs/pbkdf2) |
 | [scrypt](https://en.wikipedia.org/wiki/Scrypt)  | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt) | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) |
 | [SHA-crypt](https://www.akkadia.org/drepper/SHA-crypt.txt)    | [![crates.io](https://img.shields.io/crates/v/sha-crypt.svg)](https://crates.io/crates/sha-crypt) | [![Documentation](https://docs.rs/sha-crypt/badge.svg)](https://docs.rs/sha-crypt) |
-| [bcrypt-pbkdf](https://flak.tedunangst.com/post/bcrypt-pbkdf) | [![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) |
 
 ## License
 

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -15,9 +15,12 @@ readme = "README.md"
 
 [dependencies]
 sha2 = "0.9"
-rand = { version = "0.7",  optional = true }
+rand = { version = "0.7", optional = true }
 constant_time_eq = { version = "0.1", optional = true }
 
 [features]
-default = [ "include_simple" ]
-include_simple = [ "rand", "constant_time_eq" ]
+simple = ["rand", "constant_time_eq"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/sha-crypt/src/b64.rs
+++ b/sha-crypt/src/b64.rs
@@ -20,7 +20,7 @@ pub fn encode(source: &[u8]) -> Vec<u8> {
     out
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub fn decode(source: &[u8]) -> Vec<u8> {
     let mut out: [u8; 64] = [0; 64];
     for iter in MAP.iter().enumerate() {
@@ -49,7 +49,7 @@ pub fn decode(source: &[u8]) -> Vec<u8> {
 }
 
 mod tests {
-    #[cfg(feature = "include_simple")]
+    #[cfg(feature = "simple")]
     #[test]
     fn test_encode_decode() {
         let original: [u8; 64] = [

--- a/sha-crypt/src/defs.rs
+++ b/sha-crypt/src/defs.rs
@@ -1,5 +1,5 @@
 pub const BLOCK_SIZE: usize = 64;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub const SALT_MAX_LEN: usize = 16;
 pub static TAB: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 pub const MAP: [(u8, u8, u8, u8); 22] = [

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```
-//! # #[cfg(feature = "include_simple")]
+//! # #[cfg(feature = "simple")]
 //! # {
 //! use sha_crypt::{Sha512Params, sha512_simple, sha512_check};
 //!
@@ -28,11 +28,19 @@
 //! [2]: https://en.wikipedia.org/wiki/Crypt_(C)
 //! [3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 
-#[cfg(feature = "include_simple")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)] // TODO(tarcieri): add `missing_docs`
+
+#[cfg(feature = "simple")]
 use constant_time_eq::constant_time_eq;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use rand::distributions::Distribution;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use rand::{thread_rng, Rng};
 use sha2::{Digest, Sha512};
 use std::result::Result;
@@ -42,25 +50,26 @@ mod defs;
 pub mod errors;
 pub mod params;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use errors::CheckError;
 use errors::CryptError;
 pub use params::{Sha512Params, ROUNDS_DEFAULT, ROUNDS_MAX, ROUNDS_MIN};
 
 use defs::BLOCK_SIZE;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use defs::{SALT_MAX_LEN, TAB};
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 static SHA512_SALT_PREFIX: &str = "$6$";
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 static SHA512_ROUNDS_PREFIX: &str = "rounds=";
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[derive(Debug)]
 struct ShaCryptDistribution;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 impl Distribution<char> for ShaCryptDistribution {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
         const RANGE: u32 = 26 + 26 + 10 + 2; // 2 == "./"
@@ -264,7 +273,8 @@ pub fn sha512_crypt_b64(
 /// # Returns
 /// - `Ok(String)` containing the full SHA512 password hash format on success
 /// - `Err(CryptError)` if something went wrong.
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, CryptError> {
     let rng = thread_rng();
 
@@ -300,7 +310,8 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, Cr
 /// format or password mismatch.
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let mut iter = hashed_value.split('$');
 

--- a/sha-crypt/tests/mod.rs
+++ b/sha-crypt/tests/mod.rs
@@ -1,6 +1,6 @@
 use sha_crypt::{sha512_crypt_b64, Sha512Params, ROUNDS_MAX, ROUNDS_MIN};
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use sha_crypt::{sha512_check, sha512_simple};
 
 struct TestCrypt {
@@ -55,7 +55,7 @@ fn test_sha512_crypt_invalid_rounds() {
     assert!(params.is_err());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_check() {
     let pw = "foobar";
@@ -63,7 +63,7 @@ fn test_sha512_check() {
     assert!(sha512_check(pw, s).is_ok());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_check_with_rounds() {
     let pw = "foobar";
@@ -71,7 +71,7 @@ fn test_sha512_check_with_rounds() {
     assert!(sha512_check(pw, s).is_ok());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_simple_check_roundtrip() {
     let pw = "this is my password";
@@ -85,7 +85,7 @@ fn test_sha512_simple_check_roundtrip() {
     assert!(c_r.is_ok());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_check_invalid_format() {
     // unexpected prefix 'SHOULDNOTBEHERE'


### PR DESCRIPTION
...from `include-simple`. Just `simple` is... simpler.

Also adds `doc_cfg` for https://docs.rs to document functions gated on this feature.