### PR TITLE
argon2+pbkdf2: update `password-hash` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "password-hash"
 version = "0.0.0"
-source = "git+https://github.com/rustcrypto/traits#2927b40ef3ac3b6985466f491760159dde2a1550"
+source = "git+https://github.com/rustcrypto/traits#fbb20ebfe89c790fb63b27a39f993017497f0f54"
 dependencies = [
  "base64ct",
 ]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -55,10 +55,7 @@ use core::{
 #[cfg(feature = "password-hash")]
 use {
     core::convert::TryInto,
-    password_hash::{
-        errors::{HasherError, ParamsError},
-        Decimal, Ident, ParamsString, Salt,
-    },
+    password_hash::{Decimal, HasherError, Ident, ParamsError, ParamsString, Salt},
 };
 
 /// Minimum and maximum number of lanes (degree of parallelism)
@@ -538,10 +535,9 @@ impl PasswordHasher for Argon2<'_> {
             hasher
                 .hash_password_into(algorithm, password, salt_bytes, ad, out)
                 .map_err(|e| {
-                    use password_hash::errors::OutputError;
                     match e {
-                        Error::OutputTooShort => OutputError::TooShort,
-                        Error::OutputTooLong => OutputError::TooLong,
+                        Error::OutputTooShort => password_hash::OutputError::TooShort,
+                        Error::OutputTooLong => password_hash::OutputError::TooLong,
                         // Other cases are not returned from `hash_password_into`
                         // TODO(tarcieri): finer-grained error types?
                         _ => unreachable!(),

--- a/pbkdf2/src/hasher.rs
+++ b/pbkdf2/src/hasher.rs
@@ -8,8 +8,8 @@ use core::{
 };
 use hmac::Hmac;
 use password_hash::{
-    errors::ParamsError, Decimal, HasherError, Ident, McfHasher, Output, ParamsString,
-    PasswordHash, PasswordHasher, Salt,
+    Decimal, HasherError, Ident, McfHasher, Output, ParamsError, ParamsString, PasswordHash,
+    PasswordHasher, Salt,
 };
 use sha2::{Sha256, Sha512};
 
@@ -75,7 +75,7 @@ impl PasswordHasher for Pbkdf2 {
 
 impl McfHasher for Pbkdf2 {
     fn upgrade_mcf_hash<'a>(&self, hash: &'a str) -> Result<PasswordHash<'a>, HasherError> {
-        use password_hash::errors::ParseError;
+        use password_hash::ParseError;
 
         // TODO(tarcieri): better error here?
         let (rounds, salt, hash) = simple::parse_hash(hash)


### PR DESCRIPTION
Flattens module structure for errors