### PR TITLE
argon2 v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "argon2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake2",
  "hex-literal",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,5 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2021-02-07)
+### Added
+- `rand` feature; enabled-by-default ([#126])
+
+[#126]: https://github.com/RustCrypto/password-hashes/pull/126
+
 ## 0.1.0 (2021-01-29)
 - Initial release

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
 """
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/argon2"

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -13,6 +13,20 @@
 //!
 //! # Usage (simple with default params)
 //!
+//! Note: this example requires the `rand_core` crate with the `std` feature
+//! enabled for `rand_core::OsRng` (embedded platforms can substitute their
+//! own RNG)
+//!
+//! Add the following to your crate's `Cargo.toml` to import it:
+//!
+//! ```toml
+//! [dependencies]
+//! argon2 = "0.1"
+//! rand_core = { version = "0.6", features = ["std"]
+//! ```
+//!
+//! The following example demonstrates the high-level password hashing API:
+//!
 //! ```
 //! # #[cfg(feature = "password-hash")]
 //! # {


### PR DESCRIPTION
### Added
- `rand` feature; enabled-by-default ([#126])

[#126]: https://github.com/RustCrypto/password-hashes/pull/126