### PR TITLE
bcrypt-pbkdf v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blowfish",
  "crypto-mac 0.11.0",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (2021-08-27)
+## 0.7.1 (2021-08-27)
+### Changed
+- Bump `pbkdf2` dependency to v0.9 ([#223])
+
+[#223]: https://github.com/RustCrypto/password-hashes/pull/223
+
+## 0.7.0 (2021-08-27) [YANKED]
 ### Changed
 - Relax `zeroize` requirements ([#195])
 - Use `resolver = "2"`; MSRV 1.51+ ([#220])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.7.0"
+    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.7.1"
 )]
 
 extern crate alloc;


### PR DESCRIPTION
### Changed
- Bump `pbkdf2` dependency to v0.9 ([#223])

[#223]: https://github.com/RustCrypto/password-hashes/pull/223