### PR TITLE
pbkdf2+scrypt: pin to `password-hash` v0.1.2

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -17,7 +17,7 @@ crypto-mac = "0.10"
 rayon = { version = "1", optional = true }
 base64ct = { version = "1", default-features = false, optional = true }
 hmac = { version = "0.10", default-features = false, optional = true }
-password-hash = { version = "0.1", default-features = false, optional = true, features = ["rand_core"]  }
+password-hash = { version = "0.1.2", default-features = false, optional = true, features = ["rand_core"]  }
 sha1 = { version = "0.9", package = "sha-1", default-features = false, optional = true }
 sha2 = { version = "0.9", default-features = false, optional = true }
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64ct = { version = "1", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
-password-hash = { version = "0.1", default-features = false, features = ["rand_core"], optional = true }
+password-hash = { version = "0.1.2", default-features = false, features = ["rand_core"], optional = true }
 pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.7", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }


### PR DESCRIPTION
We've had some reports of compile errors due to an unexpected SemVer-breaking change (#147, #150).

This pins the `password-hash` version to one that's guaranteed to be compatible with the current releases.

Closes #150.