### PR TITLE
scrypt: Adds parallel feature and max_memory argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "rand_core",
+ "rayon",
  "salsa20",
  "sha2",
 ]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -16,6 +16,7 @@ base64ct = { version = "1", default-features = false, features = ["alloc"], opti
 hmac = "0.11"
 password-hash = { version = "0.2", default-features = false, features = ["rand_core"], optional = true }
 pbkdf2 = { version = "0.8", default-features = false, path = "../pbkdf2" }
+rayon = { version = "1", optional = true }
 salsa20 = { version = "0.8", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }
 
@@ -24,9 +25,10 @@ password-hash = { version = "0.2", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["std"] }
 
 [features]
-default = ["simple", "std"]
+default = ["simple", "std", "parallel"]
 simple = ["password-hash", "base64ct"]
 std = ["password-hash/std"]
+parallel = ["rayon"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/benches/lib.rs
+++ b/scrypt/benches/lib.rs
@@ -16,3 +16,29 @@ pub fn scrypt_15_8_1(bh: &mut Bencher) {
         test::black_box(&buf);
     });
 }
+
+#[bench]
+pub fn scrypt_parallel_15_8_4(bh: &mut Bencher) {
+    let password = b"my secure password";
+    let salt = b"salty salt";
+    let mut buf = [0u8; 32];
+    let params = scrypt::Params::new(15, 8, 4).unwrap();
+    bh.iter(|| {
+        scrypt::scrypt_parallel(password, salt, &params, 4 * 1024 * 1024 * 1024, 4, &mut buf)
+            .unwrap();
+        test::black_box(&buf);
+    });
+}
+
+#[bench]
+pub fn scrypt_15_8_4(bh: &mut Bencher) {
+    let password = b"my secure password";
+    let salt = b"salty salt";
+    let mut buf = [0u8; 32];
+    let params = scrypt::Params::new(15, 8, 4).unwrap();
+    bh.iter(|| {
+        scrypt::scrypt_parallel(password, salt, &params, 4 * 1024 * 1024 * 1024, 1, &mut buf)
+            .unwrap();
+        test::black_box(&buf);
+    });
+}

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -75,13 +75,110 @@ pub use crate::simple::{Scrypt, ALG_ID};
 ///   **WARNING: Make sure to compare this value in constant time!**
 ///
 /// # Return
-/// `Ok(())` if calculation is succesfull and `Err(InvalidOutputLen)` if
+/// `Ok(())` if calculation is successful and `Err(InvalidOutputLen)` if
 /// `output` does not satisfy the following condition:
 /// `output.len() > 0 && output.len() <= (2^32 - 1) * 32`.
