### PR TITLE
scrypt v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "base64ct",
  "hmac",

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-01-29)
+### Added
+- PHC hash support using `password-hash` crate ([#111])
+
+### Changed
+- Rename `include_simple` features to `simple` ([#99])
+- Rename `ScryptParams` => `Params` ([#112])
+
+[#99]: https://github.com/RustCrypto/password-hashing/pull/99
+[#111]: https://github.com/RustCrypto/password-hashing/pull/111
+[#112]: https://github.com/RustCrypto/password-hashing/pull/112
+
 ## 0.5.0 (2020-10-18)
 ### Changed
 - Bump `crypto-mac` dependency to v0.10 ([#58])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"
@@ -16,7 +16,7 @@ base64ct = { version = "0.1", default-features = false, features = ["alloc"], op
 hmac = "0.10"
 password-hash = { version = "0.1", default-features = false, optional = true }
 pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
-salsa20 = { version = "0.7.2", default-features = false, features = ["expose-core"] }
+salsa20 = { version = "0.7", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- PHC hash support using `password-hash` crate ([#111])

### Changed
- Rename `include_simple` features to `simple` ([#99])
- Rename `ScryptParams` => `Params` ([#112])

[#99]: https://github.com/RustCrypto/password-hashing/pull/99
[#111]: https://github.com/RustCrypto/password-hashing/pull/111
[#112]: https://github.com/RustCrypto/password-hashing/pull/112