### PR TITLE
sha-crypt v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "rand",
  "sha2",

--- a/sha-crypt/CHANGELOG.md
+++ b/sha-crypt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-08-27)
+### Changed
+- Use `resolver = "2"`; MSRV 1.51+ ([#220])
+
+[#220]: https://github.com/RustCrypto/password-hashes/pull/220
+
 ## 0.2.1 (2021-07-20)
 ### Changed
 - Pin `subtle` dependency to v2.4 ([#190])

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library

--- a/sha-crypt/src/defs.rs
+++ b/sha-crypt/src/defs.rs
@@ -1,7 +1,14 @@
+/// Block size
 pub const BLOCK_SIZE: usize = 64;
+
+/// Maximum length of a salt
 #[cfg(feature = "simple")]
 pub const SALT_MAX_LEN: usize = 16;
+
+/// Encoding table.
 pub static TAB: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+/// Inverse encoding map.
 pub const MAP: [(u8, u8, u8, u8); 22] = [
     (42, 21, 0, 4),
     (1, 43, 22, 4),

--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -8,14 +8,21 @@ use alloc::string::String;
 #[cfg(feature = "std")]
 use std::io;
 
+/// Error type.
 #[derive(Debug)]
 pub enum CryptError {
     /// Should be within range defs::ROUNDS_MIN < defs::ROUNDS_MIN
     RoundsError,
+
+    /// RNG failed.
     RandomError,
+
+    /// I/O error.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     IoError(io::Error),
+
+    /// UTF-8 error.
     StringError(string::FromUtf8Error),
 }
 

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -33,10 +33,10 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/sha-crypt/0.2.1"
+    html_root_url = "https://docs.rs/sha-crypt/0.3.0"
 )]
 #![deny(unsafe_code)]
-#![warn(rust_2018_idioms)] // TODO(tarcieri): add `missing_docs`
+#![warn(missing_docs, rust_2018_idioms)]
 
 // TODO(tarcieri): heapless support
 #[macro_use]

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -3,10 +3,16 @@
 use crate::errors;
 use core::default::Default;
 
+/// Default number of rounds.
 pub const ROUNDS_DEFAULT: usize = 5_000;
+
+/// Minimum number of rounds allowed.
 pub const ROUNDS_MIN: usize = 1_000;
+
+/// Maximum number of rounds allowed.
 pub const ROUNDS_MAX: usize = 999_999_999;
 
+/// Algorithm parameters.
 #[derive(Debug, Clone)]
 pub struct Sha512Params {
     pub(crate) rounds: usize,
@@ -21,6 +27,7 @@ impl Default for Sha512Params {
 }
 
 impl Sha512Params {
+    /// Create new algorithm parameters.
     pub fn new(rounds: usize) -> Result<Sha512Params, errors::CryptError> {
         if (ROUNDS_MIN..=ROUNDS_MAX).contains(&rounds) {
             Ok(Sha512Params { rounds })


### PR DESCRIPTION
### Changed
- Use `resolver = "2"`; MSRV 1.51+ ([#220])

[#220]: https://github.com/RustCrypto/password-hashes/pull/220