### PR TITLE
Bump `password-hash` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,8 +270,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "password-hash"
 version = "0.3.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f27d413faa599d728b91e2a14907d05732112cb72cfaf8cf9e169e6617b5ae4"
+source = "git+https://github.com/rustcrypto/traits.git#9e0de9d0aa33f0a7c687d7ae0809e3194027ba6c"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "scrypt",
     "sha-crypt"
 ]
+
+[patch.crates-io]
+password-hash = { git = "https://github.com/rustcrypto/traits.git" }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -39,7 +39,7 @@
 //! let salt = SaltString::generate(&mut OsRng);
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
-//! let password_hash = Pbkdf2.hash_password_simple(password, salt.as_ref()).unwrap().to_string();
+//! let password_hash = Pbkdf2.hash_password(password, salt.as_ref()).unwrap().to_string();
 //!
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash).unwrap();

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -10,7 +10,7 @@ use core::{
 };
 use hmac::Hmac;
 use password_hash::{
-    errors::InvalidValue, Error, Ident, McfHasher, Output, ParamsString, PasswordHash,
+    errors::InvalidValue, Decimal, Error, Ident, McfHasher, Output, ParamsString, PasswordHash,
     PasswordHasher, Result, Salt,
 };
 use sha2::{Sha256, Sha512};
@@ -36,14 +36,21 @@ pub struct Pbkdf2;
 impl PasswordHasher for Pbkdf2 {
     type Params = Params;
 
-    fn hash_password<'a>(
+    fn hash_password_customized<'a>(
         &self,
         password: &[u8],
         alg_id: Option<Ident<'a>>,
+        version: Option<Decimal>,
         params: Params,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>> {
         let algorithm = Algorithm::try_from(alg_id.unwrap_or(PBKDF2_SHA256))?;
+
+        // Versions unsupported
+        if version.is_some() {
+            return Err(Error::Version);
+        }
+
         let salt = salt.into();
         let mut salt_arr = [0u8; 64];
         let salt_bytes = salt.b64_decode(&mut salt_arr)?;

--- a/pbkdf2/tests/simple.rs
+++ b/pbkdf2/tests/simple.rs
@@ -30,7 +30,7 @@ fn hash_with_default_algorithm() {
     };
 
     let hash = Pbkdf2
-        .hash_password(PASSWORD.as_bytes(), None, params, salt)
+        .hash_password_customized(PASSWORD.as_bytes(), None, None, params, salt)
         .unwrap();
 
     assert_eq!(hash.algorithm, Algorithm::Pbkdf2Sha256.ident());

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -25,7 +25,7 @@
 //! let salt = SaltString::generate(&mut OsRng);
 //!
 //! // Hash password to PHC string ($scrypt$...)
-//! let password_hash = Scrypt.hash_password_simple(password, salt.as_ref()).unwrap().to_string();
+//! let password_hash = Scrypt.hash_password(password, salt.as_ref()).unwrap().to_string();
 //!
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash).unwrap();

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -4,8 +4,8 @@ use crate::{scrypt, Params};
 use base64ct::{Base64, Encoding};
 use core::convert::TryInto;
 use password_hash::{
-    errors::InvalidValue, Error, Ident, McfHasher, Output, PasswordHash, PasswordHasher, Result,
-    Salt,
+    errors::InvalidValue, Decimal, Error, Ident, McfHasher, Output, PasswordHash, PasswordHasher,
+    Result, Salt,
 };
 
 /// Algorithm identifier
@@ -19,16 +19,21 @@ pub struct Scrypt;
 impl PasswordHasher for Scrypt {
     type Params = Params;
 
-    fn hash_password<'a>(
+    fn hash_password_customized<'a>(
         &self,
         password: &[u8],
         alg_id: Option<Ident<'a>>,
+        version: Option<Decimal>,
         params: Params,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>> {
-        match alg_id {
-            Some(ALG_ID) | None => (),
-            _ => return Err(Error::Algorithm),
+        if !matches!(alg_id, Some(ALG_ID) | None) {
+            return Err(Error::Algorithm);
+        }
+
+        // Versions unsupported
+        if version.is_some() {
+            return Err(Error::Version);
         }
 
         let salt = salt.into();


### PR DESCRIPTION
Updates `argon2`, `pbkdf2`, and `scrypt` with the following upstream changes from the unreleased `password-hash` crate:

- RustCrypto/traits#719
- RustCrypto/traits#720