### PR TITLE
pbkdf2: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,12 +287,9 @@ dependencies = [
  "hex-literal",
  "hmac",
  "password-hash",
- "rand",
- "rand_core",
  "rayon",
  "sha-1",
  "sha2",
- "subtle",
 ]
 
 [[package]]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -16,13 +16,10 @@ crypto-mac = "0.10"
 
 rayon = { version = "1", optional = true }
 base64ct = { version = "0.1", default-features = false, features = ["alloc"], optional = true }
-rand = { version = "0.8", default-features = false, optional = true }
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"], optional = true }
 hmac = { version = "0.10", default-features = false, optional = true }
 password-hash = { version = "0.1", default-features = false, features = ["alloc"], optional = true }
 sha1 = { version = "0.9", package = "sha-1", default-features = false, optional = true }
 sha2 = { version = "0.9", default-features = false, optional = true }
-subtle = { version = "2", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -31,10 +28,9 @@ sha1 = { version = "0.9", package = "sha-1" }
 sha2 = "0.9"
 
 [features]
-default = ["simple", "thread_rng"]
+default = ["simple"]
 parallel = ["rayon", "std"]
-simple = ["sha2", "hmac", "password-hash", "rand_core", "base64ct", "subtle"]
-thread_rng = ["rand"]
+simple = ["sha2", "hmac", "password-hash", "base64ct"]
 std = []
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
There are several vestigial dependencies from the old `include_simple` feature which are now no-longer needed as the `password-hash` crate wraps up the same concerns.