### PR TITLE
argon2: add support for `keyid` and `data` to `Params`(Builder)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "argon2"
 version = "0.2.4"
 dependencies = [
+ "base64ct",
  "blake2",
  "hex-literal",
  "password-hash",
@@ -269,7 +270,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "password-hash"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/rustcrypto/traits.git#9e0de9d0aa33f0a7c687d7ae0809e3194027ba6c"
+source = "git+https://github.com/rustcrypto/traits.git#c759117b348ec195fab4ec835c260f0b4c402389"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
+base64ct = "1"
 blake2 = { version = "0.9", default-features = false }
 password-hash = { version = "=0.3.0-pre.1", optional = true }
 rayon = { version = "1", optional = true }

--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -9,7 +9,6 @@ use password_hash::errors::InvalidValue;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type.
-// TODO(tarcieri): consolidate/replace with `password_hash::Error`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Associated data is too long.
@@ -17,6 +16,12 @@ pub enum Error {
 
     /// Algorithm identifier invalid.
     AlgorithmInvalid,
+
+    /// "B64" encoding is invalid.
+    B64Encoding(base64ct::Error),
+
+    /// Key ID is too long.
+    KeyIdTooLong,
 
     /// Memory cost is too small.
     MemoryTooLittle,
@@ -60,6 +65,8 @@ impl fmt::Display for Error {
         f.write_str(match self {
             Error::AdTooLong => "associated data is too long",
             Error::AlgorithmInvalid => "algorithm identifier invalid",
+            Error::B64Encoding(inner) => return write!(f, "B64 encoding invalid: {}", inner),
+            Error::KeyIdTooLong => "key ID is too long",
             Error::MemoryTooLittle => "memory cost is too small",
             Error::MemoryTooMuch => "memory cost is too large",
             Error::OutputTooShort => "output is too short",
@@ -76,26 +83,32 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<base64ct::Error> for Error {
+    fn from(err: base64ct::Error) -> Error {
+        Error::B64Encoding(err)
+    }
+}
+
 #[cfg(feature = "password-hash")]
 #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl From<Error> for password_hash::Error {
     fn from(err: Error) -> password_hash::Error {
         match err {
-            Error::AdTooLong => password_hash::Error::ParamValueInvalid(InvalidValue::TooLong),
+            Error::AdTooLong => InvalidValue::TooLong.param_error(),
             Error::AlgorithmInvalid => password_hash::Error::Algorithm,
-            Error::MemoryTooLittle => {
-                password_hash::Error::ParamValueInvalid(InvalidValue::TooShort)
-            }
-            Error::MemoryTooMuch => password_hash::Error::ParamValueInvalid(InvalidValue::TooLong),
+            Error::B64Encoding(inner) => password_hash::Error::B64Encoding(inner),
+            Error::KeyIdTooLong => InvalidValue::TooLong.param_error(),
+            Error::MemoryTooLittle => InvalidValue::TooShort.param_error(),
+            Error::MemoryTooMuch => InvalidValue::TooLong.param_error(),
             Error::PwdTooLong => password_hash::Error::Password,
             Error::OutputTooShort => password_hash::Error::OutputTooShort,
             Error::OutputTooLong => password_hash::Error::OutputTooLong,
-            Error::SaltTooShort => password_hash::Error::SaltInvalid(InvalidValue::TooShort),
-            Error::SaltTooLong => password_hash::Error::SaltInvalid(InvalidValue::TooLong),
-            Error::SecretTooLong => password_hash::Error::ParamValueInvalid(InvalidValue::TooLong),
-            Error::ThreadsTooFew => password_hash::Error::ParamValueInvalid(InvalidValue::TooShort),
-            Error::ThreadsTooMany => password_hash::Error::ParamValueInvalid(InvalidValue::TooLong),
-            Error::TimeTooSmall => password_hash::Error::ParamValueInvalid(InvalidValue::TooShort),
+            Error::SaltTooShort => InvalidValue::TooShort.salt_error(),
+            Error::SaltTooLong => InvalidValue::TooLong.salt_error(),
+            Error::SecretTooLong => InvalidValue::TooLong.param_error(),
+            Error::ThreadsTooFew => InvalidValue::TooShort.param_error(),
+            Error::ThreadsTooMany => InvalidValue::TooLong.param_error(),
+            Error::TimeTooSmall => InvalidValue::TooShort.param_error(),
             Error::VersionInvalid => password_hash::Error::Version,
         }
     }

--- a/argon2/src/instance.rs
+++ b/argon2/src/instance.rs
@@ -34,7 +34,7 @@ struct Position {
     index: u32,
 }
 
-/// Argon2 instance: memory pointer, number of passes, amount of memory, type,
+/// Argon2 instance: memory buffer, number of passes, amount of memory, type,
 /// and derived values.
 ///
 /// Used to evaluate the number and location of blocks to construct in each
@@ -405,11 +405,11 @@ fn next_addresses(address_block: &mut Block, input_block: &mut Block, zero_block
 
 /// BLAKE2b with an extended output, as described in the Argon2 paper
 fn blake2b_long(inputs: &[&[u8]], mut out: &mut [u8]) -> Result<()> {
-    if out.len() < Params::MIN_OUTPUT_LENGTH as usize {
+    if out.len() < Params::MIN_OUTPUT_LEN as usize {
         return Err(Error::OutputTooLong);
     }
 
-    if out.len() > Params::MAX_OUTPUT_LENGTH as usize {
+    if out.len() > Params::MAX_OUTPUT_LEN as usize {
         return Err(Error::OutputTooLong);
     }
 

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -9,8 +9,18 @@
 // TODO(tarcieri): test full set of vectors from the reference implementation:
 // https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c
 
-use argon2::{Algorithm, Argon2, Params, Version};
+use argon2::{Algorithm, Argon2, Params, ParamsBuilder, Version};
 use hex_literal::hex;
+
+/// Params used by the KATs.
+fn example_params() -> Params {
+    let mut builder = ParamsBuilder::new();
+    builder.m_cost(32).unwrap();
+    builder.t_cost(3).unwrap();
+    builder.p_cost(4).unwrap();
+    builder.data(&[0x04; 12]).unwrap();
+    builder.params().unwrap()
+}
 
 /// =======================================
 /// Argon2d version number 16
@@ -34,26 +44,20 @@ use hex_literal::hex;
 fn argon2d_v0x10() {
     let algorithm = Algorithm::Argon2d;
     let version = Version::V0x10;
-    let m_cost = 32;
-    let t_cost = 3;
-    let parallelism = 4;
+    let params = example_params();
     let password = [0x01; 32];
     let salt = [0x02; 16];
     let secret = [0x03; 8];
-    let ad = [0x04; 12];
     let expected_tag = hex!(
         "
         96 a9 d4 e5 a1 73 40 92 c8 5e 29 f4 10 a4 59 14
         a5 dd 1f 5c bf 08 b2 67 0d a6 8a 02 85 ab f3 2b
-    "
+        "
     );
 
-    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
     let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
-
     let mut out = [0u8; 32];
-    ctx.hash_password_into(&password, &salt, &ad, &mut out)
-        .unwrap();
+    ctx.hash_password_into(&password, &salt, &mut out).unwrap();
 
     assert_eq!(out, expected_tag);
 }
@@ -80,26 +84,20 @@ fn argon2d_v0x10() {
 fn argon2i_v0x10() {
     let algorithm = Algorithm::Argon2i;
     let version = Version::V0x10;
-    let m_cost = 32;
-    let t_cost = 3;
-    let parallelism = 4;
+    let params = example_params();
     let password = [0x01; 32];
     let salt = [0x02; 16];
     let secret = [0x03; 8];
-    let ad = [0x04; 12];
     let expected_tag = hex!(
         "
         87 ae ed d6 51 7a b8 30 cd 97 65 cd 82 31 ab b2
         e6 47 a5 de e0 8f 7c 05 e0 2f cb 76 33 35 d0 fd
-    "
+        "
     );
 
-    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
     let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
-
     let mut out = [0u8; 32];
-    ctx.hash_password_into(&password, &salt, &ad, &mut out)
-        .unwrap();
+    ctx.hash_password_into(&password, &salt, &mut out).unwrap();
 
     assert_eq!(out, expected_tag);
 }
@@ -126,26 +124,20 @@ fn argon2i_v0x10() {
 fn argon2id_v0x10() {
     let algorithm = Algorithm::Argon2id;
     let version = Version::V0x10;
-    let m_cost = 32;
-    let t_cost = 3;
-    let parallelism = 4;
+    let params = example_params();
     let password = [0x01; 32];
     let salt = [0x02; 16];
     let secret = [0x03; 8];
-    let ad = [0x04; 12];
     let expected_tag = hex!(
         "
         b6 46 15 f0 77 89 b6 6b 64 5b 67 ee 9e d3 b3 77
         ae 35 0b 6b fc bb 0f c9 51 41 ea 8f 32 26 13 c0
-    "
+        "
     );
 
-    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
     let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
-
     let mut out = [0u8; 32];
-    ctx.hash_password_into(&password, &salt, &ad, &mut out)
-        .unwrap();
+    ctx.hash_password_into(&password, &salt, &mut out).unwrap();
 
     assert_eq!(out, expected_tag);
 }
@@ -183,13 +175,10 @@ fn argon2id_v0x10() {
 fn argon2d_v0x13() {
     let algorithm = Algorithm::Argon2d;
     let version = Version::V0x13;
-    let m_cost = 32;
-    let t_cost = 3;
-    let parallelism = 4;
+    let params = example_params();
     let password = [0x01; 32];
     let salt = [0x02; 16];
     let secret = [0x03; 8];
-    let ad = [0x04; 12];
     let expected_tag = hex!(
         "
         51 2b 39 1b 6f 11 62 97
@@ -199,12 +188,9 @@ fn argon2d_v0x13() {
         "
     );
 
-    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
     let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
-
     let mut out = [0u8; 32];
-    ctx.hash_password_into(&password, &salt, &ad, &mut out)
-        .unwrap();
+    ctx.hash_password_into(&password, &salt, &mut out).unwrap();
 
     assert_eq!(out, expected_tag);
 }
@@ -242,28 +228,22 @@ fn argon2d_v0x13() {
 fn argon2i_v0x13() {
     let algorithm = Algorithm::Argon2i;
     let version = Version::V0x13;
-    let m_cost = 32;
-    let t_cost = 3;
-    let parallelism = 4;
+    let params = example_params();
     let password = [0x01; 32];
     let salt = [0x02; 16];
     let secret = [0x03; 8];
-    let ad = [0x04; 12];
     let expected_tag = hex!(
         "
         c8 14 d9 d1 dc 7f 37 aa
         13 f0 d7 7f 24 94 bd a1
         c8 de 6b 01 6d d3 88 d2
         99 52 a4 c4 67 2b 6c e8
-    "
+        "
     );
 
-    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
     let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
-
     let mut out = [0u8; 32];
-    ctx.hash_password_into(&password, &salt, &ad, &mut out)
-        .unwrap();
+    ctx.hash_password_into(&password, &salt, &mut out).unwrap();
 
     assert_eq!(out, expected_tag);
 }
@@ -291,26 +271,20 @@ fn argon2i_v0x13() {
 fn argon2id_v0x13() {
     let algorithm = Algorithm::Argon2id;
     let version = Version::V0x13;
-    let m_cost = 32;
-    let t_cost = 3;
-    let parallelism = 4;
+    let params = example_params();
     let password = [0x01; 32];
     let salt = [0x02; 16];
     let secret = [0x03; 8];
-    let ad = [0x04; 12];
     let expected_tag = hex!(
         "
         0d 64 0d f5 8d 78 76 6c 08 c0 37 a3 4a 8b 53 c9
         d0 1e f0 45 2d 75 b6 5e b5 25 20 e9 6b 01 e6 59
-    "
+        "
     );
 
-    let params = Params::new(m_cost, t_cost, parallelism, None).unwrap();
     let ctx = Argon2::new_with_secret(&secret, algorithm, version, params).unwrap();
-
     let mut out = [0u8; 32];
-    ctx.hash_password_into(&password, &salt, &ad, &mut out)
-        .unwrap();
+    ctx.hash_password_into(&password, &salt, &mut out).unwrap();
 
     assert_eq!(out, expected_tag);
 }

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -197,7 +197,7 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
                         value
                             .decimal()?
                             .try_into()
-                            .map_err(|_| Error::ParamValueInvalid(InvalidValue::Malformed))?,
+                            .map_err(|_| InvalidValue::Malformed.param_error())?,
                     )
                 }
                 _ => return Err(Error::ParamNameInvalid),
@@ -207,10 +207,8 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
         if let Some(len) = output_length {
             if let Some(hash) = &hash.hash {
                 match hash.len().cmp(&len) {
-                    Ordering::Less => return Err(Error::ParamValueInvalid(InvalidValue::TooShort)),
-                    Ordering::Greater => {
-                        return Err(Error::ParamValueInvalid(InvalidValue::TooLong))
-                    }
+                    Ordering::Less => return Err(InvalidValue::TooShort.param_error()),
+                    Ordering::Greater => return Err(InvalidValue::TooLong.param_error()),
                     Ordering::Equal => (),
                 }
             }
@@ -257,13 +255,13 @@ impl McfHasher for Pbkdf2 {
                 let mut count_arr = [0u8; 4];
 
                 if Base64::decode(count, &mut count_arr)?.len() != 4 {
-                    return Err(Error::ParamValueInvalid(InvalidValue::Malformed));
+                    return Err(InvalidValue::Malformed.param_error());
                 }
 
                 let count = u32::from_be_bytes(count_arr);
                 (count, salt, hash)
             }
-            _ => return Err(Error::ParamValueInvalid(InvalidValue::Malformed)),
+            _ => return Err(InvalidValue::Malformed.param_error()),
         };
 
         let salt = Salt::new(b64_strip(salt))?;

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -138,7 +138,7 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
                     log_n = value
                         .decimal()?
                         .try_into()
-                        .map_err(|_| Error::ParamValueInvalid(InvalidValue::Malformed))?
+                        .map_err(|_| InvalidValue::Malformed.param_error())?
                 }
                 "r" => r = value.decimal()?,
                 "p" => p = value.decimal()?,
@@ -146,8 +146,7 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
             }
         }
 
-        Params::new(log_n, r, p)
-            .map_err(|_| password_hash::Error::ParamValueInvalid(InvalidValue::Malformed))
+        Params::new(log_n, r, p).map_err(|_| InvalidValue::Malformed.param_error())
     }
 }
 

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -76,25 +76,24 @@ impl McfHasher for Scrypt {
             [Some(""), Some("rscrypt"), Some("0"), Some(p), Some(s), Some(h), Some(""), None] => {
                 let pvec = Base64::decode_vec(p)?;
                 if pvec.len() != 3 {
-                    return Err(Error::ParamValueInvalid(InvalidValue::Malformed));
+                    return Err(InvalidValue::Malformed.param_error());
                 }
                 (pvec[0], pvec[1] as u32, pvec[2] as u32, s, h)
             }
             [Some(""), Some("rscrypt"), Some("1"), Some(p), Some(s), Some(h), Some(""), None] => {
                 let pvec = Base64::decode_vec(p)?;
                 if pvec.len() != 9 {
-                    return Err(Error::ParamValueInvalid(InvalidValue::Malformed));
+                    return Err(InvalidValue::Malformed.param_error());
                 }
                 let log_n = pvec[0];
                 let r = u32::from_le_bytes(pvec[1..5].try_into().unwrap());
                 let p = u32::from_le_bytes(pvec[5..9].try_into().unwrap());
                 (log_n, r, p, s, h)
             }
-            _ => return Err(Error::ParamValueInvalid(InvalidValue::Malformed)),
+            _ => return Err(InvalidValue::Malformed.param_error()),
         };
 
-        let params = Params::new(log_n, r, p)
-            .map_err(|_| Error::ParamValueInvalid(InvalidValue::Malformed))?;
+        let params = Params::new(log_n, r, p).map_err(|_| InvalidValue::Malformed.param_error())?;
 
         let salt = Salt::new(b64_strip(salt))?;
         let hash = Output::b64_decode(b64_strip(hash))?;


### PR DESCRIPTION
Adds support for optional parameters for identifying a specific Argon2 secret key ID to use when computing a password hash, and optional associated data.