### PR TITLE
argon2: eliminate redundant checks added in #135

### DIFF
--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -92,7 +92,7 @@ impl From<Error> for password_hash::Error {
             Error::PwdTooLong => password_hash::Error::Password,
             Error::OutputTooShort => password_hash::Error::OutputTooShort,
             Error::OutputTooLong => password_hash::Error::OutputTooLong,
-            Error::SaltTooShort => password_hash::Error::SaltTooLong,
+            Error::SaltTooShort => password_hash::Error::SaltTooShort,
             Error::SaltTooLong => password_hash::Error::SaltTooLong,
             Error::SecretTooLong => password_hash::Error::ParamValueInvalid,
             Error::ThreadsTooFew => password_hash::Error::ParamValueInvalid,


### PR DESCRIPTION
Now that error handling has been improved in `password-hash` v0.2, these are no longer needed as the errors will be properly handled in the `hash_password_into` function.