### PR TITLE
argon2 v0.1.2

### DIFF
--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2021-02-07)
+### Fixed
+- rustdoc typo ([#128])
+
+[#128]: https://github.com/RustCrypto/password-hashes/pull/128
+
 ## 0.1.1 (2021-02-07)
 ### Added
 - `rand` feature; enabled-by-default ([#126])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
 """
-version = "0.1.1"
+version = "0.1.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/argon2"


### PR DESCRIPTION
### Fixed
- rustdoc typo ([#128])

[#128]: https://github.com/RustCrypto/password-hashes/pull/128