### PR TITLE
sha-crypt: use `subtle` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,9 +364,9 @@ dependencies = [
 name = "sha-crypt"
 version = "0.0.0"
 dependencies = [
- "constant_time_eq",
  "rand",
  "sha2",
+ "subtle",
 ]
 
 [[package]]

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -16,11 +16,11 @@ readme = "README.md"
 [dependencies]
 sha2 = "0.9"
 rand = { version = "0.7",  optional = true }
-constant_time_eq = { version = "0.1", optional = true }
+subtle = { version = "2", default-features = false, optional = true }
 
 [features]
 default = ["include_simple"]
-include_simple = ["rand", "constant_time_eq"]
+include_simple = ["rand", "subtle"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Consistent with the other crates in this repo