### PR TITLE
scrypt: enable `rand_core` feature of `password-hash`

### DIFF
--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64ct = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
-password-hash = { version = "0.1", default-features = false, optional = true }
+password-hash = { version = "0.1", default-features = false, features = ["rand_core"], optional = true }
 pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.7", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }


### PR DESCRIPTION
This makes the `SaltString::generate` function available.

- Related: #130
- Closes: #138