### PR TITLE
sha-crypt v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rand",
  "sha2",

--- a/sha-crypt/CHANGELOG.md
+++ b/sha-crypt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2021-09-17)
+### Fixed
+- Handle B64 decoding errors ([#242])
+
+[#242]: https://github.com/RustCrypto/password-hashes/pull/242
+
 ## 0.3.0 (2021-08-27)
 ### Changed
 - Use `resolver = "2"`; MSRV 1.51+ ([#220])

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -33,7 +33,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/sha-crypt/0.3.0"
+    html_root_url = "https://docs.rs/sha-crypt/0.3.1"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Fixed
- Handle B64 decoding errors ([#242])

[#242]: https://github.com/RustCrypto/password-hashes/pull/242