### PR TITLE
sha-crypt: `std` feature (i.e. preliminary `no_std` support)

### DIFF
--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -17,26 +17,25 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-# TODO(tarcieri): no_std
-#  build:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        rust:
-#          - 1.41.0 # MSRV
-#          - stable
-#        target:
-#          - thumbv7em-none-eabi
-#          - wasm32-unknown-unknown
-#    steps:
-#      - uses: actions/checkout@v1
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          target: ${{ matrix.target }}
-#          override: true
-#      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.41.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
 
   test:
     runs-on: ubuntu-latest

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -14,13 +14,14 @@ categories = ["cryptography"]
 readme = "README.md"
 
 [dependencies]
-sha2 = "0.9"
-rand = { version = "0.7",  optional = true }
-subtle = { version = "2", default-features = false, optional = true }
+sha2 = { version = "0.9", default-features = false }
+rand = { version = "0.7", optional = true }
+subtle = { version = "2", optional = true, default-features = false }
 
 [features]
 default = ["include_simple"]
-include_simple = ["rand", "subtle"]
+include_simple = ["rand", "std", "subtle"]
+std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/src/b64.rs
+++ b/sha-crypt/src/b64.rs
@@ -1,4 +1,7 @@
+//! Base64 encoding support
+
 use crate::defs::{MAP, TAB};
+use alloc::vec::Vec;
 
 pub fn encode(source: &[u8]) -> Vec<u8> {
     let mut out: Vec<u8> = vec![];

--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -1,15 +1,25 @@
+//! Error types.
+
+use alloc::string;
+
+#[cfg(feature = "include_simple")]
+use alloc::string::String;
+
+#[cfg(feature = "std")]
 use std::io;
-use std::string;
 
 #[derive(Debug)]
 pub enum CryptError {
     /// Should be within range defs::ROUNDS_MIN < defs::ROUNDS_MIN
     RoundsError,
     RandomError,
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     IoError(io::Error),
     StringError(string::FromUtf8Error),
 }
 
+#[cfg(feature = "std")]
 impl From<io::Error> for CryptError {
     fn from(e: io::Error) -> Self {
         CryptError::IoError(e)
@@ -22,6 +32,8 @@ impl From<string::FromUtf8Error> for CryptError {
     }
 }
 
+#[cfg(feature = "include_simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
 #[derive(Debug)]
 pub enum CheckError {
     InvalidFormat(String),

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -28,6 +28,7 @@
 //! [2]: https://en.wikipedia.org/wiki/Crypt_(C)
 //! [3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -35,6 +36,13 @@
 )]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)] // TODO(tarcieri): add `missing_docs`
+
+// TODO(tarcieri): heapless support
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod errors;
 pub mod params;
@@ -48,8 +56,8 @@ pub use crate::{
     params::{Sha512Params, ROUNDS_DEFAULT, ROUNDS_MAX, ROUNDS_MIN},
 };
 
+use alloc::{string::String, vec::Vec};
 use sha2::{Digest, Sha512};
-use std::result::Result;
 
 #[cfg(feature = "include_simple")]
 use {
@@ -57,6 +65,7 @@ use {
         defs::{SALT_MAX_LEN, TAB},
         errors::CheckError,
     },
+    alloc::string::ToString,
     rand::{distributions::Distribution, thread_rng, Rng},
 };
 

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -1,5 +1,8 @@
+//! Algorithm parameters.
+
 use crate::errors;
-use std::default::Default;
+use core::default::Default;
+
 pub const ROUNDS_DEFAULT: usize = 5_000;
 pub const ROUNDS_MIN: usize = 1_000;
 pub const ROUNDS_MAX: usize = 999_999_999;


### PR DESCRIPTION
Adds basic support for disabling a `std` feature.

Presently still requires liballoc.

Also adds CI for builds on some no_std platforms.