### PR TITLE
scrypt v0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "base64ct",
  "hmac",

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.5 (2021-03-27)
+### Fixed
+- Pin `password-hash` to v0.1.2 or newer ([#151])
+
+[#151]: https://github.com/RustCrypto/password-hashing/pull/151
+
 ## 0.6.4 (2021-03-17)
 ### Changed
 - Bump `base64ct` dependency to v1.0 ([#144])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"


### PR DESCRIPTION
### Fixed
- Pin `password-hash` to v0.1.2 or newer ([#151])

[#151]: https://github.com/RustCrypto/password-hashing/pull/151