### PR TITLE
argon2: PHC string format support

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -35,6 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release
       - run: cargo build --target ${{ matrix.target }} --release --features zeroize
 
@@ -52,5 +53,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = "0.0.0"
 dependencies = [
  "blake2",
  "hex-literal",
+ "password-hash",
  "zeroize",
 ]
 
@@ -269,7 +270,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "password-hash"
 version = "0.0.0"
-source = "git+https://github.com/rustcrypto/traits#0da78eabf8edeca29ca6ee433274b05ec9356ad6"
+source = "git+https://github.com/rustcrypto/traits#2927b40ef3ac3b6985466f491760159dde2a1550"
 dependencies = [
  "base64ct",
 ]

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -16,7 +16,15 @@ readme = "README.md"
 
 [dependencies]
 blake2 = { version = "0.9", default-features = false }
+password-hash = { version = "0", optional = true }
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
+
+[features]
+default = ["password-hash"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -2,11 +2,15 @@
 
 use core::fmt;
 
-/// Error type
+/// Error type.
+// TODO(tarcieri): finer-grained context-specific errors?
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Associated data is too long
     AdTooLong,
+
+    /// Algorithm identifier invalid
+    AlgorithmInvalid,
 
     /// Too few lanes
     LanesTooFew,
@@ -46,12 +50,16 @@ pub enum Error {
 
     /// Time cost is too small
     TimeTooSmall,
+
+    /// Invalid version
+    VersionInvalid,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Error::AdTooLong => "associated data is too long",
+            Error::AlgorithmInvalid => "algorithm identifier invalid",
             Error::LanesTooFew => "too few lanes",
             Error::LanesTooMany => "too many lanes",
             Error::MemoryTooLittle => "memory cost is too small",
@@ -65,9 +73,7 @@ impl fmt::Display for Error {
             Error::ThreadsTooFew => "not enough threads",
             Error::ThreadsTooMany => "too many threads",
             Error::TimeTooSmall => "time cost is too small",
+            Error::VersionInvalid => "invalid version",
         })
     }
 }
-
-/// Result type
-pub type Result<T> = core::result::Result<T, Error>;

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -15,14 +15,15 @@
 //!
 //! Multithreading has not yet been implemented.
 //!
-//! Will still compute the correct results for higher parallelism factors, but
-//! there will be no associated performance improvement.
+//! Increasing the parallelism factor will still compute the correct results,
+//! but there will be no associated performance improvement.
 //!
 //! [Argon2]: https://en.wikipedia.org/wiki/Argon2
 //! [key derivation function]: https://en.wikipedia.org/wiki/Key_derivation_function
 //! [Password Hashing Competition]: https://www.password-hashing.net/
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
@@ -37,10 +38,28 @@ mod block;
 mod error;
 mod instance;
 
-pub use crate::error::{Error, Result};
+pub use crate::error::Error;
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub use password_hash::{self, PasswordHash, PasswordHasher, PasswordVerifier};
 
 use crate::{block::Block, instance::Instance};
 use blake2::{digest, Blake2b, Digest};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+#[cfg(feature = "password-hash")]
+use {
+    core::convert::TryInto,
+    password_hash::{
+        errors::{HasherError, ParamsError},
+        Decimal, Ident, ParamsString, Salt,
+    },
+};
 
 /// Minimum and maximum number of lanes (degree of parallelism)
 pub const MIN_LANES: u32 = 1;
@@ -93,7 +112,22 @@ pub const BLOCK_SIZE: usize = 1024;
 /// Number of synchronization points between lanes per pass
 const SYNC_POINTS: u32 = 4;
 
-/// Argon2 primitive type: variants of the algorithm
+/// Argon2d algorithm identifier
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const ARGON2D_IDENT: Ident<'_> = Ident::new("argon2d");
+
+/// Argon2i algorithm identifier
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const ARGON2I_IDENT: Ident<'_> = Ident::new("argon2i");
+
+/// Argon2id algorithm identifier
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const ARGON2ID_IDENT: Ident<'_> = Ident::new("argon2id");
+
+/// Argon2 primitive type: variants of the algorithm.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Algorithm {
     /// Optimizes against GPU cracking attacks but vulnerable to side-channels.
