### PR TITLE
argon2: add `Result` type alias

### DIFF
--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -1,6 +1,6 @@
 //! Argon2 algorithms (e.g. Argon2d, Argon2i, Argon2id).
 
-use crate::Error;
+use crate::{Error, Result};
 use core::{
     fmt::{self, Display},
     str::FromStr,
@@ -58,7 +58,7 @@ impl Default for Algorithm {
 
 impl Algorithm {
     /// Parse an [`Algorithm`] from the provided string.
-    pub fn new(id: impl AsRef<str>) -> Result<Self, Error> {
+    pub fn new(id: impl AsRef<str>) -> Result<Self> {
         id.as_ref().parse()
     }
 
@@ -103,7 +103,7 @@ impl Display for Algorithm {
 impl FromStr for Algorithm {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Algorithm, Error> {
+    fn from_str(s: &str) -> Result<Algorithm> {
         match s {
             "argon2d" => Ok(Algorithm::Argon2d),
             "argon2i" => Ok(Algorithm::Argon2i),
@@ -126,7 +126,7 @@ impl From<Algorithm> for Ident<'static> {
 impl<'a> TryFrom<Ident<'a>> for Algorithm {
     type Error = password_hash::Error;
 
-    fn try_from(ident: Ident<'a>) -> Result<Algorithm, password_hash::Error> {
+    fn try_from(ident: Ident<'a>) -> password_hash::Result<Algorithm> {
         match ident {
             ARGON2D_IDENT => Ok(Algorithm::Argon2d),
             ARGON2I_IDENT => Ok(Algorithm::Argon2i),

--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -2,6 +2,9 @@
 
 use core::fmt;
 
+/// Result with argon2's [`Error`] type.
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Error type.
 // TODO(tarcieri): consolidate/replace with `password_hash::Error`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -81,7 +81,12 @@ mod memory;
 mod params;
 mod version;
 
-pub use crate::{algorithm::Algorithm, error::Error, params::Params, version::Version};
+pub use crate::{
+    algorithm::Algorithm,
+    error::{Error, Result},
+    params::Params,
+    version::Version,
+};
 
 #[cfg(feature = "password-hash")]
 #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
@@ -229,7 +234,7 @@ impl<'key> Argon2<'key> {
         m_cost: u32,
         parallelism: u32,
         version: Version,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self> {
         let lanes = parallelism;
 
         if let Some(secret) = &secret {
@@ -294,7 +299,7 @@ impl<'key> Argon2<'key> {
         salt: &[u8],
         ad: &[u8],
         out: &mut [u8],
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         // TODO(tarcieri): move algorithm selection entirely to `Argon2::new`
         if self.algorithm.is_some() && Some(alg) != self.algorithm {
             return Err(Error::AlgorithmInvalid);
@@ -455,7 +460,7 @@ impl PasswordHasher for Argon2<'_> {
 impl<'key> TryFrom<Params> for Argon2<'key> {
     type Error = Error;
 
-    fn try_from(params: Params) -> Result<Self, Error> {
+    fn try_from(params: Params) -> Result<Self> {
         Argon2::try_from(&params)
     }
 }
@@ -463,7 +468,7 @@ impl<'key> TryFrom<Params> for Argon2<'key> {
 impl<'key> TryFrom<&Params> for Argon2<'key> {
     type Error = Error;
 
-    fn try_from(params: &Params) -> Result<Self, Error> {
+    fn try_from(params: &Params) -> Result<Self> {
         let mut argon2 = Argon2::new(
             None,
             params.t_cost,

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -68,7 +68,7 @@ impl Default for Params {
 impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
     type Error = password_hash::Error;
 
-    fn try_from(hash: &'a PasswordHash<'a>) -> Result<Self, password_hash::Error> {
+    fn try_from(hash: &'a PasswordHash<'a>) -> password_hash::Result<Self> {
         let mut params = Params::default();
 
         for (ident, value) in hash.params.iter() {
@@ -101,7 +101,7 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
 impl<'a> TryFrom<Params> for ParamsString {
     type Error = password_hash::Error;
 
-    fn try_from(params: Params) -> Result<ParamsString, password_hash::Error> {
+    fn try_from(params: Params) -> password_hash::Result<ParamsString> {
         let mut output = ParamsString::new();
         output.add_decimal("m", params.m_cost)?;
         output.add_decimal("t", params.t_cost)?;

--- a/argon2/src/version.rs
+++ b/argon2/src/version.rs
@@ -1,6 +1,6 @@
 //! Version of the algorithm.
 
-use crate::Error;
+use crate::{Error, Result};
 use core::convert::TryFrom;
 
 /// Version of the algorithm.
@@ -40,7 +40,7 @@ impl From<Version> for u32 {
 impl TryFrom<u32> for Version {
     type Error = Error;
 
-    fn try_from(version_id: u32) -> Result<Version, Error> {
+    fn try_from(version_id: u32) -> Result<Version> {
         match version_id {
             0x10 => Ok(Version::V0x10),
             0x13 => Ok(Version::V0x13),


### PR DESCRIPTION
Adds an alias for `Result<T, argon2::Error>` and uses it throughout the implementation to simplify the specification of results.