### PR TITLE
scrypt: add PHC hash support using `password-hash` crate

### DIFF
--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -17,25 +17,27 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.47.0 # MSRV
-          - stable
-        target:
-          - thumbv7em-none-eabi
-          - wasm32-unknown-unknown
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+# TODO(tarcieri): test when new cargo resolver is available (RFC 2957)
+#  build:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        rust:
+#          - 1.47.0 # MSRV
+#          - stable
+#        target:
+#          - thumbv7em-none-eabi
+#          - wasm32-unknown-unknown
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+#      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features simple
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "base64ct"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,14 +376,13 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 name = "scrypt"
 version = "0.6.0-pre"
 dependencies = [
- "base64",
+ "base64ct",
  "hmac",
+ "password-hash",
  "pbkdf2",
- "rand",
  "rand_core",
  "salsa20",
  "sha2",
- "subtle",
 ]
 
 [[package]]

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -242,7 +242,7 @@ impl McfHasher for Pbkdf2 {
             }
             _ => {
                 // TODO(tarcieri): better errors here?
-                return Err(HasherError::Parse(ParseError::InvalidChar('?')));
+                return Err(ParseError::InvalidChar('?').into());
             }
         };
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -12,17 +12,18 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-base64 = { version = "0.13", default-features = false, features = ["alloc"], optional = true }
+base64ct = { version = "0.1", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
+password-hash = { version = "0.1", default-features = false, optional = true }
 pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"], optional = true }
-rand = { version = "0.8", default-features = false, optional = true }
 salsa20 = { version = "0.7.2", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }
-subtle = { version = "2", default-features = false, optional = true }
+
+[dev-dependencies]
+password-hash = { version = "0.1", features = ["rand_core"] }
+rand_core = { version = "0.6", features = ["std"] }
 
 [features]
-default = ["simple", "thread_rng", "std"]
-simple = ["rand_core", "base64", "subtle"]
-thread_rng = ["rand"]
+default = ["simple", "std"]
+simple = ["password-hash", "base64ct"]
 std = []

--- a/scrypt/src/errors.rs
+++ b/scrypt/src/errors.rs
@@ -25,33 +25,3 @@ impl fmt::Display for InvalidParams {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidParams {}
-
-/// `scrypt_check` error
-#[cfg(feature = "simple")]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum CheckError {
-    /// Password hash mismatch, e.g. due to the incorrect password.
-    HashMismatch,
-    /// Invalid format of the hash string.
-    InvalidFormat,
-}
-
-#[cfg(feature = "simple")]
-impl fmt::Display for CheckError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match *self {
-            CheckError::HashMismatch => "password hash mismatch",
-            CheckError::InvalidFormat => "invalid `hashed_value` format",
-        })
-    }
-}
-
-#[cfg(feature = "simple")]
-impl From<base64::DecodeError> for CheckError {
-    fn from(_e: ::base64::DecodeError) -> Self {
-        CheckError::InvalidFormat
-    }
-}
-
-#[cfg(all(feature = "simple", feature = "std"))]
-impl std::error::Error for CheckError {}

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -8,25 +8,27 @@
 //! scrypt = { version = "0.2", default-features = false }
 //! ```
 //!
-//! # Usage
+//! # Usage (simple with default params)
 //!
 //! ```
-//! extern crate scrypt;
+//! # #[cfg(feature = "password-hash")]
+//! # {
+//! use scrypt::{
+//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+//!     Scrypt
+//! };
+//! use rand_core::OsRng;
 //!
-//! # #[cfg(feature="simple")]
-//! # fn main() {
-//! use scrypt::{ScryptParams, scrypt_simple, scrypt_check};
+//! let password = b"hunter42"; // Bad password; don't actually use!
+//! let salt = SaltString::generate(&mut OsRng);
 //!
-//! // First setup the ScryptParams arguments with the recommended defaults
-//! let params = ScryptParams::recommended();
-//! // Hash the password for storage
-//! let hashed_password = scrypt_simple("Not so secure password", &params)
-//!     .expect("OS RNG should not fail");
-//! // Verifying a stored password
-//! assert!(scrypt_check("Not so secure password", &hashed_password).is_ok());
+//! // Hash password to PHC string ($scrypt$...)
+//! let password_hash = Scrypt.hash_password_simple(password, salt.as_ref()).unwrap().to_string();
+//!
+//! // Verify password against PHC string
+//! let parsed_hash = PasswordHash::new(&password_hash).unwrap();
+//! assert!(Scrypt.verify_password(password, &parsed_hash).is_ok());
 //! # }
