### PR TITLE
argon2 v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "argon2"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blake2",
  "hex-literal",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 (2021-02-12)
+### Fixed
+- Salt-length related panic ([#135])
+
+[#135]: https://github.com/RustCrypto/password-hashes/pull/135
+
 ## 0.1.2 (2021-02-07)
 ### Fixed
 - rustdoc typo ([#128])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
 """
-version = "0.1.2"
+version = "0.1.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/argon2"


### PR DESCRIPTION
### Fixed
- Salt-length related panic ([#135])

[#135]: https://github.com/RustCrypto/password-hashes/pull/135