### PR TITLE
sha-crypt: remove `Vec` from public API

### DIFF
--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/sha-crypt/README.md
+++ b/sha-crypt/README.md
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sha-crypt/badge.svg
 [docs-link]: https://docs.rs/sha-crypt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/sha-crypt/badge.svg?branch=master&event=push


### PR DESCRIPTION
Slightly closer to heapless support