### PR TITLE
argon2 v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "blake2",
  "hex-literal",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.4 (2021-08-21)
+### Added
+- Impl `std::error::Error` for `argon2::Error` ([#200])
+- Impl `TryFrom<Params>` for `Argon2` ([#202])
+- `Result` type alias ([#203])
+- `ParamsBuilder` ([#204])
+
+[#200]: https://github.com/RustCrypto/password-hashes/pull/200
+[#202]: https://github.com/RustCrypto/password-hashes/pull/202
+[#203]: https://github.com/RustCrypto/password-hashes/pull/203
+[#204]: https://github.com/RustCrypto/password-hashes/pull/204
+
 ## 0.2.3 (2021-08-15)
 ### Changed
 - Relax `zeroize` requirements to `>=1, <1.4` ([#195])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.2.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.4" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -63,7 +63,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/argon2/0.2.3"
+    html_root_url = "https://docs.rs/argon2/0.2.4"
 )]
 #![warn(rust_2018_idioms, missing_docs)]
 


### PR DESCRIPTION
### Added
- Impl `std::error::Error` for `argon2::Error` ([#200])
- Impl `TryFrom<Params>` for `Argon2` ([#202])
- `Result` type alias ([#203])
- `ParamsBuilder` ([#204])

[#200]: https://github.com/RustCrypto/password-hashes/pull/200
[#202]: https://github.com/RustCrypto/password-hashes/pull/202
[#203]: https://github.com/RustCrypto/password-hashes/pull/203
[#204]: https://github.com/RustCrypto/password-hashes/pull/204