### PR TITLE
pbkdf2 v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64ct",
  "crypto-mac 0.10.0",

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.4 (2021-03-17)
+### Changed
+- Bump `base64ct` dependency to v1.0 ([#144])
+
+[#144]: https://github.com/RustCrypto/password-hashing/pull/144
+
 ## 0.7.3 (2021-02-08)
 ### Changed
 - Enable `rand_core` feature of `password-hash` ([#130])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"


### PR DESCRIPTION
### Changed
- Bump `base64ct` dependency to v1.0 ([#144])

[#144]: https://github.com/RustCrypto/password-hashing/pull/144