-//! # #[cfg(not(feature="simple"))]
-//! # fn main() {}
 //! ```
 //!
 //! # References
@@ -53,9 +55,12 @@ mod romix;
 #[cfg(feature = "simple")]
 mod simple;
 
+#[cfg(feature = "simple")]
+pub use password_hash;
+
 pub use crate::params::ScryptParams;
 #[cfg(feature = "simple")]
-pub use crate::simple::{scrypt_check, scrypt_simple};
+pub use crate::simple::{Scrypt, ALG_ID};
 
 /// The scrypt key derivation function.
 ///

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -2,12 +2,24 @@ use core::{mem::size_of, usize};
 
 use crate::errors::InvalidParams;
 
+#[cfg(feature = "simple")]
+use {
+    core::convert::{TryFrom, TryInto},
+    password_hash::{HasherError, ParamsError, ParamsString},
+};
+
+const RECOMMENDED_LOG_N: u8 = 15;
+const RECOMMENDED_R: u32 = 8;
+const RECOMMENDED_P: u32 = 1;
+const RECOMMENDED_LEN: usize = 32;
+
 /// The Scrypt parameter values.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ScryptParams {
     pub(crate) log_n: u8,
     pub(crate) r: u32,
     pub(crate) p: u32,
+    pub(crate) len: usize,
 }
 
 impl ScryptParams {
@@ -62,6 +74,7 @@ impl ScryptParams {
             log_n,
             r: r as u32,
             p: p as u32,
+            len: RECOMMENDED_LEN,
         })
     }
 
@@ -71,9 +84,58 @@ impl ScryptParams {
     /// - `p = 1`
     pub fn recommended() -> ScryptParams {
         ScryptParams {
-            log_n: 15,
-            r: 8,
-            p: 1,
+            log_n: RECOMMENDED_LOG_N,
+            r: RECOMMENDED_R,
+            p: RECOMMENDED_P,
+            len: RECOMMENDED_LEN,
         }
+    }
+}
+
+impl Default for ScryptParams {
+    fn default() -> ScryptParams {
+        ScryptParams::recommended()
+    }
+}
+
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
+impl TryFrom<&ParamsString> for ScryptParams {
+    type Error = HasherError;
+
+    fn try_from(input: &ParamsString) -> Result<Self, HasherError> {
+        let mut log_n = RECOMMENDED_LOG_N;
+        let mut r = RECOMMENDED_R;
+        let mut p = RECOMMENDED_P;
+
+        for (ident, value) in input.iter() {
+            match ident.as_str() {
+                "ln" => {
+                    log_n = value
+                        .decimal()?
+                        .try_into()
+                        .map_err(|_| ParamsError::InvalidValue)?
+                }
+                "r" => r = value.decimal()?,
+                "p" => p = value.decimal()?,
+                _ => return Err(ParamsError::InvalidName.into()),
+            }
+        }
+
+        ScryptParams::new(log_n, r, p).map_err(|_| ParamsError::InvalidValue.into())
+    }
+}
+
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
+impl<'a> TryFrom<ScryptParams> for ParamsString {
+    type Error = HasherError;
+
+    fn try_from(input: ScryptParams) -> Result<ParamsString, HasherError> {
+        let mut output = ParamsString::new();
+        output.add_decimal("ln", input.log_n as u32)?;
+        output.add_decimal("r", input.r)?;
+        output.add_decimal("p", input.p)?;
+        Ok(output)
     }
 }

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -1,140 +1,117 @@
-use super::scrypt;
-use crate::errors::CheckError;
-use crate::ScryptParams;
-
-use alloc::string::String;
+use crate::{scrypt, ScryptParams};
 use core::convert::TryInto;
-use rand_core::RngCore;
-use subtle::ConstantTimeEq;
+use password_hash::{
+    Decimal, HasherError, Ident, McfHasher, Output, OutputError, ParamsError, PasswordHash,
+    PasswordHasher, Salt,
+};
 
-#[cfg(not(features = "thread_rng"))]
-type DefaultRng = rand_core::OsRng;
-#[cfg(features = "thread_rng")]
-type DefaultRng = rand::ThreadRng;
+/// Algorithm identifier
+pub const ALG_ID: Ident = Ident::new("scrypt");
 
