### PR TITLE
argon2: move `extern crate std` directive

### DIFF
--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -1,8 +1,5 @@
 //! Error type
 
-#[cfg(feature = "std")]
-extern crate std;
-
 use core::fmt;
 
 /// Error type.

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -70,6 +70,9 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod algorithm;
 mod block;
 mod error;


### PR DESCRIPTION
Places it in lib.rs