### PR TITLE
sha-crypt: handle B64 decoding errors

### DIFF
--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -47,3 +47,16 @@ pub enum CheckError {
     Crypt(CryptError),
     HashMismatch,
 }
+
+/// Decoding errors.
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
+#[derive(Debug)]
+pub struct DecodeError;
+
+#[cfg(feature = "simple")]
+impl From<DecodeError> for CheckError {
+    fn from(_: DecodeError) -> CheckError {
+        CheckError::InvalidFormat("invalid B64".into())
+    }
+}

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -305,7 +305,7 @@ pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError
         Err(e) => return Err(CheckError::Crypt(e)),
     };
 
-    let hash = b64::decode(hash.as_bytes());
+    let hash = b64::decode(hash.as_bytes())?;
 
     use subtle::ConstantTimeEq;
     if output.ct_eq(&hash).into() {

--- a/sha-crypt/tests/lib.rs
+++ b/sha-crypt/tests/lib.rs
@@ -84,14 +84,26 @@ fn test_sha512_simple_check_roundtrip() {
 
 #[cfg(feature = "simple")]
 #[test]
-fn test_sha512_check_invalid_format() {
-    // unexpected prefix 'SHOULDNOTBEHERE'
+fn test_sha512_unexpected_prefix() {
     let pw = "foobar";
     let s = "SHOULDNOTBEHERE$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
     assert!(!sha512_check(pw, s).is_ok());
+}
 
+#[cfg(feature = "simple")]
+#[test]
+fn test_sha512_wrong_id() {
     // wrong id '7'
     let pw = "foobar";
     let s = "$7$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
+    assert!(!sha512_check(pw, s).is_ok());
+}
+
+#[cfg(feature = "simple")]
+#[test]
+fn test_sha512_missing_trailing_slash() {
+    // Missing trailing slash
+    let pw = "abc";
+    let s = "$6$rounds=656000$Ykk6fjI2sU3/uprV$Z6yV/9Z741lfroSSzB9MwxSRnGeI9Z74hBkgNsHuojQJxZ9XjPkHg9jqqGLvWZ586wqnSSx5vrXZdhrMSZZE4";
     assert!(!sha512_check(pw, s).is_ok());
 }


### PR DESCRIPTION
Changes the B64 decoder to return a `Result`, returning an error if the input is invalid instead of panicking.

Fixes #240