+///
+/// This function only uses a single thread (the current thread) for computation.
 pub fn scrypt(
     password: &[u8],
     salt: &[u8],
     params: &Params,
+    output: &mut [u8],
+) -> Result<(), errors::InvalidOutputLen> {
+    scrypt_log_f(password, salt, params, 0, 1, output)
+}
+
+/// The scrypt key derivation function that may use multiple threads.
+///
+/// # Arguments
+/// - `password` - The password to process as a byte vector
+/// - `salt` - The salt value to use as a byte vector
+/// - `params` - The ScryptParams to use
+/// - `max_memory` - The maximum amount of memory to use, in bytes. May use slightly more (on the order of hundreds of bytes).
+/// - `num_threads` - The maximum number of threads to use.
+/// - `output` - The resulting derived key is returned in this byte vector.
+///   **WARNING: Make sure to compare this value in constant time!**
+///
+/// # Return
+/// `Ok(())` if calculation is successful and `Err(InvalidOutputLen)` if
+/// `output` does not satisfy the following condition:
+/// `output.len() > 0 && output.len() <= (2^32 - 1) * 32`.
+///
+/// The parallel feature must be enabled for this function to use multiple threads.
+/// Note that scrypt normally needs 2**log_n * 128 * r * min(num_threads, p) bytes for computation.
+/// If max_memory is less than this, this implementation will automatically reduce memory usage.
+/// Though this comes at the cost of increased computation.
+/// (Note: It's always better to make this trade if it means using more CPU cores)
+pub fn scrypt_parallel(
+    password: &[u8],
+    salt: &[u8],
+    params: &Params,
+    max_memory: usize,
+    num_threads: usize,
+    output: &mut [u8],
+) -> Result<(), errors::InvalidOutputLen> {
+    // The checks in the ScryptParams constructor guarantee
+    // that the following is safe:
+    let n: usize = 1 << params.log_n;
+    let r128 = (params.r as usize) * 128;
+
+    // No point in using more than p threads.
+    let num_threads = num_threads.min(params.p as usize);
+
+    // The optimal log_f is always the one that allows the most cores to run.
+    // The increase in computation caused by increased log_f is always offset
+    // by the increased core usage. Thus log_f can be calculated based on
+    // num_threads and max_mem (assuming num_threads is less than or equal to
+    // the number of cores).
+    // So first we calculate how many blocks each thread can allocate.
+    let mem_per_thread = max_memory / num_threads;
+    let blocks_per_thread = mem_per_thread / r128;
+
+    if blocks_per_thread == 0 {
+        // TODO: Return error
+        panic!("Not enough memory");
+    }
+
+    // Now log_f is calculated by determining how far right we need to shift n
+    // to be less than or equal to blocks_per_thread.
+    let possible_log_f = blocks_per_thread
+        .leading_zeros()
+        .saturating_sub(n.leading_zeros());
+
+    // Rounding up.
+    let log_f = if (n >> possible_log_f) > blocks_per_thread {
+        // The checked_add should never fail.
+        possible_log_f.checked_add(1).expect("overflow")
+    } else {
+        possible_log_f
+    };
+
+    scrypt_log_f(password, salt, params, log_f, num_threads, output)
+}
+
+/// The scrypt key derivation function that accepts the raw log_f parameter.
+///
+/// # Arguments
+/// - `password` - The password to process as a byte vector
+/// - `salt` - The salt value to use as a byte vector
+/// - `params` - The ScryptParams to use
+/// - `log_f` - A factor that reduces memory usage at the cost of increased computation; must be less than or equal to params.log_n
+/// - `num_threads` - The maximum number of threads to use.
+/// - `output` - The resulting derived key is returned in this byte vector.
+///   **WARNING: Make sure to compare this value in constant time!**
+///
+/// # Return
+/// `Ok(())` if calculation is successful and `Err(InvalidOutputLen)` if
+/// `output` does not satisfy the following condition:
+/// `output.len() > 0 && output.len() <= (2^32 - 1) * 32`.
+#[doc(hidden)]
+pub fn scrypt_log_f(
+    password: &[u8],
+    salt: &[u8],
+    params: &Params,
+    log_f: u32,
+    num_threads: usize,
     output: &mut [u8],
 ) -> Result<(), errors::InvalidOutputLen> {
     // This check required by Scrypt:
@@ -90,6 +187,9 @@ pub fn scrypt(
         return Err(errors::InvalidOutputLen);
     }
 
+    // log_f must be less than or equal to log_n, or else V will be 0 bytes.
+    assert!(log_f <= (params.log_n as u32));
+
     // The checks in the ScryptParams constructor guarantee
     // that the following is safe:
     let n = 1 << params.log_n;
@@ -97,14 +197,35 @@ pub fn scrypt(
     let pr128 = (params.p as usize) * r128;
     let nr128 = n * r128;
 
+    // B is a set of `p` blocks of data, each `r128` in length.
     let mut b = vec![0u8; pr128];
     pbkdf2::<Hmac<Sha256>>(&password, salt, 1, &mut b);
 
-    let mut v = vec![0u8; nr128];
-    let mut t = vec![0u8; r128];
+    #[cfg(feature = "parallel")]
+    {
+        use rayon::prelude::*;
 
-    for chunk in &mut b.chunks_mut(r128) {
-        romix::scrypt_ro_mix(chunk, &mut v, &mut t, n);
+        // Each chunk of B can be operated on in parallel. Rayon is used to
+        // distribute that work across the available threads.
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .build()
+            .expect("Unable to build rayon::ThreadPool");
+        pool.install(|| {
+            b.par_chunks_exact_mut(r128).for_each_init(
+                || (vec![0u8; nr128 >> log_f], vec![0u8; r128 * 2]),
+                |(v, t), chunk| romix::scrypt_ro_mix(chunk, v, t, n, log_f),
+            );
+        });
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        let mut v = vec![0u8; nr128 >> log_f];
+        let mut t = vec![0u8; r128 * 2];
+
+        for chunk in b.chunks_exact_mut(r128) {
+            romix::scrypt_ro_mix(chunk, &mut v, &mut t, n, log_f);
+        }
     }
 
     pbkdf2::<Hmac<Sha256>>(&password, &b, 1, output);

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -1,4 +1,4 @@
-use scrypt::{scrypt, Params};
+use scrypt::{scrypt, scrypt_log_f, scrypt_parallel, Params};
 
 #[cfg(feature = "simple")]
 use {
@@ -78,6 +78,63 @@ fn test_scrypt() {
         )
         .unwrap();
         assert!(result == t.expected);
+    }
+}
+
+/// Tests that scrypt_parallel works correctly, even when max_memory is small.
+#[test]
+fn test_scrypt_parallel() {
+    let tests = tests();
+    for t in tests.iter() {
+        let mut result = vec![0u8; t.expected.len()];
+        let params = Params::new(t.log_n, t.r, t.p).unwrap();
+        scrypt_parallel(
+            t.password.as_bytes(),
+            t.salt.as_bytes(),
+            &params,
+            1024 * 1024,
+            4,
+            &mut result,
+        )
+        .unwrap();
+        assert!(result == t.expected);
+    }
+
+    for t in tests.iter() {
+        let mut result = vec![0u8; t.expected.len()];
+        let params = Params::new(t.log_n, t.r, t.p).unwrap();
+        scrypt_parallel(
+            t.password.as_bytes(),
+            t.salt.as_bytes(),
+            &params,
+            4 * 1024 * 1024 * 1024,
+            4,
+            &mut result,
+        )
+        .unwrap();
+        assert!(result == t.expected);
+    }
+}
+
+/// Tests various log_f values to ensure implementation is correct.
+#[test]
+fn test_scrypt_log_f() {
+    let tests = tests();
+    for log_f in 0..2 {
+        for t in tests.iter() {
+            let mut result = vec![0u8; t.expected.len()];
+            let params = Params::new(t.log_n, t.r, t.p).unwrap();
+            scrypt_log_f(
+                t.password.as_bytes(),
+                t.salt.as_bytes(),
+                &params,
+                log_f,
+                1,
+                &mut result,
+            )
+            .unwrap();
+            assert!(result == t.expected);
+        }
     }
 }
 


### PR DESCRIPTION
**WARNING: Do NOT merge yet; discussion is required.**

## Overview

Hello! This is my first contribution to this project. I hope it is helpful. I welcome comments and am happy to update my pull request as needed.

This pull request adds parallelism to the scrypt implementation, gated behind a new crate feature `parallel`. It uses rayon internally. The original `scrypt` function should work exactly as it did before, and does not use parallelism. Instead a new `scrypt_parallel` function is added which allows the user to specify `num_threads`.

`scrypt_parallel` also features a new `max_memory` argument that can be used to limit the memory usage of scrypt. Setting this to 1GB, for example, will make `scrypt` use less than 1GB regardless of scrypt params and number of threads (though it may use _slightly_ more than 1GB on the order of hundreds of bytes; specifically the storage of B and temporary variables is not counted).

New tests and benchs were added to cover the new features.

## Implementation details

The parallelism is straightforward and just uses rayon across the `p` parameter.

`max_memory` is a bit more involved. This is accomplished through the use of a memory-compute trade off for the scrypt algorithm. `romix::scrypt_ro_mix` has been modified with a `log_f` argument. At `log_f = 0` it operates just as it did before. At `log_f=1` it uses half the memory at the cost of more compute. And so forth.

It's easiest to understand `log_f` in terms of the size of `V` and the computational cost of `scrypt_ro_mix`. `V` must be `n >> log_f` blocks in length. The total BlockMix operations performed by `scrypt_ro_mix` is equal to `ops(n, log_f) = 2 * n + 0.5 * n * (2**log_f - 1)`.

The addition of this `log_f` functionality allows us to implement the `max_memory` argument. This means any `scrypt` parameters can be computed even on machines that otherwise don't have the memory for it. It's also very useful for parallelism as the memory usage of scrypt normally scales linearly with the number of threads used (since each thread needs its own `V`).

`scrypt_log_f` is the new workhorse, implementing the higher level scrypt algorithm, with the addition of `num_threads` to control parallelism and `log_f` to control memory usage.

`scrypt` now calls `scrypt_log_f` internally with `log_f = 0` and `num_threads = 1` to emulate previous behavior.

`scrypt_parallel` calls `scrypt_log_f` internally as well, but it calculates `log_f` automatically from the provided `max_memory` parameter.

It's always better to use all available cores on a machine to compute scrypt, even if that means increasing `log_f` to make that possible. Consider for example computing `scrypt(log_n=20, r=8, p=4)` on a four core, 1GB machine. That machine only has enough memory to compute `scrypt(log_n=20, r=8, p=1)`, so without `log_f` it can only use a single core. Increasing `log_f` to 2 allows the use of all four cores. It turns out that, despite `log_f` increasing the amount of work, it's still overall faster as that compute is offset by the additional cores that can work.

(See the section "log_f proof" for the proof. Note that we ignore the overhead bytes needed for B and temps, to simplify.)

So `scrypt_parallel` can use `max_memory` to automatically set `log_f` to the optimal value, assuming `num_threads` is less than or equal to the number of cores on the machine.


## Benchmarks

```
commit f8735676f0591ebfb2a59a2a076c2c3fa80cd5be
CARGO_PROFILE_BENCH_LTO=true CARGO_PROFILE_BENCH_CODEGEN_UNITS=1 RUSTFLAGS="-C target-cpu=native" cargo +nightly bench

test scrypt_15_8_1          ... bench:  56,664,081 ns/iter (+/- 3,567,575)
test scrypt_15_8_4          ... bench: 222,945,177 ns/iter (+/- 6,051,303)
test scrypt_parallel_15_8_4 ... bench:  72,227,336 ns/iter (+/- 4,555,001)


commit 02fcc37f63894cd699335c7f3f2e914dc577c7ea
CARGO_PROFILE_BENCH_LTO=true CARGO_PROFILE_BENCH_CODEGEN_UNITS=1 RUSTFLAGS="-C target-cpu=native" cargo +nightly bench
test scrypt_15_8_1 ... bench:  55,516,757 ns/iter (+/- 3,521,891)
```

Speed of scrypt remains unaffected by these changes (within the margin of error).


## Discussion

I don't think the API I picked for the new `scrypt_*` functions is ideal. I'm not sure what the ideal API is for the new features. So feedback would be great!

Since `log_f` always has an optimal value based on desired memory usage and number of threads, it seems like `scrypt_parallel` presents the more useful API to the user. Hence why I hid `scrypt_log_f`.

But maybe some users might want direct control of `log_f` for some reason?

And `max_memory` is also kind of a tricky argument. It requires the user to know how much memory is available on the machine. The sysinfo crate provides these kinds of stats, so I guess I would expect users to use something like that, possibly dividing it by some factor so they don't use all of the memory, and then feeding that as `max_memory`.

I thought about including that kind of functionality directly in this crate. But the sysinfo crate didn't look very straightforward and robust, so I don't personally feel comfortable including it in a cryptography crate. I guess we could put it behind a feature flag?

Of course an API user is welcome to just set `max_memory` to a huge value if they "don't care", and get the same behavior as `scrypt` but with the addition of parallelism.

Finally, the addition of the `max_memory` argument adds another failure case to `scrypt_parallel`. There are situations where `max_memory` is too small for the given parameters, so `scrypt_parallel` needs to error out. Since there were no existing errors I just put in a `panic` for now. Should a new error be added?

It's important to note that the existing `scrypt` parameter would _also_ panic in low memory situations, due to OOM. So it's more like `scrypt_parallel` makes that situation explicit.  (Though `scrypt_parallel` can still OOM since it doesn't currently account for all allocations.)


## log_f proof

```
# Suppose we have a four core, 1GB machine and need to compute scrypt(log_n=20, r=8, p=4).
# At f=1 scrypt needs 1GB of memory, so we can only use 1 core of this machine.
# At f=4 scrypt only needs 0.25GB, which means we can use all 4 cores.  But each core has to do a lot more work.
# Which is better?
# More generally, is it _always_ better to trade compute for memory if it means we can use all the cores on a given machine?
# Let's find out!

# The number of operations that need to be performed is given by:
# ops(n, f, p) = (2 * n + 0.5 * n * (f - 1)) * p
#
# From our example we assume that when f=1 we can only use one core for computation.  When f=2 we can use 2 cores.
# When f=16 we can use 16 cores.  Etc.
# So we can formulate computation time like so:
# time(n, f, p) = ops(n, f, p) / f => (2 * n + 0.5 * n * (f - 1)) * p / f
#
# By increasing f, ops(n, f, p) increases, but we can also use more cores, hence the division by f.
# 
# Now we can ask the question, is it always better to increase f?
#
# time(n, f + 1, p) <? time(n, f, p)
# 
# Note: assumes n > 0, f > 0, p > 0
# (2 * n + 0.5 * n * ((f + 1) - 1)) * p / (f + 1) <? (2 * n + 0.5 * n * (f - 1)) * p / f
# Divide by p:
# (2 * n + 0.5 * n * f) / (f + 1) <? (2 * n + 0.5 * n * (f - 1)) / f
# Divide by n:
# (2 + 0.5 * f) / (f + 1) <? (2 + 0.5 * (f - 1)) / f
# Multiply by 2:
# (4 + f) / (f + 1) <? (4 + f - 1) / f
# Multiply by f * (f + 1):
# (4 + f) * f <? (3 + f) * (f + 1)
# Expand:
# 4 * f + f**2 <? 3 * f + 3 + f**2 + f
# Subtract 4 * f + f**2
# 0 <? 3
# QED
# 0 < 3
#
# Thus we show that increasing f _always_ results in faster computation, as long as there are cores available.
# This of course also assumes that the p parameter is also large enough to keep all cores busy.
# For example when trying to compute scrypt(log_n=20, r=8, p=4) we can never use more than four cores, so it doesn't
# make sense to increase f beyond what's needed to allow four cores to run.
# And of course we're also assuming there's memory bandwidth aplenty.
#
# So for a given set of scrypt parameters, the optimal f-factor is set using:
# cores = min(machine_cores, p)
# iter_memory = machine_memory / cores
# f = ceil(n * 128 * r / iter_memory)
#
# Though in practice it's only reasonable for f to be a power of two, so the nearest power of two greater than or equal to f
# should be used.
```


## Side Note: SSE

I didn't do it in this pull request, but while digging into the code and such I also noticed that the use of SSE would make scrypt run significantly faster. I figured I'd put a note here about it, just so there's note about it _somewhere_, even though it's not relevant to this pull request.

Implementing scrypt using SSE is relatively straightforward. Colin Percival's scrypt implementation in tarsnap has a good example. The easiest way to do this is to just directly port that implementation over to Rust using `core::arch`. I did that and saw a nice improvement from `46ns` per salsa20_8 call to `33ns` per salsa20_8 call. That should translate to `scrypt` as a whole running in ~70% of the time!

But `core::arch` would introduce `unsafe` into this crate and isn't future proof. I tried to find a way to re-write the existing Rust code in such a way that the compiler itself could infer SIMD instructions. See this thread: https://users.rust-lang.org/t/can-the-compiler-infer-sse-instructions/59976

While the compiler is or will be capable of doing that, for some permutations of the code, those optimization passes are really unstable now, for example varying their outputs depending on whether you use `rotate_left` or a manual implementation.

Again, this isn't relavant to this pull request. Just wanted to put those findings down somewhere.


## TODOs

These todos should block merging until resolved:

- [ ] Should `scrypt_parallel` return an error on low memory, or panic?
- [ ] Figure out final API
- [ ] Someone else should review all changes and verify correctness, especially the changes to `romix`


## Final Note

Thank you for taking the time to review my pull request. I hope it's useful! Sorry for the long pull request notes, but I wanted to be sure to explain everything thoroughly, as this is a security sensitive codebase.