### PR TITLE
argon2: impl TryFrom<Params> for Argon2

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -96,10 +96,11 @@ use crate::{
     memory::{Memory, SYNC_POINTS},
 };
 use blake2::{digest, Blake2b, Digest};
+use core::convert::TryFrom;
 
 #[cfg(feature = "password-hash")]
 use {
-    core::convert::{TryFrom, TryInto},
+    core::convert::TryInto,
     password_hash::{Ident, Salt},
 };
 
@@ -448,6 +449,31 @@ impl PasswordHasher for Argon2<'_> {
         hasher.output_size = Some(params.output_size);
 
         hasher.hash_password_simple(password, salt.as_str())
+    }
+}
+
+impl<'key> TryFrom<Params> for Argon2<'key> {
+    type Error = Error;
+
+    fn try_from(params: Params) -> Result<Self, Error> {
+        Argon2::try_from(&params)
+    }
+}
+
+impl<'key> TryFrom<&Params> for Argon2<'key> {
+    type Error = Error;
+
+    fn try_from(params: &Params) -> Result<Self, Error> {
+        let mut argon2 = Argon2::new(
+            None,
+            params.t_cost,
+            params.m_cost,
+            params.p_cost,
+            params.version,
+        )?;
+
+        argon2.output_size = Some(params.output_size);
+        Ok(argon2)
     }
 }
 

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -11,6 +11,7 @@ use {
 /// Argon2 password hash parameters.
 ///
 /// These are parameters which can be encoded into a PHC hash string.
+// TODO(tarcieri): make members private, ensure `Params` is always valid?
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Memory size, expressed in kilobytes, between 1 and (2^32)-1.


### PR DESCRIPTION
Support for initializing the algorithm from its parameters.

The `Params` struct has `pub` fields and therefore doesn't validate its parameters, so we need a fallible conversion here.

An alternative would be to have `Params` always validate its parameters, removing the `pub` fields and replacing them with reader methods. This would allow an infallible `From` conversion instead.

This is noted as a TODO in params.rs.