### PR TITLE
bcrypt-pbkdf v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "blowfish",
  "crypto-mac 0.11.0",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-08-27)
+### Changed
+- Relax `zeroize` requirements ([#195])
+- Use `resolver = "2"`; MSRV 1.51+ ([#220])
+
+[#195]: https://github.com/RustCrypto/password-hashes/pull/195
+[#220]: https://github.com/RustCrypto/password-hashes/pull/220
+
 ## 0.6.2 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 ([#190])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.6.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.6.2"
+    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.7.0"
 )]
 
 extern crate alloc;


### PR DESCRIPTION
### Changed
- Relax `zeroize` requirements ([#195])
- Use `resolver = "2"`; MSRV 1.51+ ([#220])

[#195]: https://github.com/RustCrypto/password-hashes/pull/195
[#220]: https://github.com/RustCrypto/password-hashes/pull/220