### PR TITLE
argon2: make `Params` always available; fix `hash_password_simple`

### DIFF
--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -1,0 +1,137 @@
+//! Argon2 algorithms (e.g. Argon2d, Argon2i, Argon2id).
+
+use crate::Error;
+use core::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+#[cfg(feature = "password-hash")]
+use {core::convert::TryFrom, password_hash::Ident};
+
+/// Argon2d algorithm identifier
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const ARGON2D_IDENT: Ident<'_> = Ident::new("argon2d");
+
+/// Argon2i algorithm identifier
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const ARGON2I_IDENT: Ident<'_> = Ident::new("argon2i");
+
+/// Argon2id algorithm identifier
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const ARGON2ID_IDENT: Ident<'_> = Ident::new("argon2id");
+
+/// Argon2 primitive type: variants of the algorithm.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Algorithm {
+    /// Optimizes against GPU cracking attacks but vulnerable to side-channels.
+    ///
+    /// Accesses the memory array in a password dependent order, reducing the
+    /// possibility of time–memory tradeoff (TMTO) attacks.
+    Argon2d = 0,
+
+    /// Optimized to resist side-channel attacks.
+    ///
+    /// Accesses the memory array in a password independent order, increasing the
+    /// possibility of time-memory tradeoff (TMTO) attacks.
+    Argon2i = 1,
+
+    /// Hybrid that mixes Argon2i and Argon2d passes (*default*).
+    ///
+    /// Uses the Argon2i approach for the first half pass over memory and
+    /// Argon2d approach for subsequent passes. This effectively places it in
+    /// the "middle" between the other two: it doesn't provide as good
+    /// TMTO/GPU cracking resistance as Argon2d, nor as good of side-channel
+    /// resistance as Argon2i, but overall provides the most well-rounded
+    /// approach to both classes of attacks.
+    Argon2id = 2,
+}
+
+impl Default for Algorithm {
+    fn default() -> Algorithm {
+        Algorithm::Argon2id
+    }
+}
+
+impl Algorithm {
+    /// Parse an [`Algorithm`] from the provided string.
+    pub fn new(id: impl AsRef<str>) -> Result<Self, Error> {
+        id.as_ref().parse()
+    }
+
+    /// Get the identifier string for this PBKDF2 [`Algorithm`].
+    pub fn as_str(&self) -> &str {
+        match self {
+            Algorithm::Argon2d => "argon2d",
+            Algorithm::Argon2i => "argon2i",
+            Algorithm::Argon2id => "argon2id",
+        }
+    }
+
+    /// Get the [`Ident`] that corresponds to this Argon2 [`Algorithm`].
+    #[cfg(feature = "password-hash")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+    pub fn ident(&self) -> Ident<'static> {
+        match self {
+            Algorithm::Argon2d => ARGON2D_IDENT,
+            Algorithm::Argon2i => ARGON2I_IDENT,
+            Algorithm::Argon2id => ARGON2ID_IDENT,
+        }
+    }
+
+    /// Serialize primitive type as little endian bytes
+    pub(crate) fn to_le_bytes(self) -> [u8; 4] {
+        (self as u32).to_le_bytes()
+    }
+}
+
+impl AsRef<str> for Algorithm {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Algorithm {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Algorithm, Error> {
+        match s {
+            "argon2d" => Ok(Algorithm::Argon2d),
+            "argon2i" => Ok(Algorithm::Argon2i),
+            "argon2id" => Ok(Algorithm::Argon2id),
+            _ => Err(Error::AlgorithmInvalid),
+        }
+    }
+}
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+impl From<Algorithm> for Ident<'static> {
+    fn from(alg: Algorithm) -> Ident<'static> {
+        alg.ident()
+    }
+}
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+impl<'a> TryFrom<Ident<'a>> for Algorithm {
+    type Error = password_hash::Error;
+
+    fn try_from(ident: Ident<'a>) -> Result<Algorithm, password_hash::Error> {
+        match ident {
+            ARGON2D_IDENT => Ok(Algorithm::Argon2d),
+            ARGON2I_IDENT => Ok(Algorithm::Argon2i),
+            ARGON2ID_IDENT => Ok(Algorithm::Argon2id),
+            _ => Err(password_hash::Error::Algorithm),
+        }
+    }
+}

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -1,51 +1,69 @@
 //! Argon2 password hash parameters.
 
-use crate::{Argon2, Version};
-use core::convert::{TryFrom, TryInto};
-use password_hash::{Decimal, ParamsString, PasswordHash};
+use crate::Version;
+
+#[cfg(feature = "password-hash")]
+use {
+    core::convert::{TryFrom, TryInto},
+    password_hash::{ParamsString, PasswordHash},
+};
 
 /// Argon2 password hash parameters.
 ///
 /// These are parameters which can be encoded into a PHC hash string.
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Memory size, expressed in kilobytes, between 1 and (2^32)-1.
     ///
     /// Value is an integer in decimal (1 to 10 digits).
-    pub m_cost: Decimal,
+    pub m_cost: u32,
 
     /// Number of iterations, between 1 and (2^32)-1.
     ///
     /// Value is an integer in decimal (1 to 10 digits).
-    pub t_cost: Decimal,
+    pub t_cost: u32,
 
     /// Degree of parallelism, between 1 and 255.
     ///
     /// Value is an integer in decimal (1 to 3 digits).
-    pub p_cost: Decimal,
+    pub p_cost: u32,
 
     /// Size of the output (in bytes)
     pub output_size: usize,
 
     /// Algorithm version
+    // TODO(tarcieri): make this separate from params in the next breaking release?
     pub version: Version,
+}
+
+impl Params {
+    /// Default memory cost.
+    pub const DEFAULT_M_COST: u32 = 4096;
+
+    /// Default number of iterations.
+    pub const DEFAULT_T_COST: u32 = 3;
+
+    /// Default degree of parallelism.
+    pub const DEFAULT_P_COST: u32 = 1;
+
+    /// Default output size.
+    pub const DEFAULT_OUTPUT_SIZE: usize = 32;
 }
 
 impl Default for Params {
     fn default() -> Params {
-        let ctx = Argon2::default();
-
         Params {
-            m_cost: ctx.m_cost,
-            t_cost: ctx.t_cost,
-            p_cost: ctx.threads,
-            output_size: 32,
+            m_cost: Self::DEFAULT_M_COST,
+            t_cost: Self::DEFAULT_T_COST,
+            p_cost: Self::DEFAULT_P_COST,
+            output_size: Self::DEFAULT_OUTPUT_SIZE,
             version: Version::default(),
         }
     }
 }
 
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
     type Error = password_hash::Error;
 
@@ -77,6 +95,8 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
     }
 }
 
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<'a> TryFrom<Params> for ParamsString {
     type Error = password_hash::Error;
 


### PR DESCRIPTION
Closes #179.

This commit makes the `Params` struct always available regardless of enabled crate features, adding on functionality when the `password-hash` feature is enabled.

Per the added TODOs in this commit, it really seems like in the next breaking release, `Argon2::new` should accept `Params` as an argument rather than duplicating all of the individual parameter fields and passing them in as arguments. After that, they can be validated and stored within the `Argon2` struct itself. But that would be a breaking change, so for now they're stored piecemeal.

Additionally, this commit now ensures enough context is available in the `Argon2` struct in order to implement `hash_password_simple` that uses the configured params rather than the defaults, which addresses the aforementioned issue.