### PR TITLE
sha-crypt v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rand",
  "sha2",

--- a/sha-crypt/CHANGELOG.md
+++ b/sha-crypt/CHANGELOG.md
@@ -5,5 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-01-29)
+### Changed
+- Bump `rand` dependency to v0.8 ([#86])
+- Rename `include_simple` feature to `simple` ([#99])
+- Remove `Vec` from public API ([#113]) 
+- MSRV 1.47+ ([#113])
+
+[#86]: https://github.com/RustCrypto/password-hashing/pull/86
+[#99]: https://github.com/RustCrypto/password-hashing/pull/99
+[#113]: https://github.com/RustCrypto/password-hashing/pull/113
+
 ## 0.1.0 (2020-12-28)
 - Initial release

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.1.0"
+version = "0.2.0"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -44,11 +44,10 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod errors;
-pub mod params;
-
 mod b64;
 mod defs;
+mod errors;
+mod params;
 
 pub use crate::{
     defs::BLOCK_SIZE,


### PR DESCRIPTION
### Changed
- Bump `rand` dependency to v0.8 ([#86])
- Rename `include_simple` feature to `simple` ([#99])
- Remove `Vec` from public API ([#113]) 
- MSRV 1.47+ ([#113])

[#86]: https://github.com/RustCrypto/password-hashing/pull/86
[#99]: https://github.com/RustCrypto/password-hashing/pull/99
[#113]: https://github.com/RustCrypto/password-hashing/pull/113