### PR TITLE
argon2: refactor `Params` handling

### DIFF
--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -12,49 +12,43 @@ pub type Result<T> = core::result::Result<T, Error>;
 // TODO(tarcieri): consolidate/replace with `password_hash::Error`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
-    /// Associated data is too long
+    /// Associated data is too long.
     AdTooLong,
 
-    /// Algorithm identifier invalid
+    /// Algorithm identifier invalid.
     AlgorithmInvalid,
 
-    /// Too few lanes
-    LanesTooFew,
-
-    /// Too many lanes
-    LanesTooMany,
-
-    /// Memory cost is too small
+    /// Memory cost is too small.
     MemoryTooLittle,
 
-    /// Memory cost is too large
+    /// Memory cost is too large.
     MemoryTooMuch,
 
-    /// Output is too short
+    /// Output is too short.
     OutputTooShort,
 
-    /// Output is too long
+    /// Output is too long.
     OutputTooLong,
 
-    /// Password is too long
+    /// Password is too long.
     PwdTooLong,
 
-    /// Salt is too short
+    /// Salt is too short.
     SaltTooShort,
 
-    /// Salt is too long
+    /// Salt is too long.
     SaltTooLong,
 
-    /// Secret is too long
+    /// Secret is too long.
     SecretTooLong,
 
-    /// Not enough threads
+    /// Not enough threads.
     ThreadsTooFew,
 
-    /// Too many threads
+    /// Too many threads.
     ThreadsTooMany,
 
-    /// Time cost is too small
+    /// Time cost is too small.
     TimeTooSmall,
 
     /// Invalid version
