### PR TITLE
scrypt v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hmac",
  "password-hash",

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-08-27)
+### Changed
+- Bump `password-hash` to v0.3 ([#217])
+- Use `resolver = "2"`; MSRV 1.51+ ([#220])
+- Bump `pbkdf2` dependency to v0.9 ([#233])
+
+### Removed
+- `McfHasher` impls for `Scrypt` ([#219])
+
+[#217]: https://github.com/RustCrypto/password-hashing/pull/217
+[#219]: https://github.com/RustCrypto/password-hashing/pull/219
+[#220]: https://github.com/RustCrypto/password-hashing/pull/220
+[#233]: https://github.com/RustCrypto/password-hashing/pull/233
+
 ## 0.7.0 (2021-04-29)
 ### Changed
 - Bump `password-hash` crate dependency to v0.2 ([#164])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Scrypt password-based key derivation function"

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -47,7 +47,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/scrypt/0.7.0"
+    html_root_url = "https://docs.rs/scrypt/0.8.0"
 )]
 
 #[macro_use]
@@ -64,13 +64,15 @@ use sha2::Sha256;
 pub mod errors;
 mod params;
 mod romix;
+
 #[cfg(feature = "simple")]
 mod simple;
+
+pub use crate::params::Params;
 
 #[cfg(feature = "simple")]
 pub use password_hash;
 
-pub use crate::params::Params;
 #[cfg(feature = "simple")]
 pub use crate::simple::{Scrypt, ALG_ID};
 


### PR DESCRIPTION
### Changed
- Bump `password-hash` to v0.3 ([#217])
- Use `resolver = "2"`; MSRV 1.51+ ([#220])
- Bump `pbkdf2` dependency to v0.9 ([#233])

### Removed
- `McfHasher` impls for `Scrypt` ([#219])

[#217]: https://github.com/RustCrypto/password-hashing/pull/217
[#219]: https://github.com/RustCrypto/password-hashing/pull/219
[#220]: https://github.com/RustCrypto/password-hashing/pull/220
[#233]: https://github.com/RustCrypto/password-hashing/pull/233