### PR TITLE
argon2 v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "argon2"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake2",
  "hex-literal",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2021-05-28)
+### Changed
+- `Params` always available; no longer feature-gated on `password-hash` ([#182])
+
+### Fixed
+- Configured params are used with `hash_password_simple` ([#182])
+
+[#182]: https://github.com/RustCrypto/password-hashes/pull/182
+
 ## 0.2.0 (2021-04-29)
 ### Changed
 - Forbid unsafe code outside parallel implementation ([#157])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
 """
-version = "0.2.0"
+version = "0.2.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/argon2"


### PR DESCRIPTION
### Changed
- `Params` always available; no longer feature-gated on `password-hash` ([#182])

### Fixed
- Configured params are used with `hash_password_simple` ([#182])

[#182]: https://github.com/RustCrypto/password-hashes/pull/182