### PR TITLE
Fixed version in docs

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argon2 = "0.2"
+//! argon2 = "0.3"
 //! rand_core = { version = "0.6", features = ["std"] }
 //! ```
 //!


### PR DESCRIPTION
The docs for version "0.3.1" recommend version "0.2" in the docs.
This fixes it.