### PR TITLE
Bump `password-hash` crate dependency to v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,8 +258,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/traits#d6a1e128825113d29eb7fd2525a9bba161415717"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7561a874264c351c35ccde0da29a98dea5f2483357c049673319c7f3446d14da"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
     "scrypt",
     "sha-crypt"
 ]
-
-[patch.crates-io]
-password-hash = { git = "https://github.com/RustCrypto/traits" }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -16,13 +16,13 @@ readme = "README.md"
 
 [dependencies]
 blake2 = { version = "0.9", default-features = false }
-password-hash = { version = "=0.2.0-pre", optional = true }
+password-hash = { version = "0.2", optional = true }
 rayon = { version = "1", optional = true }
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
-password-hash = { version = "=0.2.0-pre", features = ["rand_core"] }
+password-hash = { version = "0.2", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["std"] }
 
 [features]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -17,7 +17,7 @@ crypto-mac = "0.10"
 rayon = { version = "1", optional = true }
 base64ct = { version = "1", default-features = false, optional = true }
 hmac = { version = "0.10", default-features = false, optional = true }
-password-hash = { version = "=0.2.0-pre", default-features = false, optional = true, features = ["rand_core"]  }
+password-hash = { version = "0.2", default-features = false, optional = true, features = ["rand_core"]  }
 sha1 = { version = "0.9", package = "sha-1", default-features = false, optional = true }
 sha2 = { version = "0.9", default-features = false, optional = true }
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,13 +14,13 @@ readme = "README.md"
 [dependencies]
 base64ct = { version = "1", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.10"
-password-hash = { version = "=0.2.0-pre", default-features = false, features = ["rand_core"], optional = true }
+password-hash = { version = "0.2", default-features = false, features = ["rand_core"], optional = true }
 pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.7", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
-password-hash = { version = "=0.2.0-pre", features = ["rand_core"] }
+password-hash = { version = "0.2", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["std"] }
 
 [features]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/624