### PR TITLE
scrypt v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "base64ct",
  "hmac",

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Bump `password-hash` crate dependency to v0.2 ([#164])
+- Bump `hmac` and `crypto-mac` crate deps to v0.11 ([#165])
+- Bump `salsa20` crate dependency to v0.8 ([#166])
+- Bump `pbkdf2` crate dependency to v0.8 ([#167])
+
+[#164]: https://github.com/RustCrypto/password-hashing/pull/164
+[#165]: https://github.com/RustCrypto/password-hashing/pull/165
+[#166]: https://github.com/RustCrypto/password-hashing/pull/166
+[#167]: https://github.com/RustCrypto/password-hashing/pull/167
+
 ## 0.6.5 (2021-03-27)
 ### Fixed
 - Pin `password-hash` to v0.1.2 or newer ([#151])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.6.5"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"


### PR DESCRIPTION
### Changed
- Bump `password-hash` crate dependency to v0.2 ([#164])
- Bump `hmac` and `crypto-mac` crate deps to v0.11 ([#165])
- Bump `salsa20` crate dependency to v0.8 ([#166])
- Bump `pbkdf2` crate dependency to v0.8 ([#167])

[#164]: https://github.com/RustCrypto/password-hashing/pull/164
[#165]: https://github.com/RustCrypto/password-hashing/pull/165
[#166]: https://github.com/RustCrypto/password-hashing/pull/166
[#167]: https://github.com/RustCrypto/password-hashing/pull/167