### PR TITLE
pbkdf2 v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64ct",
  "crypto-mac 0.10.0",

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2021-01-29)
+### Removed
+- `alloc` dependencies for `simple` feature ([#107])
+
+[#107]: https://github.com/RustCrypto/password-hashing/pull/107
+
 ## 0.7.0 (2021-01-29)
 ### Added
 - PHC hash format support using `password-hash` crate ([#82])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"


### PR DESCRIPTION
### Removed
- `alloc` dependencies for `simple` feature ([#107])

[#107]: https://github.com/RustCrypto/password-hashing/pull/107