@@ -111,7 +145,11 @@ pub enum Algorithm {
     /// Hybrid that mixes Argon2i and Argon2d passes (*default*).
     ///
     /// Uses the Argon2i approach for the first half pass over memory and
-    /// Argon2d approach for subsequent passes.
+    /// Argon2d approach for subsequent passes. This effectively places it in
+    /// the "middle" between the other two: it doesn't provide as good
+    /// TMTO/GPU cracking resistance as Argon2d, nor as good of side-channel
+    /// resistance as Argon2i, but overall provides the most well-rounded
+    /// approach to both classes of attacks.
     Argon2id = 2,
 }
 
@@ -122,13 +160,86 @@ impl Default for Algorithm {
 }
 
 impl Algorithm {
+    /// Parse an [`Algorithm`] from the provided string.
+    pub fn new(id: impl AsRef<str>) -> Result<Self, Error> {
+        id.as_ref().parse()
+    }
+
+    /// Get the identifier string for this PBKDF2 [`Algorithm`].
+    pub fn as_str(&self) -> &str {
+        match self {
+            Algorithm::Argon2d => "argon2d",
+            Algorithm::Argon2i => "argon2i",
+            Algorithm::Argon2id => "argon2id",
+        }
+    }
+
+    /// Get the [`Ident`] that corresponds to this Argon2 [`Algorithm`].
+    #[cfg(feature = "password-hash")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+    pub fn ident(&self) -> Ident<'static> {
+        match self {
+            Algorithm::Argon2d => ARGON2D_IDENT,
+            Algorithm::Argon2i => ARGON2I_IDENT,
+            Algorithm::Argon2id => ARGON2ID_IDENT,
+        }
+    }
+
     /// Serialize primitive type as little endian bytes
     fn to_le_bytes(self) -> [u8; 4] {
         (self as u32).to_le_bytes()
     }
 }
 
-/// Version of the algorithm
+impl AsRef<str> for Algorithm {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Algorithm {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Algorithm, Error> {
+        match s {
+            "argon2d" => Ok(Algorithm::Argon2d),
+            "argon2i" => Ok(Algorithm::Argon2i),
+            "argon2id" => Ok(Algorithm::Argon2id),
+            _ => Err(Error::AlgorithmInvalid),
+        }
+    }
+}
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+impl From<Algorithm> for Ident<'static> {
+    fn from(alg: Algorithm) -> Ident<'static> {
+        alg.ident()
+    }
+}
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+impl<'a> TryFrom<Ident<'a>> for Algorithm {
+    type Error = HasherError;
+
+    fn try_from(ident: Ident<'a>) -> Result<Algorithm, HasherError> {
+        match ident {
+            ARGON2D_IDENT => Ok(Algorithm::Argon2d),
+            ARGON2I_IDENT => Ok(Algorithm::Argon2i),
+            ARGON2ID_IDENT => Ok(Algorithm::Argon2id),
+            _ => Err(HasherError::Algorithm),
+        }
+    }
+}
+
+/// Version of the algorithm.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Version {
@@ -156,7 +267,25 @@ impl Default for Version {
     }
 }
 
-/// Argon2 context
+impl From<Version> for u32 {
+    fn from(version: Version) -> u32 {
+        version as u32
+    }
+}
+
+impl TryFrom<u32> for Version {
+    type Error = Error;
+
+    fn try_from(version_id: u32) -> Result<Version, Error> {
+        match version_id {
+            0x10 => Ok(Version::V0x10),
+            0x13 => Ok(Version::V0x13),
+            _ => Err(Error::VersionInvalid),
+        }
+    }
+}
+
+/// Argon2 context.
 ///
 /// Holds the following Argon2 inputs:
 ///
