### PR TITLE
argon2 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "argon2"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "blake2",
  "hex-literal",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-04-29)
+### Changed
+- Forbid unsafe code outside parallel implementation ([#157])
+- Bump `password-hash` crate dependency to v0.2 ([#164])
+
+### Removed
+- `argon2::BLOCK_SIZE` constant ([#161])
+
+[#157]: https://github.com/RustCrypto/password-hashes/pull/157
+[#161]: https://github.com/RustCrypto/password-hashes/pull/161
+[#164]: https://github.com/RustCrypto/password-hashes/pull/164
+
 ## 0.1.5 (2021-04-18)
 ### Added
 - Parallel lane processing using `rayon` ([#149])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
 """
-version = "0.1.5"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/argon2"

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -156,10 +156,6 @@ pub const MAX_SALT_LENGTH: usize = 0xFFFFFFFF;
 /// Maximum key length in bytes
 pub const MAX_SECRET: usize = 0xFFFFFFFF;
 
-/// Memory block size in bytes
-#[deprecated(since = "0.1.6", note = "use Block::SIZE instead")]
-pub const BLOCK_SIZE: usize = Block::SIZE;
-
 /// Argon2d algorithm identifier
 #[cfg(feature = "password-hash")]
 #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]


### PR DESCRIPTION
### Changed
- Forbid unsafe code outside parallel implementation ([#157])
- Bump `password-hash` crate dependency to v0.2 ([#164])

### Removed
- `argon2::BLOCK_SIZE` constant ([#161])

[#157]: https://github.com/RustCrypto/password-hashes/pull/157
[#161]: https://github.com/RustCrypto/password-hashes/pull/161
[#164]: https://github.com/RustCrypto/password-hashes/pull/164