### PR TITLE
pbkdf2: add PHC hash support using `password-hash` crate

### DIFF
--- a/.github/workflows/bcrypt-pbkdf.yml
+++ b/.github/workflows/bcrypt-pbkdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -35,14 +35,14 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -52,5 +52,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release --no-default-features
-      - run: cargo test --release --features parallel
       - run: cargo test --release
+      - run: cargo test --release --features include_simple
+      - run: cargo test --release --features parallel
+      - run: cargo test --release --features sha1
+      - run: cargo test --release --features include_simple,sha1
+      - run: cargo test --release --all-features

--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.41.0 # MSRV
+          toolchain: 1.47.0 # MSRV
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "b64ct"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a293adc36d315fd3f03a3c4a5594b0a30be4678cbae95ce9b430e9b8d6e34032"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
+
+[[package]]
 name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,12 +244,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "password-hash"
+version = "0.0.0"
+source = "git+https://github.com/rustcrypto/traits#8c0ead96042eda8dd3031ebb7224965163d0e0f3"
+dependencies = [
+ "b64ct",
+]
+
+[[package]]
 name = "pbkdf2"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "base64",
  "crypto-mac",
+ "hex-literal",
  "hmac",
+ "password-hash",
  "rand",
  "rand_core",
  "rayon",
@@ -335,7 +357,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "base64",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "scrypt",
     "sha-crypt"
 ]
+
+[patch.crates-io]
+password-hash = { git = "https://github.com/rustcrypto/traits" }

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 blowfish = { version = "0.7", features = ["bcrypt"] }
 crypto-mac = "0.10"
