### PR TITLE
rustdoc improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,6 @@ dependencies = [
  "blake2",
  "hex-literal",
  "password-hash",
- "rand_core",
  "rayon",
  "zeroize",
 ]
@@ -286,7 +285,6 @@ dependencies = [
  "hex-literal",
  "hmac",
  "password-hash",
- "rand_core",
  "rayon",
  "sha-1",
  "sha2",
@@ -387,7 +385,6 @@ dependencies = [
  "hmac",
  "password-hash",
  "pbkdf2",
- "rand_core",
  "salsa20",
  "sha2",
 ]

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -23,7 +23,6 @@ zeroize = { version = ">=1, <1.4", optional = true }
 [dev-dependencies]
 hex-literal = "0.3"
 password-hash = { version = "=0.3.0-pre.1", features = ["rand_core"] }
-rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["password-hash", "rand"]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! - **Argon2d**: maximizes resistance to GPU cracking attacks
 //! - **Argon2i**: optimized to resist side-channel attacks
-//! - **Argon2id**: (default) hybrid version
+//! - **Argon2id**: (default) hybrid version combining both Argon2i and Argon2d
 //!
 //! # Usage (simple with default params)
 //!
@@ -28,13 +28,16 @@
 //! The following example demonstrates the high-level password hashing API:
 //!
 //! ```
-//! # #[cfg(feature = "password-hash")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(all(feature = "password-hash", feature = "std"))]
 //! # {
 //! use argon2::{
-//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+//!     password_hash::{
+//!         rand_core::OsRng,
+//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
+//!     },
 //!     Argon2
 //! };
-//! use rand_core::OsRng;
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
 //! let salt = SaltString::generate(&mut OsRng);
@@ -43,11 +46,13 @@
 //! let argon2 = Argon2::default();
 //!
 //! // Hash password to PHC string ($argon2id$v=19$...)
-//! let password_hash = argon2.hash_password(password, salt.as_ref()).unwrap().to_string();
+//! let password_hash = argon2.hash_password(password, &salt)?.to_string();
 //!
 //! // Verify password against PHC string
-//! let parsed_hash = PasswordHash::new(&password_hash).unwrap();
+//! let parsed_hash = PasswordHash::new(&password_hash)?;
 //! assert!(argon2.verify_password(password, &parsed_hash).is_ok());
+//! # }
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -24,7 +24,6 @@ sha2 = { version = "0.9", default-features = false, optional = true }
 [dev-dependencies]
 hex-literal = "0.3"
 hmac = "0.11"
-rand_core = { version = "0.6", features = ["std"] }
 sha1 = { version = "0.9", package = "sha-1" }
 sha2 = "0.9"
 streebog = "0.9"

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -27,23 +27,28 @@
 //! The following example demonstrates the high-level password hashing API:
 //!
 //! ```
-//! # #[cfg(feature = "password-hash")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(all(feature = "password-hash", feature = "std"))]
 //! # {
 //! use pbkdf2::{
-//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+//!     password_hash::{
+//!         rand_core::OsRng,
+//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
+//!     },
 //!     Pbkdf2
 //! };
-//! use rand_core::OsRng;
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
 //! let salt = SaltString::generate(&mut OsRng);
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
-//! let password_hash = Pbkdf2.hash_password(password, salt.as_ref()).unwrap().to_string();
+//! let password_hash = Pbkdf2.hash_password(password, &salt)?.to_string();
 //!
 //! // Verify password against PHC string
-//! let parsed_hash = PasswordHash::new(&password_hash).unwrap();
+//! let parsed_hash = PasswordHash::new(&password_hash)?;
 //! assert!(Pbkdf2.verify_password(password, &parsed_hash).is_ok());
+//! # }
+//! # Ok(())
 //! # }
 //! ```
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -21,7 +21,6 @@ sha2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 password-hash = { version = "=0.3.0-pre.1", features = ["rand_core"] }
-rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["simple", "std"]

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -41,7 +41,7 @@ impl PasswordHasher for Scrypt {
         let salt_bytes = salt.b64_decode(&mut salt_arr)?;
 
         let output = Output::init_with(params.len, |out| {
-            scrypt(password, &salt_bytes, &params, out).map_err(|_e| {
+            scrypt(password, salt_bytes, &params, out).map_err(|_e| {
                 // TODO(tarcieri): handle output variants
                 Error::OutputTooLong
             })


### PR DESCRIPTION
- Replace use of `unwrap()` with `?`
- Use `rand_core` re-export from `password-hash` crate