### PR TITLE
Bump password-hash to 0.1.2 due to breaking change

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -17,7 +17,7 @@ crypto-mac = "0.10"
 rayon = { version = "1", optional = true }
 base64ct = { version = "1", default-features = false, optional = true }
 hmac = { version = "0.10", default-features = false, optional = true }
-password-hash = { version = "0.1", default-features = false, optional = true, features = ["rand_core"]  }
+password-hash = { version = "0.1.2", default-features = false, optional = true, features = ["rand_core"]  }
 sha1 = { version = "0.9", package = "sha-1", default-features = false, optional = true }
 sha2 = { version = "0.9", default-features = false, optional = true }
 


### PR DESCRIPTION
I had a use case where I was using the v0.7.3 of `pbkdf2`, and when dependabot bumped to v0.7.4 there was an error with compiling `pbkdf2`:

```
 if Base64::decode(count, &mut count_arr)?.len() != 4 {
    |                                                         ^ the trait `From<base64ct::Error>` is not implemented for `HasherError`
...
```
I found that this is due to my version of `password-hash` being stuck on v0.1.1. Once I did a `cargo update -p password-hash` all was resolved.