@@ -183,6 +312,7 @@ impl Default for Version {
 ///
 /// You want to erase the password, but you're OK with last pass not being
 /// erased.
+#[derive(Clone)]
 pub struct Argon2<'key> {
     /// Key array
     secret: Option<&'key [u8]>,
@@ -198,9 +328,6 @@ pub struct Argon2<'key> {
 
     /// Maximum number of threads
     threads: u32,
-
-    /// Segment length
-    pub(crate) segment_length: u32,
 
     /// Version number
     version: Version,
@@ -220,7 +347,7 @@ impl<'key> Argon2<'key> {
         m_cost: u32,
         parallelism: u32,
         version: Version,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let lanes = parallelism;
 
         if let Some(secret) = &secret {
@@ -265,36 +392,25 @@ impl<'key> Argon2<'key> {
             return Err(Error::ThreadsTooMany);
         }
 
-        // Align memory size
-        // Minimum memory_blocks = 8L blocks, where L is the number of lanes
-        let memory_blocks = if m_cost < 2 * SYNC_POINTS * lanes {
-            2 * SYNC_POINTS * lanes
-        } else {
-            m_cost
-        };
-
-        let segment_length = memory_blocks / (lanes * SYNC_POINTS);
-
         Ok(Self {
             secret,
             t_cost,
             m_cost,
             lanes,
             threads: parallelism,
-            segment_length,
             version,
         })
     }
 
-    /// Function that performs memory-hard hashing with certain degree of parallelism.
-    pub fn hash_password(
+    /// Hash a password and associated parameters into the provided output buffer.
+    pub fn hash_password_into(
         &self,
         alg: Algorithm,
         pwd: &[u8],
         salt: &[u8],
         ad: &[u8],
         out: &mut [u8],
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
         // Validate output length
         if MIN_OUTLEN > out.len() {
             return Err(Error::OutputTooShort);
@@ -322,11 +438,10 @@ impl<'key> Argon2<'key> {
             return Err(Error::AdTooLong);
         }
 
-        let memory_blocks = (self.segment_length * self.lanes * SYNC_POINTS) as usize;
+        let memory_blocks = (self.segment_length() * self.lanes * SYNC_POINTS) as usize;
 
         // Hashing all inputs
-        #[allow(unused_mut)]
-        let mut initial_hash = self.initial_hash(alg, pwd, salt, ad, out);
+        let initial_hash = self.initial_hash(alg, pwd, salt, ad, out);
 
         // TODO(tarcieri): support for stack-allocated memory blocks (i.e. no alloc)
         let mut memory = vec![Block::default(); memory_blocks];
@@ -335,7 +450,7 @@ impl<'key> Argon2<'key> {
     }
 
     /// Hashes all the inputs into `blockhash[PREHASH_DIGEST_LENGTH]`.
-    fn initial_hash(
+    pub(crate) fn initial_hash(
         &self,
         alg: Algorithm,
         pwd: &[u8],
@@ -364,7 +479,159 @@ impl<'key> Argon2<'key> {
 
         digest.update(&(ad.len() as u32).to_le_bytes());
         digest.update(ad);
-
         digest.finalize()
+    }
+
+    pub(crate) fn segment_length(&self) -> u32 {
+        // Align memory size
+        // Minimum memory_blocks = 8L blocks, where L is the number of lanes
+        let memory_blocks = if self.m_cost < 2 * SYNC_POINTS * self.lanes {
+            2 * SYNC_POINTS * self.lanes
+        } else {
+            self.m_cost
+        };
+
+        memory_blocks / (self.lanes * SYNC_POINTS)
+    }
+}
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+impl PasswordHasher for Argon2<'_> {
+    type Params = Params;
+
+    fn hash_password<'a>(
+        &self,
+        password: &[u8],
+        alg_id: Option<Ident<'a>>,
+        version_id: Option<Decimal>,
+        params: Params,
+        salt: Salt<'a>,
+    ) -> Result<PasswordHash<'a>, HasherError> {
+        let algorithm = alg_id
+            .map(Algorithm::try_from)
+            .transpose()?
+            .unwrap_or_default();
+
+        let version = version_id
+            .map(Version::try_from)
+            .transpose()
+            .map_err(|_| HasherError::Version)?
+            .unwrap_or(self.version);
+
+        let mut salt_arr = [0u8; 64];
+        let salt_bytes = salt.b64_decode(&mut salt_arr)?;
+
+        // TODO(tarcieri): support the `data` parameter (i.e. associated data)
+        let ad = b"";
+
+        let hasher = Self::new(
+            self.secret,
+            params.t_cost,
+            params.m_cost,
+            params.p_cost,
+            version,
+        )
+        .map_err(|_| HasherError::Params(ParamsError::InvalidValue))?;
+
+        let output = password_hash::Output::init_with(params.output_length, |out| {
+            hasher
+                .hash_password_into(algorithm, password, salt_bytes, ad, out)
+                .map_err(|e| {
+                    use password_hash::errors::OutputError;
+                    match e {
+                        Error::OutputTooShort => OutputError::TooShort,
+                        Error::OutputTooLong => OutputError::TooLong,
+                        // Other cases are not returned from `hash_password_into`
+                        // TODO(tarcieri): finer-grained error types?
+                        _ => unreachable!(),
+                    }
+                })
+        })?;
+
+        let res = Ok(PasswordHash {
+            algorithm: algorithm.ident(),
+            version: Some(version.into()),
+            params: params.try_into()?,
+            salt: Some(salt),
+            hash: Some(output),
+        });
+
+        res
+    }
+}
+
+/// Argon2 password hash parameters.
+///
+/// These are parameters which can be encoded into a PHC hash string.
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Params {
+    /// Memory size, expressed in kilobytes, between 1 and (2^32)-1.
+    ///
+    /// Value is an integer in decimal (1 to 10 digits).
+    pub m_cost: u32,
+
+    /// Number of iterations, between 1 and (2^32)-1.
+    ///
+    /// Value is an integer in decimal (1 to 10 digits).
+    pub t_cost: u32,
+
+    /// Degree of parallelism, between 1 and 255.
+    ///
+    /// Value is an integer in decimal (1 to 3 digits).
+    pub p_cost: u32,
+
+    /// Size of the output (in bytes)
+    pub output_length: usize,
+}
+
+#[cfg(feature = "password-hash")]
+impl Default for Params {
+    fn default() -> Params {
+        let ctx = Argon2::default();
+
+        Params {
+            m_cost: ctx.m_cost,
+            t_cost: ctx.t_cost,
+            p_cost: ctx.threads,
+            output_length: 32,
+        }
+    }
+}
+
+#[cfg(feature = "password-hash")]
+impl TryFrom<&ParamsString> for Params {
+    type Error = HasherError;
+
+    fn try_from(input: &ParamsString) -> Result<Self, HasherError> {
+        let mut params = Params::default();
+
+        for (ident, value) in input.iter() {
+            match ident.as_str() {
+                "m" => params.m_cost = value.decimal()?,
+                "t" => params.t_cost = value.decimal()?,
+                "p" => params.p_cost = value.decimal()?,
+                "keyid" => (), // Ignored; correct key must be given to `Argon2` context
+                // TODO(tarcieri): `data` parameter
+                _ => return Err(ParamsError::InvalidName.into()),
+            }
+        }
+
+        Ok(params)
+    }
+}
+
+#[cfg(feature = "password-hash")]
+impl<'a> TryFrom<Params> for ParamsString {
+    type Error = HasherError;
+
+    fn try_from(params: Params) -> Result<ParamsString, HasherError> {
+        let mut output = ParamsString::new();
+        output.add_decimal("m", params.m_cost)?;
+        output.add_decimal("t", params.t_cost)?;
+        output.add_decimal("p", params.p_cost)?;
+        Ok(output)
     }
 }

--- a/argon2/tests/phc_strings.rs
+++ b/argon2/tests/phc_strings.rs
@@ -1,0 +1,42 @@
+//! Test vectors for Argon2 password hashes in the PHC string format
+//!
+//! Adapted from: <https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c>
+
+#![cfg(feature = "password-hash")]
+
+use argon2::{Argon2, PasswordHash, PasswordVerifier};
+
+/// Valid password
+pub const VALID_PASSWORD: &[u8] = b"password";
+
+/// Invalid password
+pub const INVALID_PASSWORD: &[u8] = b"sassword";
+
+/// Password hashes for "password"
+pub const VALID_PASSWORD_HASHES: &[&str] = &[
+    "$argon2i$v=19$m=65536,t=1,p=1$c29tZXNhbHQAAAAAAAAAAA$+r0d29hqEB0yasKr55ZgICsQGSkl0v0kgwhd+U3wyRo",
+    "$argon2id$v=19$m=262144,t=2,p=1$c29tZXNhbHQ$eP4eyR+zqlZX1y5xCFTkw9m5GYx0L5YWwvCFvtlbLow",
+    "$argon2id$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$CTFhFdXPJO1aFaMaO6Mm5c8y7cJHAph8ArZWb2GRPPc",
+    "$argon2d$v=19$m=65536,t=2,p=1$YzI5dFpYTmhiSFFBQUFBQUFBQUFBQQ$Jxy74cswY2mq9y+u+iJcJy8EqOp4t/C7DWDzGwGB3IM"
+];
+
+#[test]
+fn verifies_correct_password() {
+    for hash_string in VALID_PASSWORD_HASHES {
+        let hash = PasswordHash::new(hash_string).unwrap();
+        assert_eq!(
+            Argon2::default().verify_password(VALID_PASSWORD, &hash),
+            Ok(())
+        );
+    }
+}
+
+#[test]
+fn rejects_incorrect_password() {
+    for hash_string in VALID_PASSWORD_HASHES {
+        let hash = PasswordHash::new(hash_string).unwrap();
+        assert!(Argon2::default()
+            .verify_password(INVALID_PASSWORD, &hash)
+            .is_err());
+    }
+}

--- a/argon2/tests/test_vectors.rs
+++ b/argon2/tests/test_vectors.rs
@@ -4,6 +4,9 @@
 //! `draft-irtf-cfrg-argon2-12` Section 5:
 //! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-argon2/>
 
+// TODO(tarcieri): test full set of vectors from the reference implementation:
+// https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c
+
 use argon2::{Algorithm, Argon2, Version};
 use hex_literal::hex;
 
@@ -45,7 +48,7 @@ fn argon2d_v0x10() {
     let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password(Algorithm::Argon2d, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(Algorithm::Argon2d, &password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -89,7 +92,7 @@ fn argon2i_v0x10() {
     let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password(Algorithm::Argon2i, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(Algorithm::Argon2i, &password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -133,7 +136,7 @@ fn argon2id_v0x10() {
     let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password(Algorithm::Argon2id, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(Algorithm::Argon2id, &password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -190,7 +193,7 @@ fn argon2d_v0x13() {
     let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password(Algorithm::Argon2d, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(Algorithm::Argon2d, &password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -247,7 +250,7 @@ fn argon2i_v0x13() {
     let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password(Algorithm::Argon2i, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(Algorithm::Argon2i, &password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -292,7 +295,7 @@ fn argon2id_v0x13() {
     let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password(Algorithm::Argon2id, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(Algorithm::Argon2id, &password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);

--- a/pbkdf2/tests/hasher.rs
+++ b/pbkdf2/tests/hasher.rs
@@ -30,7 +30,7 @@ fn hash_with_default_algorithm() {
     };
 
     let hash = Pbkdf2
-        .hash_password(PASSWORD.as_bytes(), None, params.into(), salt)
+        .hash_password(PASSWORD.as_bytes(), None, None, params.into(), salt)
         .unwrap();
 
     assert_eq!(hash.algorithm, Algorithm::Pbkdf2Sha256.ident());


### PR DESCRIPTION
Uses the `password-hash` crate to implement PHC string format support