### PR TITLE
pbkdf2: remove `alloc` dependencies for `simple` feature

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -15,9 +15,9 @@ readme = "README.md"
 crypto-mac = "0.10"
 
 rayon = { version = "1", optional = true }
-base64ct = { version = "0.1", default-features = false, features = ["alloc"], optional = true }
+base64ct = { version = "0.1", default-features = false, optional = true }
 hmac = { version = "0.10", default-features = false, optional = true }
-password-hash = { version = "0.1", default-features = false, features = ["alloc"], optional = true }
+password-hash = { version = "0.1", default-features = false, optional = true }
 sha1 = { version = "0.9", package = "sha-1", default-features = false, optional = true }
 sha2 = { version = "0.9", default-features = false, optional = true }
 

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -231,10 +231,11 @@ impl McfHasher for Pbkdf2 {
         let (rounds, salt, hash) = match buf {
             [Some(""), Some("rpbkdf2"), Some("0"), Some(count), Some(salt), Some(hash), Some(""), None] =>
             {
-                let count_arr = base64ct::padded::decode_vec(count)?
-                    .as_slice()
-                    .try_into()
-                    .map_err(|_| HasherError::Params(ParamsError::InvalidValue))?;
+                let mut count_arr = [0u8; 4];
+
+                if base64ct::padded::decode(count, &mut count_arr)?.len() != 4 {
+                    return Err(ParamsError::InvalidValue.into());
+                }
 
                 let count = u32::from_be_bytes(count_arr);
                 (count, salt, hash)


### PR DESCRIPTION
They are trivial to remove as `password-hash` was written with the intent of "heapless" support, so might as well remove them.