### PR TITLE
Relax `zeroize` requirements

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,26 +16,23 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: 1.47.0 # MSRV
           components: clippy
+          override: true
+          profile: minimal
       - run: cargo clippy --all -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
+          profile: minimal
+          override: true
           components: rustfmt
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 blake2 = { version = "0.9", default-features = false }
 password-hash = { version = "0.2", optional = true }
 rayon = { version = "1", optional = true }
-zeroize = { version = "=1.3", optional = true }
+zeroize = { version = ">=1, <1.4", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -15,7 +15,7 @@ blowfish = { version = "0.8", features = ["bcrypt"] }
 crypto-mac = "0.11"
 pbkdf2 = { version = "0.8", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
-zeroize = { version = "=1.3", default-features = false }
+zeroize = { version = ">=1, <1.4", default-features = false }
 
 [features]
 default = ["std"]

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -220,7 +220,7 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, Cr
         .take(SALT_MAX_LEN)
         .collect();
 
-    let out = sha512_crypt(password.as_bytes(), salt.as_bytes(), &params)?;
+    let out = sha512_crypt(password.as_bytes(), salt.as_bytes(), params)?;
 
     let mut result = String::new();
     result.push_str(SHA512_SALT_PREFIX);


### PR DESCRIPTION
Locks `zeroize` to a supported MSRV range `>=1, <1.4`, since neither of these crates require functionality specific to 1.3.

This allows more possible version combinations, preventing needless incompatibilities.