### PR TITLE
argon2: error handling improvements

### DIFF
--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 /// Error type.
-// TODO(tarcieri): finer-grained context-specific errors?
+// TODO(tarcieri): consolidate/replace with `password_hash::Error`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Associated data is too long
@@ -75,5 +75,30 @@ impl fmt::Display for Error {
             Error::TimeTooSmall => "time cost is too small",
             Error::VersionInvalid => "invalid version",
         })
+    }
+}
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+impl From<Error> for password_hash::Error {
+    fn from(err: Error) -> password_hash::Error {
+        match err {
+            Error::AdTooLong => password_hash::Error::ParamValueInvalid,
+            Error::AlgorithmInvalid => password_hash::Error::Algorithm,
+            Error::LanesTooFew => password_hash::Error::ParamValueInvalid,
+            Error::LanesTooMany => password_hash::Error::ParamValueInvalid,
+            Error::MemoryTooLittle => password_hash::Error::ParamValueInvalid,
+            Error::MemoryTooMuch => password_hash::Error::ParamValueInvalid,
+            Error::PwdTooLong => password_hash::Error::Password,
+            Error::OutputTooShort => password_hash::Error::OutputTooShort,
+            Error::OutputTooLong => password_hash::Error::OutputTooLong,
+            Error::SaltTooShort => password_hash::Error::SaltTooLong,
+            Error::SaltTooLong => password_hash::Error::SaltTooLong,
+            Error::SecretTooLong => password_hash::Error::ParamValueInvalid,
+            Error::ThreadsTooFew => password_hash::Error::ParamValueInvalid,
+            Error::ThreadsTooMany => password_hash::Error::ParamValueInvalid,
+            Error::TimeTooSmall => password_hash::Error::ParamValueInvalid,
+            Error::VersionInvalid => password_hash::Error::Version,
+        }
     }
 }

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -533,17 +533,7 @@ impl PasswordHasher for Argon2<'_> {
 
         // TODO(tarcieri): improve this API to eliminate redundant checks above
         let output = password_hash::Output::init_with(params.output_size, |out| {
-            hasher
-                .hash_password_into(algorithm, password, salt_bytes, ad, out)
-                .map_err(|e| {
-                    match e {
-                        Error::OutputTooShort => password_hash::Error::OutputTooShort,
-                        Error::OutputTooLong => password_hash::Error::OutputTooLong,
-                        // Other cases are not returned from `hash_password_into`
-                        // TODO(tarcieri): finer-grained error types?
-                        _ => panic!("unhandled error type: {}", e),
-                    }
-                })
+            Ok(hasher.hash_password_into(algorithm, password, salt_bytes, ad, out)?)
         })?;
 
         let res = Ok(PasswordHash {


### PR DESCRIPTION
Adds a proper conversion between argon2::Error and password_hash::Error and uses it when hashing the password.