@@ -66,8 +60,6 @@ impl fmt::Display for Error {
         f.write_str(match self {
             Error::AdTooLong => "associated data is too long",
             Error::AlgorithmInvalid => "algorithm identifier invalid",
-            Error::LanesTooFew => "too few lanes",
-            Error::LanesTooMany => "too many lanes",
             Error::MemoryTooLittle => "memory cost is too small",
             Error::MemoryTooMuch => "memory cost is too large",
             Error::OutputTooShort => "output is too short",
@@ -91,8 +83,6 @@ impl From<Error> for password_hash::Error {
         match err {
             Error::AdTooLong => password_hash::Error::ParamValueInvalid(InvalidValue::TooLong),
             Error::AlgorithmInvalid => password_hash::Error::Algorithm,
-            Error::LanesTooFew => password_hash::Error::ParamValueInvalid(InvalidValue::TooShort),
-            Error::LanesTooMany => password_hash::Error::ParamValueInvalid(InvalidValue::TooLong),
             Error::MemoryTooLittle => {
                 password_hash::Error::ParamValueInvalid(InvalidValue::TooShort)
             }

--- a/argon2/src/instance.rs
+++ b/argon2/src/instance.rs
@@ -1,8 +1,6 @@
 //! Argon2 instance (i.e. state)
 
-use crate::{
-    Algorithm, Argon2, Block, Error, Memory, Result, Version, MAX_OUTLEN, MIN_OUTLEN, SYNC_POINTS,
-};
+use crate::{Algorithm, Argon2, Block, Error, Memory, Params, Result, Version, SYNC_POINTS};
 use blake2::{
     digest::{self, VariableOutput},
     Blake2b, Digest, VarBlake2b,
@@ -98,10 +96,10 @@ impl<'a> Instance<'a> {
         let mut instance = Instance {
             version: context.version,
             memory,
-            passes: context.t_cost,
+            passes: context.params.t_cost(),
             lane_length,
-            lanes: context.lanes,
-            threads: context.threads,
+            lanes: context.lanes(),
+            threads: context.params.t_cost(),
             alg,
         };
 
@@ -407,11 +405,11 @@ fn next_addresses(address_block: &mut Block, input_block: &mut Block, zero_block
 
 /// BLAKE2b with an extended output, as described in the Argon2 paper
 fn blake2b_long(inputs: &[&[u8]], mut out: &mut [u8]) -> Result<()> {
-    if out.len() < MIN_OUTLEN as usize {
+    if out.len() < Params::MIN_OUTPUT_LENGTH as usize {
         return Err(Error::OutputTooLong);
     }
 
-    if out.len() > MAX_OUTLEN as usize {
+    if out.len() > Params::MAX_OUTPUT_LENGTH as usize {
         return Err(Error::OutputTooLong);
     }
 

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -7,7 +7,7 @@
 // TODO(tarcieri): test full set of vectors from the reference implementation:
 // https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c
 
-use argon2::{Algorithm, Argon2, Version};
+use argon2::{Algorithm, Argon2, Params, Version};
 use hex_literal::hex;
 
 /// =======================================
@@ -30,6 +30,7 @@ use hex_literal::hex;
 ///     a5 dd 1f 5c bf 08 b2 67 0d a6 8a 02 85 ab f3 2b
 #[test]
 fn argon2d_v0x10() {
+    let algorithm = Algorithm::Argon2d;
     let version = Version::V0x10;
     let m_cost = 32;
     let t_cost = 3;
@@ -45,10 +46,11 @@ fn argon2d_v0x10() {
     "
     );
 
-    let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
+    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
+    let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password_into(Algorithm::Argon2d, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(&password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -74,6 +76,7 @@ fn argon2d_v0x10() {
 ///    e6 47 a5 de e0 8f 7c 05 e0 2f cb 76 33 35 d0 fd
 #[test]
 fn argon2i_v0x10() {
+    let algorithm = Algorithm::Argon2i;
     let version = Version::V0x10;
     let m_cost = 32;
     let t_cost = 3;
@@ -89,10 +92,11 @@ fn argon2i_v0x10() {
     "
     );
 
-    let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
+    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
+    let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password_into(Algorithm::Argon2i, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(&password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -118,6 +122,7 @@ fn argon2i_v0x10() {
 ///     ae 35 0b 6b fc bb 0f c9 51 41 ea 8f 32 26 13 c0
 #[test]
 fn argon2id_v0x10() {
+    let algorithm = Algorithm::Argon2id;
     let version = Version::V0x10;
     let m_cost = 32;
     let t_cost = 3;
@@ -133,10 +138,11 @@ fn argon2id_v0x10() {
     "
     );
 
-    let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
+    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
+    let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password_into(Algorithm::Argon2id, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(&password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -173,6 +179,7 @@ fn argon2id_v0x10() {
 ///     a1 3a 4d b9 fa be 4a cb
 #[test]
 fn argon2d_v0x13() {
+    let algorithm = Algorithm::Argon2d;
     let version = Version::V0x13;
     let m_cost = 32;
     let t_cost = 3;
@@ -190,10 +197,11 @@ fn argon2d_v0x13() {
         "
     );
 
-    let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
+    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
+    let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password_into(Algorithm::Argon2d, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(&password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -230,6 +238,7 @@ fn argon2d_v0x13() {
 ///     99 52 a4 c4 67 2b 6c e8
 #[test]
 fn argon2i_v0x13() {
+    let algorithm = Algorithm::Argon2i;
     let version = Version::V0x13;
     let m_cost = 32;
     let t_cost = 3;
@@ -247,10 +256,11 @@ fn argon2i_v0x13() {
     "
     );
 
-    let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
+    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
+    let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password_into(Algorithm::Argon2i, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(&password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);
@@ -277,6 +287,7 @@ fn argon2i_v0x13() {
 ///     d0 1e f0 45 2d 75 b6 5e b5 25 20 e9 6b 01 e6 59
 #[test]
 fn argon2id_v0x13() {
+    let algorithm = Algorithm::Argon2id;
     let version = Version::V0x13;
     let m_cost = 32;
     let t_cost = 3;
@@ -292,10 +303,11 @@ fn argon2id_v0x13() {
     "
     );
 
-    let ctx = Argon2::new(Some(&secret), t_cost, m_cost, parallelism, version).unwrap();
+    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
+    let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
 
     let mut out = [0u8; 32];
-    ctx.hash_password_into(Algorithm::Argon2id, &password, &salt, &ad, &mut out)
+    ctx.hash_password_into(&password, &salt, &ad, &mut out)
         .unwrap();
 
     assert_eq!(out, expected_tag);


### PR DESCRIPTION
Uses `Params` internally within the `Argon2` context, refactoring all of the logic related to parameter handling into that type/module:

- Changes `Argon2::new` to accept explicit `version` and `params`
- Factors apart `Argon2::new` and `Argon2::new_with_secret`, making the former infallible.
- Makes the `Params` struct opaque with field accessors, and ensures it always represents a valid set of parameters.
- Removes `version` parameter from `hash_password_into`, using the one supplied to `Argon2::new`.