### PR TITLE
pbkdf2: deprecate old `include_simple` API

### DIFF
--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -28,6 +28,7 @@ mod hasher;
 mod simple;
 
 #[cfg(feature = "include_simple")]
+#[allow(deprecated)]
 pub use crate::{
     errors::CheckError,
     hasher::{Algorithm, Params, Pbkdf2},

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -38,6 +38,10 @@ type DefaultRng = rand::ThreadRng;
 /// * `password` - The password to process
 /// * `c` - The iteration count
 #[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[deprecated(
+    since = "0.7.0",
+    note = "use Pbkdf2 struct and PasswordHasher/McfHasher traits instead"
+)]
 pub fn pbkdf2_simple(password: &str, rounds: u32) -> Result<String, rand_core::Error> {
     // 128-bit salt
     let mut salt = [0u8; 16];
@@ -71,6 +75,10 @@ pub fn pbkdf2_simple(password: &str, rounds: u32) -> Result<String, rand_core::E
 /// * `hashed_value` - A string representing a hashed password returned by
 /// `pbkdf2_simple`
 #[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[deprecated(
+    since = "0.7.0",
+    note = "use Pbkdf2 struct and PasswordHasher/McfHasher traits instead"
+)]
 pub fn pbkdf2_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let (count, salt, hash) = parse_hash(hashed_value)?;
     let salt = base64::decode(salt)?;

--- a/pbkdf2/tests/hasher.rs
+++ b/pbkdf2/tests/hasher.rs
@@ -42,6 +42,7 @@ fn hash_with_default_algorithm() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn upgrade_mcf_hash() {
     let rounds = 1024;
     let mcf_hash = pbkdf2::pbkdf2_simple(PASSWORD, rounds).unwrap();

--- a/pbkdf2/tests/lib.rs
+++ b/pbkdf2/tests/lib.rs
@@ -1,3 +1,7 @@
+//! PBKDF2 tests
+
+#![allow(deprecated)]
+
 use pbkdf2;
 
 use hmac::Hmac;


### PR DESCRIPTION
This API is based on an MCF hash format (`$rpbkdf2$...`) which is unique to this crate and therefore not interoperable.

As of #82, the PHC string format is supported, which provides an interoperable way to serialize PBKDF2 password hashes.

It also implements the `McfHasher` trait which can be used to both verify old `$rpbkdf2$` MCF hashes as well as upgrade them to PHC hashes.

This commit deprecates the old MCF API in the hope of getting people to upgrade to the PHC format.