### PR TITLE
argon2: Add parallel lane processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "hex-literal",
  "password-hash",
  "rand_core",
+ "rayon",
  "zeroize",
 ]
 

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -26,6 +26,7 @@ rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["password-hash", "rand"]
+parallel = []
 rand = ["password-hash/rand_core"]
 std = ["password-hash/std"]
 

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -17,6 +17,7 @@ readme = "README.md"
 [dependencies]
 blake2 = { version = "0.9", default-features = false }
 password-hash = { version = "0.1", optional = true }
+rayon = { version = "1", optional = true }
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -26,7 +27,7 @@ rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["password-hash", "rand"]
-parallel = []
+parallel = ["rayon", "std"]
 rand = ["password-hash/rand_core"]
 std = ["password-hash/std"]
 

--- a/argon2/src/instance.rs
+++ b/argon2/src/instance.rs
@@ -10,8 +10,9 @@ use blake2::{
 
 #[cfg(feature = "parallel")]
 use {
+    alloc::vec::Vec,
+    core::mem,
     rayon::iter::{ParallelBridge, ParallelIterator},
-    std::mem,
 };
 
 #[cfg(feature = "zeroize")]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -62,13 +62,14 @@
 //! [key derivation function]: https://en.wikipedia.org/wiki/Key_derivation_function
 //! [Password Hashing Competition]: https://www.password-hashing.net/
 
-#![no_std]
+#![cfg_attr(not(feature = "parallel"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "parallel"), forbid(unsafe_code))]
+#![cfg_attr(feature = "parallel", deny(unsafe_code))]
 #![warn(rust_2018_idioms, missing_docs)]
 
 #[macro_use]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -68,8 +68,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![cfg_attr(not(feature = "parallel"), forbid(unsafe_code))]
-#![cfg_attr(feature = "parallel", deny(unsafe_code))]
+#![deny(unsafe_code)]
 #![warn(rust_2018_idioms, missing_docs)]
 
 #[macro_use]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -62,7 +62,7 @@
 //! [key derivation function]: https://en.wikipedia.org/wiki/Key_derivation_function
 //! [Password Hashing Competition]: https://www.password-hashing.net/
 
-#![cfg_attr(not(feature = "parallel"), no_std)]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",


### PR DESCRIPTION
Adds parallel processing for lanes 
Closes #103 

The parallelism is gated behind the feature `parallel`  

When the feature is activated, the `#![forbid(unsafe_code)]` gets downgraded to `#![deny(unsafe_code)]` due to unsafe usage ([here](https://github.com/smallglitch/password-hashes/blob/f06f51d04bae051dc9ae809f016a3c85b82dac3a/argon2/src/instance.rs#L127-L135))  
The `#![no_std]` flag is being disabled as well