-pbkdf2 = { version = "0.6.0", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "=0.7.0-pre", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/bcrypt-pbkdf/README.md
+++ b/bcrypt-pbkdf/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the bcrypt-pbkdf password-based key derivation funct
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bcrypt-pbkdf/badge.svg
 [docs-link]: https://docs.rs/bcrypt-pbkdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/bcrypt-pbkdf/badge.svg?branch=master&event=push

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.6.0"
+version = "0.7.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -19,17 +19,24 @@ base64 = { version = "0.13", default-features = false, features = ["alloc"], opt
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"], optional = true }
 hmac = { version = "0.10", default-features = false, optional = true }
+password-hash = { version = "0", default-features = false, features = ["alloc"], optional = true }
+sha1 = { version = "0.9", package = "sha-1", default-features = false, optional = true }
 sha2 = { version = "0.9", default-features = false, optional = true }
 subtle = { version = "2", default-features = false, optional = true }
 
 [dev-dependencies]
+hex-literal = "0.3"
 hmac = "0.10"
-sha-1 = "0.9"
+sha1 = { version = "0.9", package = "sha-1" }
 sha2 = "0.9"
 
 [features]
 default = ["include_simple", "thread_rng"]
 parallel = ["rayon", "std"]
-include_simple = ["sha2", "hmac", "rand_core", "base64", "subtle"]
+include_simple = ["sha2", "hmac", "password-hash", "rand_core", "base64", "subtle"]
 thread_rng = ["rand"]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/pbkdf2/README.md
+++ b/pbkdf2/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the [Password-Based Key Derivation Function v2 (PBKD
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pbkdf2/badge.svg
 [docs-link]: https://docs.rs/pbkdf2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/pbkdf2/badge.svg?branch=master&event=push

--- a/pbkdf2/src/hasher.rs
+++ b/pbkdf2/src/hasher.rs
@@ -1,0 +1,229 @@
+//! Implementation of the `password-hash` crate API.
+
+use crate::{pbkdf2, simple};
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt,
+    str::FromStr,
+};
+use hmac::Hmac;
+use password_hash::{
+    errors::ParamsError, HasherError, Ident, McfHasher, Output, ParamsString, PasswordHash,
+    PasswordHasher, Salt,
+};
+use sha2::{Sha256, Sha512};
+
+#[cfg(feature = "sha1")]
+use sha1::Sha1;
+
+/// PBKDF2 (SHA-1)
+#[cfg(feature = "sha1")]
+pub const PBKDF2_SHA1: Ident = Ident::new("pbkdf2");
+
+/// PBKDF2 (SHA-256)
+pub const PBKDF2_SHA256: Ident = Ident::new("pbkdf2-sha256");
+
+/// PBKDF2 (SHA-512)
+pub const PBKDF2_SHA512: Ident = Ident::new("pbkdf2-sha512");
+
+/// PBKDF2 type for use with [`PasswordHasher`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+pub struct Pbkdf2;
+
+impl PasswordHasher for Pbkdf2 {
+    type Params = Params;
+
+    fn hash_password<'a>(
+        &self,
+        password: &[u8],
+        algorithm: Option<Ident<'a>>,
+        params: Params,
+        salt: Salt<'a>,
+    ) -> Result<PasswordHash<'a>, HasherError> {
+        let algorithm = AlgorithmId::new(algorithm.unwrap_or(PBKDF2_SHA256))?;
+
+        let mut salt_arr = [0u8; 64];
+        let salt_bytes = salt.b64_decode(&mut salt_arr)?;
+
+        let output = Output::init_with(params.output_length, |out| {
+            let f = match algorithm {
+                #[cfg(feature = "sha1")]
+                AlgorithmId::Sha1 => pbkdf2::<Hmac<Sha1>>,
+                AlgorithmId::Sha256 => pbkdf2::<Hmac<Sha256>>,
+                AlgorithmId::Sha512 => pbkdf2::<Hmac<Sha512>>,
+            };
+
+            f(password, salt_bytes, params.rounds, out);
+            Ok(())
+        })?;
+
+        Ok(PasswordHash {
+            algorithm: algorithm.ident(),
+            version: None,
+            params: params.try_into()?,
+            salt: Some(salt),
+            hash: Some(output),
+        })
+    }
+}
+
+impl McfHasher for Pbkdf2 {
+    fn upgrade_mcf_hash<'a>(&self, hash: &'a str) -> Result<PasswordHash<'a>, HasherError> {
+        use password_hash::errors::ParseError;
+
+        // TODO(tarcieri): better error here?
+        let (rounds, salt, hash) = simple::parse_hash(hash)
+            .map_err(|_| HasherError::Parse(ParseError::InvalidChar('?')))?;
+
+        let salt = Salt::new(b64_strip(salt))?;
+        let hash = Output::b64_decode(b64_strip(hash))?;
+
+        let params = Params {
+            rounds,
+            output_length: hash.len(),
+        };
+
+        Ok(PasswordHash {
+            algorithm: PBKDF2_SHA256,
+            version: None,
+            params: params.try_into()?,
+            salt: Some(salt),
+            hash: Some(hash),
+        })
+    }
+}
+
+/// Strip trailing `=` signs off a Base64 value to make a valid B64 value
+pub fn b64_strip(mut s: &str) -> &str {
+    while s.ends_with('=') {
+        s = &s[..(s.len() - 1)]
+    }
+    s
+}
+
+/// PBKDF2 variants.
+///
+/// <https://en.wikipedia.org/wiki/PBKDF2>
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+pub enum AlgorithmId {
+    /// PBKDF2 SHA1
+    #[cfg(feature = "sha1")]
+    Sha1,
+
+    /// PBKDF2 SHA-256
+    Sha256,
+
+    /// PBKDF2 SHA-512
+    Sha512,
+}
+
+impl AlgorithmId {
+    /// Parse an [`AlgorithmId`] from the provided [`Ident`]
+    pub fn new(id: Ident<'_>) -> Result<Self, HasherError> {
+        match id {
+            #[cfg(feature = "sha1")]
+            PBKDF2_SHA1 => Ok(AlgorithmId::Sha1),
+            PBKDF2_SHA256 => Ok(AlgorithmId::Sha256),
+            PBKDF2_SHA512 => Ok(AlgorithmId::Sha512),
+            _ => Err(HasherError::Algorithm),
+        }
+    }
+
+    /// Get the [`Ident`] that corresponds to this PBKDF2 [`AlgorithmId`].
+    pub fn ident(&self) -> Ident<'static> {
+        match self {
+            #[cfg(feature = "sha1")]
+            AlgorithmId::Sha1 => PBKDF2_SHA1,
+            AlgorithmId::Sha256 => PBKDF2_SHA256,
+            AlgorithmId::Sha512 => PBKDF2_SHA512,
+        }
+    }
+
+    /// Get the identifier string for this PBKDF2 [`AlgorithmId`].
+    pub fn as_str(&self) -> &str {
+        self.ident().as_str()
+    }
+}
+
+impl FromStr for AlgorithmId {
+    type Err = HasherError;
+
+    fn from_str(s: &str) -> Result<AlgorithmId, HasherError> {
+        Self::new(Ident::try_from(s)?)
+    }
+}
+
+impl AsRef<str> for AlgorithmId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<AlgorithmId> for Ident<'static> {
+    fn from(alg: AlgorithmId) -> Ident<'static> {
+        alg.ident()
+    }
+}
+
+impl fmt::Display for AlgorithmId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// PBKDF2 params
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+pub struct Params {
+    /// Number of rounds
+    pub rounds: u32,
+
+    /// Size of the output (in bytes)
+    pub output_length: usize,
+}
+
+impl Default for Params {
+    fn default() -> Params {
+        Params {
+            rounds: 10_000,
+            output_length: 32,
+        }
+    }
+}
+
+impl TryFrom<&ParamsString> for Params {
+    type Error = HasherError;
+
+    fn try_from(input: &ParamsString) -> Result<Self, HasherError> {
+        let mut output = Params::default();
+
+        for (ident, value) in input.iter() {
+            match ident.as_str() {
+                "i" => output.rounds = value.decimal()?,
+                "l" => {
+                    output.output_length = value
+                        .decimal()?
+                        .try_into()
+                        .map_err(|_| ParamsError::InvalidValue)?
+                }
+                _ => return Err(ParamsError::InvalidName.into()),
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+impl<'a> TryFrom<Params> for ParamsString {
+    type Error = HasherError;
+
+    fn try_from(input: Params) -> Result<ParamsString, HasherError> {
+        let mut output = ParamsString::new();
+        output.add_decimal("i", input.rounds)?;
+        output.add_decimal("l", input.output_length as u32)?;
+        Ok(output)
+    }
+}

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -1,13 +1,15 @@
 //! This crate implements the PBKDF2 key derivation function as specified
 //! in [RFC 2898](https://tools.ietf.org/html/rfc2898).
 //!
-//! If you are not using convinience functions `pbkdf2_check` and `pbkdf2_simple`
+//! If you are not using convenience functions `pbkdf2_check` and `pbkdf2_simple`
 //! it's recommended to disable `pbkdf2` default features in your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
 //! pbkdf2 = { version = "0.2", default-features = false }
 //! ```
+
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
 #[cfg(feature = "std")]
@@ -16,13 +18,21 @@ extern crate std;
 #[cfg(feature = "include_simple")]
 extern crate alloc;
 
+#[cfg(feature = "password-hash")]
+pub use password_hash;
+
 mod errors;
+#[cfg(feature = "include_simple")]
+mod hasher;
+#[cfg(feature = "include_simple")]
 mod simple;
 
 #[cfg(feature = "include_simple")]
-pub use crate::errors::CheckError;
-#[cfg(feature = "include_simple")]
-pub use crate::simple::{pbkdf2_check, pbkdf2_simple};
+pub use crate::{
+    errors::CheckError,
+    hasher::{AlgorithmId, Params, Pbkdf2},
+    simple::{pbkdf2_check, pbkdf2_simple},
+};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/pbkdf2/tests/hasher.rs
+++ b/pbkdf2/tests/hasher.rs
@@ -1,0 +1,59 @@
+//! Tests for `password-hash` crate integration.
+//!
+//! PBKDF2-SHA256 vectors adapted from: https://stackoverflow.com/a/5136918
+
+#![cfg(feature = "include_simple")]
+
+use hex_literal::hex;
+use pbkdf2::{
+    password_hash::{McfHasher, PasswordHasher, Salt},
+    AlgorithmId, Params, Pbkdf2,
+};
+use std::convert::TryFrom;
+
+const PASSWORD: &str = "password";
+const SALT_B64: &str = "c2FsdA"; // "salt"
+
+/// Test with `algorithm: None` - uses default PBKDF2-SHA256
+#[test]
+fn hash_with_default_algorithm() {
+    // Input:
+    //   P = "password" (8 octets)
+    //   S = "salt" (4 octets)
+    //   c = 4096
+    //   dkLen = 32
+    let salt = Salt::new(SALT_B64).unwrap();
+
+    let params = Params {
+        rounds: 4096,
+        output_length: 32,
+    };
+
+    let hash = Pbkdf2
+        .hash_password(PASSWORD.as_bytes(), None, params.into(), salt)
+        .unwrap();
+
+    assert_eq!(hash.algorithm, AlgorithmId::Sha256.ident());
+    assert_eq!(hash.salt.unwrap().as_str(), SALT_B64);
+    assert_eq!(Params::try_from(&hash.params).unwrap(), params);
+
+    let expected_output = hex!("c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a");
+    assert_eq!(hash.hash.unwrap().as_ref(), expected_output);
+}
+
+#[test]
+fn upgrade_mcf_hash() {
+    let rounds = 1024;
+    let mcf_hash = pbkdf2::pbkdf2_simple(PASSWORD, rounds).unwrap();
+    let phc_hash = Pbkdf2.upgrade_mcf_hash(&mcf_hash).unwrap();
+
+    assert_eq!(phc_hash.algorithm, AlgorithmId::Sha256.ident());
+
+    let params = Params::try_from(&phc_hash.params).unwrap();
+    assert_eq!(params.rounds, rounds);
+    assert_eq!(params.output_length, 32);
+    assert_eq!(
+        Pbkdf2.verify_mcf_hash(PASSWORD.as_bytes(), &mcf_hash),
+        Ok(())
+    );
+}

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.5.0"
+version = "0.6.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64 = { version = "0.13", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
-pbkdf2 = { version = "0.6.0", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "=0.7.0-pre", default-features = false, path = "../pbkdf2" }
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"], optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 salsa20 = { version = "0.7.2", default-features = false, features = ["expose-core"] }

--- a/scrypt/README.md
+++ b/scrypt/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the [scrypt key derivation function][1].
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.47** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/scrypt/badge.svg
 [docs-link]: https://docs.rs/scrypt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/scrypt/badge.svg?branch=master&event=push


### PR DESCRIPTION
Implements the PHC string format for hashes, currently gated under the `include_simple` cargo feature.

Specifics of how the format is encoded/decoded are modeled off of the implementation of PHC hashes for PBKDF2 implemented by Auth0.

See this thread for more information:

https://community.auth0.com/t/bulk-user-import-custom-password-hash-issue/47408/5