### PR TITLE
Enable password-hash/std feature

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -27,6 +27,7 @@ rand_core = { version = "0.6", features = ["std"] }
 [features]
 default = ["password-hash", "rand"]
 rand = ["password-hash/rand_core"]
+std = ["password-hash/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -32,7 +32,7 @@ sha2 = "0.9"
 default = ["simple"]
 parallel = ["rayon", "std"]
 simple = ["sha2", "hmac", "password-hash", "base64ct"]
-std = []
+std = ["password-hash/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -26,7 +26,7 @@ rand_core = { version = "0.6", features = ["std"] }
 [features]
 default = ["simple", "std"]
 simple = ["password-hash", "base64ct"]
-std = []
+std = ["password-hash/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Enables `password-hash/std` feature, allowing crates like argon2 to throw error up from password-hash.

This is helpful in situations where you want to bubble up the error:

```sh
error[E0277]: the trait bound `HashError: StdError` is not satisfied
   --> auth/src/models.rs:104:47
    |
104 |     let parsed_hash = PasswordHash::new(&hash)?;
    |                                               ^ the trait `StdError` is not implemented for `HashError`
    |
    = note: required because of the requirements on the impl of `From<HashError>` for `anyhow::Error`
    = note: required by `std::convert::From::from`
```