-/// `scrypt_simple` is a helper function that should be sufficient for the
-/// majority of cases where an application needs to use Scrypt to hash a
-/// password for storage. The result is a String that contains the parameters
-/// used as part of its encoding. The `scrypt_check` function may be used on
-/// a password to check if it is equal to a hashed value.
-///
-/// # Format
-/// The format of the output is a modified version of the Modular Crypt Format
-/// that encodes algorithm used and the parameter values. If all parameter
-/// values can each fit within a single byte, a compact format is used
-/// (format 0). However, if any value cannot, an expanded format where the
-/// rand `p` parameters are encoded using 4 bytes (format 1) is used. Both
-/// formats use a 128-bit salt and a 256-bit hash. The format is indicated as
-/// "rscrypt" which is short for "Rust Scrypt format."
-///
-/// `$rscrypt$<format>$<base64(log_n,r,p)>$<base64(salt)>$<based64(hash)>$`
-///
-/// # Arguments
-/// - `password` - The password to process as a str
-/// - `params` - The ScryptParams to use
-///
-/// # Return
-/// `Ok(String)` if calculation is succesfull with the computation result.
-/// It will return `io::Error` error in the case of an unlikely `OsRng` failure.
-#[cfg(feature = "simple")]
-pub fn scrypt_simple(password: &str, params: &ScryptParams) -> Result<String, rand_core::Error> {
-    let mut salt = [0u8; 16];
-    DefaultRng::default().try_fill_bytes(&mut salt)?;
+/// scrypt type for use with [`PasswordHasher`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
+pub struct Scrypt;
 
-    // 256-bit derived key
-    let mut dk = [0u8; 32];
+impl PasswordHasher for Scrypt {
+    type Params = ScryptParams;
 
-    scrypt(password.as_bytes(), &salt, params, &mut dk)
-        .expect("32 bytes always satisfy output length requirements");
+    fn hash_password<'a>(
+        &self,
+        password: &[u8],
+        alg_id: Option<Ident<'a>>,
+        version: Option<Decimal>,
+        params: ScryptParams,
+        salt: Salt<'a>,
+    ) -> Result<PasswordHash<'a>, HasherError> {
+        match alg_id {
+            Some(ALG_ID) | None => (),
+            _ => return Err(HasherError::Algorithm),
+        }
 
-    // usually 128 bytes is enough
-    let mut result = String::with_capacity(128);
-    result.push_str("$rscrypt$");
-    if params.r < 256 && params.p < 256 {
-        result.push_str("0$");
-        let mut tmp = [0u8; 3];
-        tmp[0] = params.log_n;
-        tmp[1] = params.r as u8;
-        tmp[2] = params.p as u8;
-        result.push_str(&base64::encode(&tmp));
-    } else {
-        result.push_str("1$");
-        let mut tmp = [0u8; 9];
-        tmp[0] = params.log_n;
-        tmp[1..5].copy_from_slice(&params.r.to_le_bytes());
-        tmp[5..9].copy_from_slice(&params.p.to_le_bytes());
-        result.push_str(&base64::encode(&tmp));
+        if version.is_some() {
+            return Err(HasherError::Version);
+        }
+
+        let mut salt_arr = [0u8; 64];
+        let salt_bytes = salt.b64_decode(&mut salt_arr)?;
+
+        let output = Output::init_with(params.len, |out| {
+            scrypt(password, &salt_bytes, &params, out).map_err(|_e| {
+                // TODO(tarcieri): handle output variants
+                OutputError::TooLong
+            })
+        })?;
+
+        Ok(PasswordHash {
+            algorithm: ALG_ID,
+            version: None,
+            params: params.try_into()?,
+            salt: Some(salt),
+            hash: Some(output),
+        })
     }
-    result.push('$');
-    result.push_str(&base64::encode(&salt));
-    result.push('$');
-    result.push_str(&base64::encode(&dk));
-    result.push('$');
-
-    Ok(result)
 }
 
-/// `scrypt_check` compares a password against the result of a previous call
-/// to scrypt_simple and returns `Ok(())` if the passed in password hashes to
-/// the same value, `Err(CheckError::HashMismatch)` if hashes have
-/// different values, and `Err(CheckError::InvalidFormat)` if `hashed_value`
-/// has an invalid format.
-///
-/// # Arguments
-/// - password - The password to process as a str
-/// - hashed_value - A string representing a hashed password returned
-/// by `scrypt_simple()`
-#[cfg(feature = "simple")]
-pub fn scrypt_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
-    let mut parts = hashed_value.split('$');
+impl McfHasher for Scrypt {
+    fn upgrade_mcf_hash<'a>(&self, hash: &'a str) -> Result<PasswordHash<'a>, HasherError> {
+        use password_hash::ParseError;
 
