### PR TITLE
argon2: move segment length calculation to `Memory` type

### DIFF
--- a/argon2/src/memory.rs
+++ b/argon2/src/memory.rs
@@ -2,21 +2,38 @@
 
 use crate::Block;
 
+/// Number of synchronization points between lanes per pass
+pub(crate) const SYNC_POINTS: u32 = 4;
+
 /// Structure containing references to the memory blocks
 pub(crate) struct Memory<'a> {
     /// Memory blocks
     data: &'a mut [Block],
 
-    /// Size of the memory in blocks
-    size: usize,
+    /// Size of a memory segment in blocks
+    segment_length: u32,
 }
 
 impl<'a> Memory<'a> {
-    /// Instantiate a new memory struct
-    pub(crate) fn new(data: &'a mut [Block]) -> Self {
-        let size = data.len();
+    /// Align memory size.
+    ///
+    /// Minimum memory_blocks = 8*`L` blocks, where `L` is the number of lanes.
+    pub(crate) fn segment_length_for_params(m_cost: u32, lanes: u32) -> u32 {
+        let memory_blocks = if m_cost < 2 * SYNC_POINTS * lanes {
+            2 * SYNC_POINTS * lanes
+        } else {
+            m_cost
+        };
 
-        Self { data, size }
+        memory_blocks / (lanes * SYNC_POINTS)
+    }
+
+    /// Instantiate a new memory struct
+    pub(crate) fn new(data: &'a mut [Block], segment_length: u32) -> Self {
+        Self {
+            data,
+            segment_length,
+        }
     }
 
     /// Get a copy of the block
@@ -30,7 +47,14 @@ impl<'a> Memory<'a> {
     }
 
     /// Size of the memory
+    #[inline]
     pub(crate) fn len(&self) -> usize {
-        self.size
+        self.data.len()
+    }
+
+    /// Size of a memory segment
+    #[inline]
+    pub(crate) fn segment_length(&self) -> u32 {
+        self.segment_length
     }
 }


### PR DESCRIPTION
Begins the work of moving calculations about the memory buffer to the `Memory` type.