### PR TITLE
pbkdf2 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crypto-mac 0.11.0",
  "hex-literal",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -17,6 +17,8 @@ readme = "README.md"
 [dependencies]
 base64ct = "1"
 blake2 = { version = "0.9", default-features = false }
+
+# optional dependencies
 password-hash = { version = "0.3", optional = true }
 rayon = { version = "1", optional = true }
 zeroize = { version = ">=1, <1.5", optional = true }

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 blowfish = { version = "0.8", features = ["bcrypt"] }
 crypto-mac = "0.11"
-pbkdf2 = { version = "0.8", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.9", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = ">=1, <1.5", default-features = false }
 

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2021-08-27)
+### Added
+- GOST test vectors ([#191])
+
+### Changed
+- Bump `password-hash` to v0.3 ([#217], [RustCrypto/traits#724])
+- Use `resolver = "2"`; MSRV 1.51+ ([#220])
+
+### Removed
+- `McfHasher` impl on `Pbkdf2` ([#219])
+
+[#191]: https://github.com/RustCrypto/password-hashing/pull/191
+[#217]: https://github.com/RustCrypto/password-hashing/pull/217
+[#219]: https://github.com/RustCrypto/password-hashing/pull/219
+[#220]: https://github.com/RustCrypto/password-hashing/pull/220
+[RustCrypto/traits#724]: https://github.com/RustCrypto/traits/pull/724
+
 ## 0.8.0 (2021-04-29)
 ### Changed
 - Bump `password-hash` crate dependency to v0.2 ([#164])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -14,6 +14,7 @@ readme = "README.md"
 [dependencies]
 crypto-mac = "0.11"
 
+# optional dependencies
 rayon = { version = "1", optional = true }
 hmac = { version = "0.11", default-features = false, optional = true }
 password-hash = { version = "0.3", default-features = false, optional = true, features = ["rand_core"]  }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/pbkdf2/0.8.0"
+    html_root_url = "https://docs.rs/pbkdf2/0.9.0"
 )]
 
 #[cfg(feature = "std")]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -13,10 +13,12 @@ readme = "README.md"
 
 [dependencies]
 hmac = "0.11"
-password-hash = { version = "0.3", default-features = false, features = ["rand_core"], optional = true }
-pbkdf2 = { version = "0.8", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.9", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.8", default-features = false, features = ["expose-core"] }
 sha2 = { version = "0.9", default-features = false }
+
+# optional dependencies
+password-hash = { version = "0.3", default-features = false, features = ["rand_core"], optional = true }
 
 [dev-dependencies]
 password-hash = { version = "0.3", features = ["rand_core"] }

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -16,6 +16,8 @@ readme = "README.md"
 
 [dependencies]
 sha2 = { version = "0.9", default-features = false }
+
+# optional dependencies
 rand = { version = "0.8", optional = true }
 subtle = { version = ">=2, <2.4", optional = true, default-features = false }
 


### PR DESCRIPTION
### Added
- GOST test vectors ([#191])

### Changed
- Bump `password-hash` to v0.3 ([#217], [RustCrypto/traits#724])
- Use `resolver = "2"`; MSRV 1.51+ ([#220])

### Removed
- `McfHasher` impl on `Pbkdf2` ([#219])

[#191]: https://github.com/RustCrypto/password-hashing/pull/191
[#217]: https://github.com/RustCrypto/password-hashing/pull/217
[#219]: https://github.com/RustCrypto/password-hashing/pull/219
[#220]: https://github.com/RustCrypto/password-hashing/pull/220
[RustCrypto/traits#724]: https://github.com/RustCrypto/traits/pull/724