-    let buf = [
-        parts.next(),
-        parts.next(),
-        parts.next(),
-        parts.next(),
-        parts.next(),
-        parts.next(),
-        parts.next(),
-        parts.next(),
-    ];
+        let mut parts = hash.split('$');
 
-    let (log_n, r, p, salt, hash) = match buf {
-        [Some(""), Some("rscrypt"), Some("0"), Some(p), Some(s), Some(h), Some(""), None] => {
-            let pvec = base64::decode(p)?;
-            if pvec.len() != 3 {
-                return Err(CheckError::InvalidFormat);
+        let buf = [
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+        ];
+
+        let (log_n, r, p, salt, hash) = match buf {
+            [Some(""), Some("rscrypt"), Some("0"), Some(p), Some(s), Some(h), Some(""), None] => {
+                let pvec = base64ct::padded::decode_vec(p)?;
+                if pvec.len() != 3 {
+                    return Err(ParamsError::InvalidValue.into());
+                }
+                (pvec[0], pvec[1] as u32, pvec[2] as u32, s, h)
             }
-            (pvec[0], pvec[1] as u32, pvec[2] as u32, s, h)
-        }
-        [Some(""), Some("rscrypt"), Some("1"), Some(p), Some(s), Some(h), Some(""), None] => {
-            let pvec = base64::decode(p)?;
-            if pvec.len() != 9 {
-                return Err(CheckError::InvalidFormat);
+            [Some(""), Some("rscrypt"), Some("1"), Some(p), Some(s), Some(h), Some(""), None] => {
+                let pvec = base64ct::padded::decode_vec(p)?;
+                if pvec.len() != 9 {
+                    return Err(ParamsError::InvalidValue.into());
+                }
+                let log_n = pvec[0];
+                let r = u32::from_le_bytes(pvec[1..5].try_into().unwrap());
+                let p = u32::from_le_bytes(pvec[5..9].try_into().unwrap());
+                (log_n, r, p, s, h)
             }
-            let log_n = pvec[0];
-            let r = u32::from_le_bytes(pvec[1..5].try_into().unwrap());
-            let p = u32::from_le_bytes(pvec[5..9].try_into().unwrap());
-            (log_n, r, p, s, h)
-        }
-        _ => return Err(CheckError::InvalidFormat),
-    };
+            _ => {
+                // TODO(tarcieri): better errors here?
+                return Err(ParseError::InvalidChar('?').into());
+            }
+        };
 
-    let params = ScryptParams::new(log_n, r, p).map_err(|_| CheckError::InvalidFormat)?;
-    let salt = base64::decode(salt)?;
-    let hash = base64::decode(hash)?;
+        let params = ScryptParams::new(log_n, r, p).map_err(|_| ParamsError::InvalidValue)?;
+        let salt = Salt::new(b64_strip(salt))?;
+        let hash = Output::b64_decode(b64_strip(hash))?;
 
-    let mut output = vec![0u8; hash.len()];
-    scrypt(password.as_bytes(), &salt, &params, &mut output)
-        .map_err(|_| CheckError::InvalidFormat)?;
-
-    // Be careful here - its important that the comparison is done using a fixed
-    // time equality check. Otherwise an adversary that can measure how long
-    // this step takes can learn about the hashed value which would allow them
-    // to mount an offline brute force attack against the hashed password.
-    if output.ct_eq(&hash).unwrap_u8() == 1 {
-        Ok(())
-    } else {
-        Err(CheckError::HashMismatch)
+        Ok(PasswordHash {
+            algorithm: ALG_ID,
+            version: None,
+            params: params.try_into()?,
+            salt: Some(salt),
+            hash: Some(hash),
+        })
     }
+}
+
+/// Strip trailing `=` signs off a Base64 value to make a valid B64 value
+pub fn b64_strip(mut s: &str) -> &str {
+    while s.ends_with('=') {
+        s = &s[..(s.len() - 1)]
+    }
+    s
 }


### PR DESCRIPTION
Implements the PHC string format for hashes, gated under the `simple` cargo feature.

Specifics of how the format is encoded/decoded are modeled off of how passlib implements PHC scrypt hashes:

https://passlib.readthedocs.io/en/stable/lib/passlib.hash.scrypt.html