### PR TITLE
pbkdf2 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "base64ct",
  "crypto-mac 0.10.0",

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 blowfish = { version = "0.7", features = ["bcrypt"] }
 crypto-mac = "0.10"
-pbkdf2 = { version = "=0.7.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-01-29)
+### Added
+- PHC hash format support using `password-hash` crate ([#82])
+
+### Changed
+- Rename `include_simple` features to `simple` ([#99])
+
+### Removed
+- Legacy `simple` API ([#98])
+
+[#82]: https://github.com/RustCrypto/password-hashing/pull/82
+[#98]: https://github.com/RustCrypto/password-hashing/pull/98
+[#99]: https://github.com/RustCrypto/password-hashing/pull/99
+
 ## 0.6.0 (2020-10-18)
 ### Changed
 - Bump `crypto-mac` dependency to v0.10 ([#58])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -1,8 +1,10 @@
 //! This crate implements the PBKDF2 key derivation function as specified
 //! in [RFC 2898](https://tools.ietf.org/html/rfc2898).
 //!
-//! If you are not using convenience functions `pbkdf2_check` and `pbkdf2_simple`
-//! it's recommended to disable `pbkdf2` default features in your `Cargo.toml`:
+//! If you are only using the low-level [`pbkdf2`] function instead of the
+//! higher-level [`Pbkdf2`] struct to produce/verify hash strings,
+//! it's recommended to disable default features in your `Cargo.toml`:
+//!
 //! ```toml
 //! [dependencies]
 //! pbkdf2 = { version = "0.2", default-features = false }
@@ -18,7 +20,8 @@ extern crate std;
 #[cfg(feature = "simple")]
 extern crate alloc;
 
-#[cfg(feature = "password-hash")]
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub use password_hash;
 
 #[cfg(feature = "simple")]
@@ -36,7 +39,6 @@ use crypto_mac::{Mac, NewMac};
 #[inline(always)]
 fn xor(res: &mut [u8], salt: &[u8]) {
     debug_assert!(salt.len() >= res.len(), "length mismatch in xor");
-
     res.iter_mut().zip(salt.iter()).for_each(|(a, b)| *a ^= b);
 }
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64 = { version = "0.13", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
-pbkdf2 = { version = "=0.7.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"], optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 salsa20 = { version = "0.7.2", default-features = false, features = ["expose-core"] }


### PR DESCRIPTION
### Added
- PHC hash format support using `password-hash` crate ([#82])

### Changed
- Rename `include_simple` features to `simple` ([#99])

### Removed
- Legacy `simple` API ([#98])

[#82]: https://github.com/RustCrypto/password-hashing/pull/82
[#98]: https://github.com/RustCrypto/password-hashing/pull/98
[#99]: https://github.com/RustCrypto/password-hashing/pull/99