### PR TITLE
bcrypt-pbkdf v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "c502cbac2e4ffc38047434d0c88b54da5e7c76829ff16f0a479f90116336d9f3"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "blowfish",
  "crypto-mac 0.10.0",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2020-10-18)
+## 0.5.0 (2021-01-29)
+### Changed
+- Bump `pbkdf2` dependency to v0.7 ([#102])
+
+[#102]: https://github.com/RustCrypto/password-hashing/pull/102
+
+## 0.4.0 (2020-10-18)
 ### Changed
 - Bump `crypto-mac` dependency to v0.10 ([#58])
 - Bump `pbkdf2` dependency to v0.10 ([#61])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bcrypt-pbkdf"
 description = "bcrypt-pbkdf password-based key derivation function"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"
 keywords = ["crypto", "password", "hashing"]

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -3,8 +3,9 @@
 //!
 //! [bcrypt_pbkdf]: https://flak.tedunangst.com/post/bcrypt-pbkdf
 //! [OpenSSH]: https://flak.tedunangst.com/post/new-openssh-key-format-and-bcrypt-pbkdf
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+
 #![no_std]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
 extern crate alloc;
 #[cfg(feature = "std")]


### PR DESCRIPTION
### Changed
- Bump `pbkdf2` dependency to v0.7 ([#102])

[#102]: https://github.com/RustCrypto/password-hashing/pull/102