### PR TITLE
argon2: remove version from params

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -219,7 +219,7 @@ impl Default for Argon2<'_> {
             params.t_cost,
             params.m_cost,
             params.p_cost,
-            params.version,
+            Version::default(),
         )
         .expect("invalid default Argon2 params")
     }
@@ -352,7 +352,6 @@ impl<'key> Argon2<'key> {
             t_cost: self.t_cost,
             p_cost: self.threads,
             output_size: self.output_size.unwrap_or(Params::DEFAULT_OUTPUT_SIZE),
-            version: self.version,
         }
     }
 
@@ -439,6 +438,11 @@ impl PasswordHasher for Argon2<'_> {
             .transpose()?
             .unwrap_or_default();
 
+        let version = version
+            .map(Version::try_from)
+            .transpose()?
+            .unwrap_or_default();
+
         let salt = salt.into();
 
         let mut hasher = Self::new(
@@ -446,10 +450,7 @@ impl PasswordHasher for Argon2<'_> {
             params.t_cost,
             params.m_cost,
             params.p_cost,
-            version
-                .map(Version::try_from)
-                .transpose()?
-                .unwrap_or_else(|| params.version),
+            version,
         )?;
 
         // TODO(tarcieri): pass these via `Params` when `Argon::new` accepts `Params`
@@ -477,7 +478,7 @@ impl<'key> TryFrom<&Params> for Argon2<'key> {
             params.t_cost,
             params.m_cost,
             params.p_cost,
-            params.version,
+            Version::default(),
         )?;
 
         argon2.output_size = Some(params.output_size);

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -1,10 +1,8 @@
 //! Argon2 password hash parameters.
 
-use crate::Version;
-
 #[cfg(feature = "password-hash")]
 use {
-    core::convert::{TryFrom, TryInto},
+    core::convert::TryFrom,
     password_hash::{ParamsString, PasswordHash},
 };
 
@@ -31,10 +29,6 @@ pub struct Params {
 
     /// Size of the output (in bytes).
     pub output_size: usize,
-
-    /// Algorithm version.
-    // TODO(tarcieri): make this separate from params in the next breaking release?
-    pub version: Version,
 }
 
 impl Params {
@@ -58,7 +52,6 @@ impl Default for Params {
             t_cost: Self::DEFAULT_T_COST,
             p_cost: Self::DEFAULT_P_COST,
             output_size: Self::DEFAULT_OUTPUT_SIZE,
-            version: Version::default(),
         }
     }
 }
@@ -80,12 +73,6 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
                 // TODO(tarcieri): `data` parameter
                 _ => return Err(password_hash::Error::ParamNameInvalid),
             }
-        }
-
-        if let Some(version) = hash.version {
-            params.version = version
-                .try_into()
-                .map_err(|_| password_hash::Error::Version)?;
         }
 
         if let Some(output) = &hash.hash {
@@ -145,13 +132,6 @@ impl ParamsBuilder {
     /// Set size of the output (in bytes).
     pub fn output_size(mut self, output_size: usize) -> Self {
         self.params.output_size = output_size;
-        self
-    }
-
-    /// Set algorithm version.
-    // TODO(tarcieri): make this separate from params in the next breaking release?
-    pub fn version(mut self, version: Version) -> Self {
-        self.params.version = version;
         self
     }
 


### PR DESCRIPTION
In the PHC string format, version is out-of-band from the rest of the parameters.

This change reflects that in the API and types.