### PR TITLE
pbkdf2 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "base64ct",
  "crypto-mac 0.11.0",

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 blowfish = { version = "0.7", features = ["bcrypt"] }
 crypto-mac = "0.11"
-pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.8", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-04-29)
+### Changed
+- Bump `password-hash` crate dependency to v0.2 ([#164])
+- Bump `hmac` and `crypto-mac` crate deps to v0.11 ([#165])
+
+[#164]: https://github.com/RustCrypto/password-hashing/pull/164
+[#165]: https://github.com/RustCrypto/password-hashing/pull/165
+
 ## 0.7.5 (2021-03-27)
 ### Fixed
 - Pin `password-hash` to v0.1.2 or newer ([#151])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.7.5"
+version = "0.8.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 base64ct = { version = "1", default-features = false, features = ["alloc"], optional = true }
 hmac = "0.11"
 password-hash = { version = "0.2", default-features = false, features = ["rand_core"], optional = true }
-pbkdf2 = { version = "0.7", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.8", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.8", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }
 


### PR DESCRIPTION
### Changed
- Bump `password-hash` crate dependency to v0.2 ([#164])
- Bump `hmac` and `crypto-mac` crate deps to v0.11 ([#165])

[#164]: https://github.com/RustCrypto/password-hashing/pull/164
[#165]: https://github.com/RustCrypto/password-hashing/pull/165