### PR TITLE
argon2: use Block::SIZE constant

### DIFF
--- a/argon2/src/instance.rs
+++ b/argon2/src/instance.rs
@@ -1,8 +1,7 @@
 //! Argon2 instance (i.e. state)
 
 use crate::{
-    Algorithm, Argon2, Block, Error, Memory, Version, BLOCK_SIZE, MAX_OUTLEN, MIN_OUTLEN,
-    SYNC_POINTS,
+    Algorithm, Argon2, Block, Error, Memory, Version, MAX_OUTLEN, MIN_OUTLEN, SYNC_POINTS,
 };
 use blake2::{
     digest::{self, VariableOutput},
@@ -201,7 +200,7 @@ impl<'a> Instance<'a> {
         }
 
         // Hash the result
-        let mut blockhash_bytes = [0u8; BLOCK_SIZE];
+        let mut blockhash_bytes = [0u8; Block::SIZE];
 
         for (chunk, v) in blockhash_bytes.chunks_mut(8).zip(blockhash.iter()) {
             chunk.copy_from_slice(&v.to_le_bytes())
@@ -220,7 +219,7 @@ impl<'a> Instance<'a> {
 
     /// Function creates first 2 blocks per lane
     fn fill_first_blocks(&mut self, blockhash: &[u8]) -> Result<(), Error> {
-        let mut hash = [0u8; BLOCK_SIZE];
+        let mut hash = [0u8; Block::SIZE];
 
         for l in 0..self.lanes {
             // Make the first and second block in each lane as G(H0||0||i) or

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -123,10 +123,10 @@ pub const MIN_OUTLEN: usize = 4;
 /// Maximum digest size in bytes
 pub const MAX_OUTLEN: usize = 0xFFFFFFFF;
 
-/// Minimum number of memory blocks (each of [`BLOCK_SIZE`] bytes)
+/// Minimum number of memory blocks.
 pub const MIN_MEMORY: u32 = 2 * SYNC_POINTS; // 2 blocks per slice
 
-/// Maximum number of memory blocks (each of [`BLOCK_SIZE`] bytes)
+/// Maximum number of memory blocks.
 pub const MAX_MEMORY: u32 = 0x0FFFFFFF;
 
 /// Minimum number of passes
@@ -151,7 +151,8 @@ pub const MAX_SALT_LENGTH: usize = 0xFFFFFFFF;
 pub const MAX_SECRET: usize = 0xFFFFFFFF;
 
 /// Memory block size in bytes
-pub const BLOCK_SIZE: usize = 1024;
+#[deprecated(since = "0.1.6", note = "use Block::SIZE instead")]
+pub const BLOCK_SIZE: usize = Block::SIZE;
 
 /// Argon2d algorithm identifier
 #[cfg(feature = "password-hash")]


### PR DESCRIPTION
Also deprecates the previous `argon2::BLOCK_SIZE` constant.