### PR TITLE
argon2: move `Memory` to its own module

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -79,6 +79,7 @@ extern crate alloc;
 mod block;
 mod error;
 mod instance;
+mod memory;
 
 pub use crate::error::Error;
 
@@ -86,7 +87,7 @@ pub use crate::error::Error;
 #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 pub use password_hash::{self, PasswordHash, PasswordHasher, PasswordVerifier};
 
-use crate::{block::Block, instance::Instance};
+use crate::{block::Block, instance::Instance, memory::Memory};
 use blake2::{digest, Blake2b, Digest};
 use core::{
     convert::TryFrom,
@@ -485,7 +486,7 @@ impl<'key> Argon2<'key> {
         // TODO(tarcieri): support for stack-allocated memory blocks (i.e. no alloc)
         let mut memory = vec![Block::default(); memory_blocks];
 
-        Instance::hash(self, alg, initial_hash, &mut memory, out)
+        Instance::hash(self, alg, initial_hash, Memory::new(&mut memory), out)
     }
 
     /// Hashes all the inputs into `blockhash[PREHASH_DIGEST_LENGTH]`.

--- a/argon2/src/memory.rs
+++ b/argon2/src/memory.rs
@@ -1,0 +1,36 @@
+//! Memory blocks
+
+use crate::Block;
+
+/// Structure containing references to the memory blocks
+pub(crate) struct Memory<'a> {
+    /// Memory blocks
+    data: &'a mut [Block],
+
+    /// Size of the memory in blocks
+    size: usize,
+}
+
+impl<'a> Memory<'a> {
+    /// Instantiate a new memory struct
+    pub(crate) fn new(data: &'a mut [Block]) -> Self {
+        let size = data.len();
+
+        Self { data, size }
+    }
+
+    /// Get a copy of the block
+    pub(crate) fn get_block(&self, idx: usize) -> Block {
+        self.data[idx]
+    }
+
+    /// Get a mutable reference to the block
+    pub(crate) fn get_block_mut(&mut self, idx: usize) -> &mut Block {
+        &mut self.data[idx]
+    }
+
+    /// Size of the memory
+    pub(crate) fn len(&self) -> usize {
+        self.size
+    }
+}


### PR DESCRIPTION
Also makes `Instance` accept `Memory` as a parameter.

This is in preparation for moving slice handling to `Memory`.