### PR TITLE
argon2: add `alloc` feature

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -37,6 +37,7 @@ jobs:
 #          target: ${{ matrix.target }}
 #          override: true
 #      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+#      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features password-hash
 #      - run: cargo build --target ${{ matrix.target }} --release
 #      - run: cargo build --target ${{ matrix.target }} --release --features zeroize
 
@@ -55,5 +56,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release --no-default-features
+      - run: cargo test --release --no-default-features --features password-hash
       - run: cargo test --release
       - run: cargo test --release --all-features

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -25,10 +25,11 @@ hex-literal = "0.3"
 password-hash = { version = "=0.3.0-pre.1", features = ["rand_core"] }
 
 [features]
-default = ["password-hash", "rand"]
+default = ["alloc", "password-hash", "rand"]
+alloc = []
 parallel = ["rayon", "std"]
 rand = ["password-hash/rand_core"]
-std = ["password-hash/std"]
+std = ["alloc", "password-hash/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/argon2/src/block.rs
+++ b/argon2/src/block.rs
@@ -12,7 +12,7 @@ use zeroize::Zeroize;
 
 /// Structure for the (1KB) memory block implemented as 128 64-bit words.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct Block([u64; Self::SIZE / 8]);
+pub struct Block([u64; Self::SIZE / 8]);
 
 impl Default for Block {
     fn default() -> Self {
@@ -25,7 +25,7 @@ impl Block {
     pub const SIZE: usize = 1024;
 
     /// Load a block from a block-sized byte slice
-    pub fn load(&mut self, input: &[u8]) {
+    pub(crate) fn load(&mut self, input: &[u8]) {
         debug_assert_eq!(input.len(), Block::SIZE);
 
         for (i, chunk) in input.chunks(8).enumerate() {
@@ -34,18 +34,18 @@ impl Block {
     }
 
     /// Iterate over the `u64` values contained in this block
-    pub fn iter(&self) -> slice::Iter<'_, u64> {
+    pub(crate) fn iter(&self) -> slice::Iter<'_, u64> {
         self.0.iter()
     }
 
     /// Iterate mutably over the `u64` values contained in this block
-    pub fn iter_mut(&mut self) -> slice::IterMut<'_, u64> {
+    pub(crate) fn iter_mut(&mut self) -> slice::IterMut<'_, u64> {
         self.0.iter_mut()
     }
 
     /// Function fills a new memory block and optionally XORs the old block over the new one.
     // TODO(tarcieri): optimized implementation (i.e. from opt.c instead of ref.c)
-    pub fn fill_block(&mut self, prev_block: Block, ref_block: Block, with_xor: bool) {
+    pub(crate) fn fill_block(&mut self, prev_block: Block, ref_block: Block, with_xor: bool) {
         let mut block_r = ref_block ^ prev_block;
         let mut block_tmp = block_r;
 

--- a/argon2/src/instance.rs
+++ b/argon2/src/instance.rs
@@ -98,7 +98,7 @@ impl<'a> Instance<'a> {
             memory,
             passes: context.params.t_cost(),
             lane_length,
-            lanes: context.lanes(),
+            lanes: context.params.lanes(),
             threads: context.params.t_cost(),
             alg,
         };

--- a/argon2/src/memory.rs
+++ b/argon2/src/memory.rs
@@ -15,19 +15,6 @@ pub(crate) struct Memory<'a> {
 }
 
 impl<'a> Memory<'a> {
-    /// Align memory size.
-    ///
-    /// Minimum memory_blocks = 8*`L` blocks, where `L` is the number of lanes.
-    pub(crate) fn segment_length_for_params(m_cost: u32, lanes: u32) -> u32 {
-        let memory_blocks = if m_cost < 2 * SYNC_POINTS * lanes {
-            2 * SYNC_POINTS * lanes
-        } else {
-            m_cost
-        };
-
-        memory_blocks / (lanes * SYNC_POINTS)
-    }
-
     /// Instantiate a new memory struct
     pub(crate) fn new(data: &'a mut [Block], segment_length: u32) -> Self {
         Self {

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -110,6 +110,29 @@ impl Params {
     pub fn output_len(self) -> Option<usize> {
         self.output_len
     }
+
+    /// Get the number of lanes.
+    pub(crate) fn lanes(self) -> u32 {
+        self.p_cost
+    }
+
+    /// Get the segment length given the configured `m_cost` and `p_cost`.
+    ///
+    /// Minimum memory_blocks = 8*`L` blocks, where `L` is the number of lanes.
+    pub(crate) fn segment_length(self) -> u32 {
+        let memory_blocks = if self.m_cost < 2 * SYNC_POINTS * self.lanes() {
+            2 * SYNC_POINTS * self.lanes()
+        } else {
+            self.m_cost
+        };
+
+        memory_blocks / (self.lanes() * SYNC_POINTS)
+    }
+
+    /// Get the number of blocks required given the configured `m_cost` and `p_cost`.
+    pub(crate) fn block_count(self) -> usize {
+        (self.segment_length() * self.p_cost * SYNC_POINTS) as usize
+    }
 }
 
 impl Default for Params {

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -4,6 +4,8 @@
 //! `draft-irtf-cfrg-argon2-12` Section 5:
 //! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-argon2/>
 
+#![cfg(feature = "alloc")]
+
 // TODO(tarcieri): test full set of vectors from the reference implementation:
 // https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c
 

--- a/argon2/tests/phc_strings.rs
+++ b/argon2/tests/phc_strings.rs
@@ -2,7 +2,7 @@
 //!
 //! Adapted from: <https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c>
 
-#![cfg(feature = "password-hash")]
+#![cfg(all(feature = "alloc", feature = "password-hash"))]
 
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 


### PR DESCRIPTION
Makes linking against liballoc optional, and adds an API which allows users to stack allocate their own memory blocks array instead of using a dynamically allocated `vec`.