### PR TITLE
argon2 v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64ct",
  "blake2",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2021-08-27)
+## 0.3.1 (2021-09-11)
+### Fixed
+- Handling of `p_cost` parameter ([#235])
+
+[#235]: https://github.com/RustCrypto/password-hashes/pull/235
+
+## 0.3.0 (2021-08-27) [YANKED]
 ### Added
 - `alloc` feature ([#215])
 - `Params` now supports `keyid` and `data` fields ([#216])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants


### PR DESCRIPTION
### Fixed
- Handling of `p_cost` parameter ([#235])

[#235]: https://github.com/RustCrypto/password-hashes/pull/235