### PR TITLE
Rename "include_simple" features to "simple"

### DIFF
--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -53,8 +53,8 @@ jobs:
           override: true
       - run: cargo test --release --no-default-features
       - run: cargo test --release
-      - run: cargo test --release --features include_simple
+      - run: cargo test --release --features simple
       - run: cargo test --release --features parallel
       - run: cargo test --release --features sha1
-      - run: cargo test --release --features include_simple,sha1
+      - run: cargo test --release --features simple,sha1
       - run: cargo test --release --all-features

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -31,9 +31,9 @@ sha1 = { version = "0.9", package = "sha-1" }
 sha2 = "0.9"
 
 [features]
-default = ["include_simple", "thread_rng"]
+default = ["simple", "thread_rng"]
 parallel = ["rayon", "std"]
-include_simple = ["sha2", "hmac", "password-hash", "rand_core", "base64ct", "subtle"]
+simple = ["sha2", "hmac", "password-hash", "rand_core", "base64ct", "subtle"]
 thread_rng = ["rand"]
 std = []
 

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -15,16 +15,16 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 extern crate alloc;
 
 #[cfg(feature = "password-hash")]
 pub use password_hash;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 mod simple;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub use crate::simple::{Algorithm, Params, Pbkdf2};
 
 #[cfg(feature = "parallel")]

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -28,7 +28,7 @@ pub const PBKDF2_SHA512: Ident = Ident::new("pbkdf2-sha512");
 
 /// PBKDF2 type for use with [`PasswordHasher`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub struct Pbkdf2;
 
 impl PasswordHasher for Pbkdf2 {
@@ -78,7 +78,7 @@ impl PasswordHasher for Pbkdf2 {
 /// <https://en.wikipedia.org/wiki/PBKDF2>
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
-#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub enum Algorithm {
     /// PBKDF2 SHA1
     #[cfg(feature = "sha1")]
@@ -155,7 +155,7 @@ impl<'a> TryFrom<Ident<'a>> for Algorithm {
 }
 
 /// PBKDF2 params
-#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Number of rounds

--- a/pbkdf2/tests/simple.rs
+++ b/pbkdf2/tests/simple.rs
@@ -2,7 +2,7 @@
 //!
 //! PBKDF2-SHA256 vectors adapted from: https://stackoverflow.com/a/5136918
 
-#![cfg(feature = "include_simple")]
+#![cfg(feature = "simple")]
 
 use hex_literal::hex;
 use pbkdf2::{

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2", default-features = false, optional = true }
 
 [features]
-default = ["include_simple", "thread_rng", "std"]
-include_simple = ["rand_core", "base64", "subtle"]
+default = ["simple", "thread_rng", "std"]
+simple = ["rand_core", "base64", "subtle"]
 thread_rng = ["rand"]
 std = []

--- a/scrypt/src/errors.rs
+++ b/scrypt/src/errors.rs
@@ -27,7 +27,7 @@ impl fmt::Display for InvalidParams {
 impl std::error::Error for InvalidParams {}
 
 /// `scrypt_check` error
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CheckError {
     /// Password hash mismatch, e.g. due to the incorrect password.
@@ -36,7 +36,7 @@ pub enum CheckError {
     InvalidFormat,
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 impl fmt::Display for CheckError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
@@ -46,12 +46,12 @@ impl fmt::Display for CheckError {
     }
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 impl From<base64::DecodeError> for CheckError {
     fn from(_e: ::base64::DecodeError) -> Self {
         CheckError::InvalidFormat
     }
 }
 
-#[cfg(all(feature = "include_simple", feature = "std"))]
+#[cfg(all(feature = "simple", feature = "std"))]
 impl std::error::Error for CheckError {}

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -13,7 +13,7 @@
 //! ```
 //! extern crate scrypt;
 //!
-//! # #[cfg(feature="include_simple")]
+//! # #[cfg(feature="simple")]
 //! # fn main() {
 //! use scrypt::{ScryptParams, scrypt_simple, scrypt_check};
 //!
@@ -25,7 +25,7 @@
 //! // Verifying a stored password
 //! assert!(scrypt_check("Not so secure password", &hashed_password).is_ok());
 //! # }
-//! # #[cfg(not(feature="include_simple"))]
+//! # #[cfg(not(feature="simple"))]
 //! # fn main() {}
 //! ```
 //!
@@ -50,11 +50,11 @@ use sha2::Sha256;
 pub mod errors;
 mod params;
 mod romix;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 mod simple;
 
 pub use crate::params::ScryptParams;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub use crate::simple::{scrypt_check, scrypt_simple};
 
 /// The scrypt key derivation function.

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -36,7 +36,7 @@ type DefaultRng = rand::ThreadRng;
 /// # Return
 /// `Ok(String)` if calculation is succesfull with the computation result.
 /// It will return `io::Error` error in the case of an unlikely `OsRng` failure.
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub fn scrypt_simple(password: &str, params: &ScryptParams) -> Result<String, rand_core::Error> {
     let mut salt = [0u8; 16];
     DefaultRng::default().try_fill_bytes(&mut salt)?;
@@ -84,7 +84,7 @@ pub fn scrypt_simple(password: &str, params: &ScryptParams) -> Result<String, ra
 /// - password - The password to process as a str
 /// - hashed_value - A string representing a hashed password returned
 /// by `scrypt_simple()`
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub fn scrypt_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let mut parts = hashed_value.split('$');
 

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use scrypt::errors::CheckError;
 use scrypt::{scrypt, ScryptParams};
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use scrypt::{scrypt_check, scrypt_simple};
 
 struct Test {
@@ -79,7 +79,7 @@ fn test_scrypt() {
     }
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 fn test_scrypt_simple(log_n: u8, r: u32, p: u32) {
     let password = "password";
 
@@ -104,7 +104,7 @@ fn test_scrypt_simple(log_n: u8, r: u32, p: u32) {
     );
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_scrypt_simple_compact() {
     // These parameters are intentionally very weak - the goal is to make
@@ -112,7 +112,7 @@ fn test_scrypt_simple_compact() {
     test_scrypt_simple(7, 8, 1);
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_scrypt_simple_expanded() {
     // These parameters are intentionally very weak - the goal is to make

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -20,8 +20,8 @@ rand = { version = "0.8", optional = true }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]
-default = ["include_simple"]
-include_simple = ["rand", "std", "subtle"]
+default = ["simple"]
+simple = ["rand", "std", "subtle"]
 std = []
 
 [package.metadata.docs.rs]

--- a/sha-crypt/src/b64.rs
+++ b/sha-crypt/src/b64.rs
@@ -23,7 +23,7 @@ pub fn encode(source: &[u8]) -> Vec<u8> {
     out
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub fn decode(source: &[u8]) -> Vec<u8> {
     let mut out: [u8; 64] = [0; 64];
     for iter in MAP.iter().enumerate() {
@@ -52,7 +52,7 @@ pub fn decode(source: &[u8]) -> Vec<u8> {
 }
 
 mod tests {
-    #[cfg(feature = "include_simple")]
+    #[cfg(feature = "simple")]
     #[test]
     fn test_encode_decode() {
         let original: [u8; 64] = [

--- a/sha-crypt/src/defs.rs
+++ b/sha-crypt/src/defs.rs
@@ -1,5 +1,5 @@
 pub const BLOCK_SIZE: usize = 64;
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 pub const SALT_MAX_LEN: usize = 16;
 pub static TAB: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 pub const MAP: [(u8, u8, u8, u8); 22] = [

--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -2,7 +2,7 @@
 
 use alloc::string;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use alloc::string::String;
 
 #[cfg(feature = "std")]
@@ -32,8 +32,8 @@ impl From<string::FromUtf8Error> for CryptError {
     }
 }
 
-#[cfg(feature = "include_simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 #[derive(Debug)]
 pub enum CheckError {
     InvalidFormat(String),

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```
-//! # #[cfg(feature = "include_simple")]
+//! # #[cfg(feature = "simple")]
 //! # {
 //! use sha_crypt::{Sha512Params, sha512_simple, sha512_check};
 //!
@@ -59,7 +59,7 @@ pub use crate::{
 use alloc::{string::String, vec::Vec};
 use sha2::{Digest, Sha512};
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use {
     crate::{
         defs::{SALT_MAX_LEN, TAB},
@@ -69,16 +69,16 @@ use {
     rand::{distributions::Distribution, thread_rng, Rng},
 };
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 static SHA512_SALT_PREFIX: &str = "$6$";
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 static SHA512_ROUNDS_PREFIX: &str = "rounds=";
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[derive(Debug)]
 struct ShaCryptDistribution;
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 impl Distribution<char> for ShaCryptDistribution {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
         const RANGE: u32 = 26 + 26 + 10 + 2; // 2 == "./"
@@ -286,8 +286,8 @@ pub fn sha512_crypt_b64(
 /// - `Err(CryptError)` if something went wrong.
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
-#[cfg(feature = "include_simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, CryptError> {
     let rng = thread_rng();
 
@@ -323,8 +323,8 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, Cr
 /// format or password mismatch.
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
-#[cfg(feature = "include_simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "include_simple")))]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let mut iter = hashed_value.split('$');
 

--- a/sha-crypt/tests/mod.rs
+++ b/sha-crypt/tests/mod.rs
@@ -1,6 +1,6 @@
 use sha_crypt::{sha512_crypt_b64, Sha512Params, ROUNDS_MAX, ROUNDS_MIN};
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 use sha_crypt::{sha512_check, sha512_simple};
 
 struct TestCrypt {
@@ -55,7 +55,7 @@ fn test_sha512_crypt_invalid_rounds() {
     assert!(params.is_err());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_check() {
     let pw = "foobar";
@@ -63,7 +63,7 @@ fn test_sha512_check() {
     assert!(sha512_check(pw, s).is_ok());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_check_with_rounds() {
     let pw = "foobar";
@@ -71,7 +71,7 @@ fn test_sha512_check_with_rounds() {
     assert!(sha512_check(pw, s).is_ok());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_simple_check_roundtrip() {
     let pw = "this is my password";
@@ -85,7 +85,7 @@ fn test_sha512_simple_check_roundtrip() {
     assert!(c_r.is_ok());
 }
 
-#[cfg(feature = "include_simple")]
+#[cfg(feature = "simple")]
 #[test]
 fn test_sha512_check_invalid_format() {
     // unexpected prefix 'SHOULDNOTBEHERE'


### PR DESCRIPTION
This name seems more idiomatic in regard to Rust crate features