### PR TITLE
Bump argon version number in docs

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argon2 = "0.1"
+//! argon2 = "0.2"
 //! rand_core = { version = "0.6", features = ["std"] }
 //! ```
 //!


### PR DESCRIPTION
The latest release is 0.2 and I'm not sure that Cargo resolves to that from 0.1.

I might be wrong though so please ignore if so :) 