### PR TITLE
bcrypt-pbkdf v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blowfish",
  "crypto-mac 0.11.0",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2021-04-29)
+## 0.6.1 (2021-05-04)
+### Changed
+- Bump `blowfish` dependency to v0.8 ([#171])
+
+[#171]: https://github.com/RustCrypto/password-hashing/pull/171
+
+## 0.6.0 (2021-04-29) [YANKED]
 ### Changed
 - Bump `crypto-mac` dependency to v0.11 ([#165])
 - Bump `pbkdf2` to v0.8 ([#167])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bcrypt-pbkdf"
 description = "bcrypt-pbkdf password-based key derivation function"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"
 keywords = ["crypto", "password", "hashing"]


### PR DESCRIPTION
### Changed
- Bump `blowfish` dependency to v0.8 ([#171])

[#171]: https://github.com/RustCrypto/password-hashing/pull/171