### PR TITLE
ability to use custom output key length for scrypt

### DIFF
--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -77,7 +77,7 @@ impl Params {
             log_n,
             r: r as u32,
             p: p as u32,
-            len: len,
+            len,
         })
     }
 

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -4,7 +4,6 @@ use scrypt::{scrypt, Params};
 use {
     password_hash::{PasswordHash, PasswordVerifier},
     scrypt::Scrypt,
-	
 };
 
 struct Test {

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -4,6 +4,7 @@ use scrypt::{scrypt, Params};
 use {
     password_hash::{PasswordHash, PasswordVerifier},
     scrypt::Scrypt,
+	
 };
 
 struct Test {
@@ -69,7 +70,7 @@ fn test_scrypt() {
     let tests = tests();
     for t in tests.iter() {
         let mut result = vec![0u8; t.expected.len()];
-        let params = Params::new(t.log_n, t.r, t.p).unwrap();
+        let params = Params::new(t.log_n, t.r, t.p, t.expected.len()).unwrap();
         scrypt(
             t.password.as_bytes(),
             t.salt.as_bytes(),


### PR DESCRIPTION
I've faced with an issue when i need dynamically specify the output length of scrypt function. With current state of your crate it's not possible because in `Params::new` there is a statically used output hash length (RECOMMENDED_LEN = 64 bytes), so i don't understand why it's "recommended" if there is no choice