### PR TITLE
scrypt: rename ScryptParams => Params

### DIFF
--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -27,3 +27,7 @@ rand_core = { version = "0.6", features = ["std"] }
 default = ["simple", "std"]
 simple = ["password-hash", "base64ct"]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/scrypt/benches/lib.rs
+++ b/scrypt/benches/lib.rs
@@ -10,7 +10,7 @@ pub fn scrypt_15_8_1(bh: &mut Bencher) {
     let password = b"my secure password";
     let salt = b"salty salt";
     let mut buf = [0u8; 32];
-    let params = scrypt::ScryptParams::new(15, 8, 1).unwrap();
+    let params = scrypt::Params::new(15, 8, 1).unwrap();
     bh.iter(|| {
         scrypt::scrypt(password, salt, &params, &mut buf).unwrap();
         test::black_box(&buf);

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -1,8 +1,10 @@
 //! This crate implements the Scrypt key derivation function as specified
 //! in \[1\].
 //!
-//! If you are not using convinience functions `scrypt_check` and `scrypt_simple`
-//! it's recommended to disable `scrypt` default features in your `Cargo.toml`:
+//! If you are only using the low-level [`scrypt`] function instead of the
+//! higher-level [`Scrypt`] struct to produce/verify hash strings,
+//! it's recommended to disable default features in your `Cargo.toml`:
+//!
 //! ```toml
 //! [dependencies]
 //! scrypt = { version = "0.2", default-features = false }
@@ -36,6 +38,7 @@
 //! Memory-Hard Functions](http://www.tarsnap.com/scrypt/scrypt.pdf)
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
 #[macro_use]
@@ -58,7 +61,7 @@ mod simple;
 #[cfg(feature = "simple")]
 pub use password_hash;
 
-pub use crate::params::ScryptParams;
+pub use crate::params::Params;
 #[cfg(feature = "simple")]
 pub use crate::simple::{Scrypt, ALG_ID};
 
@@ -78,7 +81,7 @@ pub use crate::simple::{Scrypt, ALG_ID};
 pub fn scrypt(
     password: &[u8],
     salt: &[u8],
-    params: &ScryptParams,
+    params: &Params,
     output: &mut [u8],
 ) -> Result<(), errors::InvalidOutputLen> {
     // This check required by Scrypt:

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -15,14 +15,14 @@ const RECOMMENDED_LEN: usize = 32;
 
 /// The Scrypt parameter values.
 #[derive(Clone, Copy, Debug)]
-pub struct ScryptParams {
+pub struct Params {
     pub(crate) log_n: u8,
     pub(crate) r: u32,
     pub(crate) p: u32,
     pub(crate) len: usize,
 }
 
-impl ScryptParams {
+impl Params {
     /// Create a new instance of ScryptParams.
     ///
     /// # Arguments
@@ -33,7 +33,7 @@ impl ScryptParams {
     /// - `log_n` must be less than `64`
     /// - `r` must be greater than `0` and less than or equal to `4294967295`
     /// - `p` must be greater than `0` and less than `4294967295`
-    pub fn new(log_n: u8, r: u32, p: u32) -> Result<ScryptParams, InvalidParams> {
+    pub fn new(log_n: u8, r: u32, p: u32) -> Result<Params, InvalidParams> {
         let cond1 = (log_n as usize) < size_of::<usize>() * 8;
         let cond2 = size_of::<usize>() >= size_of::<u32>();
         let cond3 = r <= usize::MAX as u32 && p < usize::MAX as u32;
@@ -70,7 +70,7 @@ impl ScryptParams {
             return Err(InvalidParams);
         }
 
-        Ok(ScryptParams {
+        Ok(Params {
             log_n,
             r: r as u32,
             p: p as u32,
@@ -82,8 +82,8 @@ impl ScryptParams {
     /// - `log_n = 15` (`n = 32768`)
     /// - `r = 8`
     /// - `p = 1`
-    pub fn recommended() -> ScryptParams {
-        ScryptParams {
+    pub fn recommended() -> Params {
+        Params {
             log_n: RECOMMENDED_LOG_N,
             r: RECOMMENDED_R,
             p: RECOMMENDED_P,
@@ -92,15 +92,15 @@ impl ScryptParams {
     }
 }
 
-impl Default for ScryptParams {
-    fn default() -> ScryptParams {
-        ScryptParams::recommended()
+impl Default for Params {
+    fn default() -> Params {
+        Params::recommended()
     }
 }
 
 #[cfg(feature = "simple")]
 #[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
-impl TryFrom<&ParamsString> for ScryptParams {
+impl TryFrom<&ParamsString> for Params {
     type Error = HasherError;
 
     fn try_from(input: &ParamsString) -> Result<Self, HasherError> {
@@ -122,16 +122,16 @@ impl TryFrom<&ParamsString> for ScryptParams {
             }
         }
 
-        ScryptParams::new(log_n, r, p).map_err(|_| ParamsError::InvalidValue.into())
+        Params::new(log_n, r, p).map_err(|_| ParamsError::InvalidValue.into())
     }
 }
 
 #[cfg(feature = "simple")]
 #[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
-impl<'a> TryFrom<ScryptParams> for ParamsString {
+impl<'a> TryFrom<Params> for ParamsString {
     type Error = HasherError;
 
-    fn try_from(input: ScryptParams) -> Result<ParamsString, HasherError> {
+    fn try_from(input: Params) -> Result<ParamsString, HasherError> {
         let mut output = ParamsString::new();
         output.add_decimal("ln", input.log_n as u32)?;
         output.add_decimal("r", input.r)?;

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -1,4 +1,4 @@
-use crate::{scrypt, ScryptParams};
+use crate::{scrypt, Params};
 use core::convert::TryInto;
 use password_hash::{
     Decimal, HasherError, Ident, McfHasher, Output, OutputError, ParamsError, PasswordHash,
@@ -14,14 +14,14 @@ pub const ALG_ID: Ident = Ident::new("scrypt");
 pub struct Scrypt;
 
 impl PasswordHasher for Scrypt {
-    type Params = ScryptParams;
+    type Params = Params;
 
     fn hash_password<'a>(
         &self,
         password: &[u8],
         alg_id: Option<Ident<'a>>,
         version: Option<Decimal>,
-        params: ScryptParams,
+        params: Params,
         salt: Salt<'a>,
     ) -> Result<PasswordHash<'a>, HasherError> {
         match alg_id {
@@ -94,7 +94,7 @@ impl McfHasher for Scrypt {
             }
         };
 
-        let params = ScryptParams::new(log_n, r, p).map_err(|_| ParamsError::InvalidValue)?;
+        let params = Params::new(log_n, r, p).map_err(|_| ParamsError::InvalidValue)?;
         let salt = Salt::new(b64_strip(salt))?;
         let hash = Output::b64_decode(b64_strip(hash))?;
 

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -1,4 +1,4 @@
-use scrypt::{scrypt, ScryptParams};
+use scrypt::{scrypt, Params};
 
 #[cfg(feature = "simple")]
 use {
@@ -69,7 +69,7 @@ fn test_scrypt() {
     let tests = tests();
     for t in tests.iter() {
         let mut result = vec![0u8; t.expected.len()];
-        let params = ScryptParams::new(t.log_n, t.r, t.p).unwrap();
+        let params = Params::new(t.log_n, t.r, t.p).unwrap();
         scrypt(
             t.password.as_bytes(),
             t.salt.as_bytes(),


### PR DESCRIPTION
This follows RFC 356 naming conventions:

https://rust-lang.github.io/rfcs/0356-no-module-prefixes.html