### PR TITLE
Test and fix min versions build

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -40,6 +40,20 @@ jobs:
       - run: cargo build --target ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --features zeroize
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - run: rm ../Cargo.toml
+    - run: cargo update -Z minimal-versions
+    - run: cargo test --release
+    - run: cargo test --release --all-features
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/balloon-hash.yml
+++ b/.github/workflows/balloon-hash.yml
@@ -39,6 +39,20 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features password-hash
       - run: cargo build --target ${{ matrix.target }} --release
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - run: rm ../Cargo.toml
+    - run: cargo update -Z minimal-versions
+    - run: cargo test --release
+    - run: cargo test --release --all-features
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/bcrypt-pbkdf.yml
+++ b/.github/workflows/bcrypt-pbkdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,12 +37,26 @@ jobs:
           override: true
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - run: rm ../Cargo.toml
+    - run: cargo update -Z minimal-versions
+    - run: cargo test --release
+    - run: cargo test --release --all-features
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -38,6 +38,20 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --no-default-features
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features simple
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - run: rm ../Cargo.toml
+    - run: cargo update -Z minimal-versions
+    - run: cargo test --release
+    - run: cargo test --release --all-features
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -38,12 +38,26 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --no-default-features
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features simple
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - run: rm ../Cargo.toml
+    - run: cargo update -Z minimal-versions
+    - run: cargo test --release
+    - run: cargo test --release --all-features
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -37,6 +37,20 @@ jobs:
           override: true
       - run: cargo build --target ${{ matrix.target }} --no-default-features
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - run: rm ../Cargo.toml
+    - run: cargo update -Z minimal-versions
+    - run: cargo test --release
+    - run: cargo test --release --all-features
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64ct",
  "blake2",
@@ -16,13 +16,13 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -40,7 +40,7 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -51,31 +51,30 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94ba84325db59637ffc528bbe8c7f86c02c57cff5c0e2b9b00f9a851f42f309"
+checksum = "f08f9f6871a8eacbb960d18db3d077ae6db1f0bc0df3272a78ca09eef8c5a931"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
- "opaque-debug",
 ]
 
 [[package]]
@@ -92,11 +91,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "035bd298db1557b73a277e9c599c5a50e0d2e6ee9dcac78f3f951cb2f7d88d8c"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -164,22 +164,22 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "generic-array",
  "subtle",
 ]
 
@@ -191,9 +191,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -227,11 +227,20 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -242,9 +251,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.109"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "memoffset"
@@ -257,19 +266,13 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
@@ -284,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -298,20 +301,19 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -331,15 +333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -369,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
 ]
@@ -384,7 +377,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "hmac",
  "password-hash",
@@ -415,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -426,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a93b52a311873ee038192d8a95dc3bad1d638ac926c2afee0ea9887ecfaf0"
+checksum = "8d94bd56cd86f4e14c55c935baa313bfd37846284f6bb1f35fc71bc30e621241"
 dependencies = [
  "digest",
 ]
@@ -441,15 +434,15 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # RustCrypto: Password Hashes
 
-[![Project Chat][chat-image]][chat-link] [![dependency status][deps-image]][deps-link] ![Apache2/MIT licensed][license-image]
+[![Project Chat][chat-image]][chat-link]
+[![dependency status][deps-image]][deps-link]
+![Apache2/MIT licensed][license-image]
 
 Collection of password hashing algorithms, otherwise known as password-based key derivation functions, written in pure Rust.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Collection of password hashing algorithms, otherwise known as password-based key
 |-----------|------------------|:----------:|:-------------:|:----:|
 | [Argon2] | [`argon2`]       | [![crates.io](https://img.shields.io/crates/v/argon2.svg)](https://crates.io/crates/argon2) | [![Documentation](https://docs.rs/argon2/badge.svg)](https://docs.rs/argon2) | ![MSRV 1.51][msrv-1.51] |
 | [Balloon] | [`balloon-hash`] | [![crates.io](https://img.shields.io/crates/v/balloon-hash.svg)](https://crates.io/crates/balloon-hash) | [![Documentation](https://docs.rs/balloon-hash/badge.svg)](https://docs.rs/balloon-hash) | ![MSRV 1.56][msrv-1.56] |
-| [bcrypt-pbkdf] | [`bcrypt-pbkdf`] |[![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) | ![MSRV 1.51][msrv-1.51] |
+| [bcrypt-pbkdf] | [`bcrypt-pbkdf`] |[![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) | ![MSRV 1.56][msrv-1.56] |
 | [PBKDF2] | [`pbkdf2`]       | [![crates.io](https://img.shields.io/crates/v/pbkdf2.svg)](https://crates.io/crates/pbkdf2) | [![Documentation](https://docs.rs/pbkdf2/badge.svg)](https://docs.rs/pbkdf2) | ![MSRV 1.51][msrv-1.51] |
-| [scrypt] | [`scrypt`]       | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt) | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) | ![MSRV 1.51][msrv-1.51] |
+| [scrypt] | [`scrypt`]       | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt) | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) | ![MSRV 1.56][msrv-1.56] |
 | [SHA-crypt] | [`sha-crypt`]    | [![crates.io](https://img.shields.io/crates/v/sha-crypt.svg)](https://crates.io/crates/sha-crypt) | [![Documentation](https://docs.rs/sha-crypt/badge.svg)](https://docs.rs/sha-crypt) | ![MSRV 1.51][msrv-1.51] |
 
 Please see the [OWASP Password Storage Cheat Sheet] for assistance in selecting an appropriate algorithm for your use case.

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.4 (2022-02-17)
+### Fixed
+- Minimal versions build ([#273])
+
+[#273]: https://github.com/RustCrypto/password-hashes/pull/273
+
 ## 0.3.3 (2022-01-30)
 ### Changed
 - Make `Params::block_count()` public ([#258])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.3.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.4" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
@@ -16,11 +16,11 @@ readme = "README.md"
 
 [dependencies]
 base64ct = "1"
-blake2 = { version = "0.10", default-features = false }
+blake2 = { version = "0.10.3", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.3", optional = true }
-rayon = { version = "1", optional = true }
+rayon = { version = "1.2", optional = true }
 zeroize = { version = ">=1, <1.6", optional = true }
 
 [dev-dependencies]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -74,7 +74,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/argon2/0.3.3"
+    html_root_url = "https://docs.rs/argon2/0.3.4"
 )]
 #![warn(rust_2018_idioms, missing_docs)]
 

--- a/balloon-hash/CHANGELOG.md
+++ b/balloon-hash/CHANGELOG.md
@@ -5,5 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-02-17)
+### Fixed
+- Minimal versions build ([#273])
+
+[#273]: https://github.com/RustCrypto/password-hashes/pull/273
+
 ## 0.1.0 (2022-01-22)
 - Initial release

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,12 +13,12 @@ rust-version = "1.56"
 readme = "README.md"
 
 [dependencies]
-digest = { version = "0.10", default-features = false }
+digest = { version = "0.10.3", default-features = false }
 crypto-bigint = { version = "0.3", default-features = false, features = ["generic-array"] }
 
 # optional dependencies
 password-hash = { version = "0.3", default-features = false, optional = true }
-rayon = { version = "1", optional = true }
+rayon = { version = "1.2", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/balloon-hash/0.1.0"
+    html_root_url = "https://docs.rs/balloon-hash/0.1.1"
 )]
 #![warn(rust_2018_idioms, missing_docs)]
 

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2022-02-17)
+### Changed
+- Bump `blowfish` dependency to v0.9, edition to 2021, and MSRV to 1.56 ([#273])
+
+[#273]: https://github.com/RustCrypto/password-hashes/pull/273
+
 ## 0.7.2 (2021-11-25)
 ### Changed
 - Bump `sha2` and `pbkdf2` dependencies to v0.10 ([#254])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,21 +1,25 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.7.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.56"
+readme = "README.md"
+documentation = "https://docs.rs/bcrypt-pbkdf"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-readme = "README.md"
 
 [dependencies]
-blowfish = { version = "0.8", features = ["bcrypt"] }
-pbkdf2 = { version = "0.10", default-features = false, path = "../pbkdf2" }
-sha2 = { version = "0.10", default-features = false }
+blowfish = { version = "0.9.1", features = ["bcrypt"] }
+pbkdf2 = { version = "0.10.1", default-features = false, path = "../pbkdf2" }
+sha2 = { version = "0.10.2", default-features = false }
 zeroize = { version = ">=1, <1.6", default-features = false, optional = true }
-hex-literal = "0.3"
+
+[dev-dependencies]
+hex-literal = "0.3.3"
 
 [features]
 default = ["std"]

--- a/bcrypt-pbkdf/README.md
+++ b/bcrypt-pbkdf/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the bcrypt-pbkdf password-based key derivation funct
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/bcrypt-pbkdf/badge.svg
 [docs-link]: https://docs.rs/bcrypt-pbkdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/bcrypt-pbkdf/badge.svg?branch=master&event=push

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.7.2"
+    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.8.0"
 )]
 
 extern crate alloc;
@@ -54,7 +54,7 @@ fn bhash(sha2_pass: &Output<Sha512>, sha2_salt: &Output<Sha512>) -> Output<Bhash
 
     for _ in 0..64 {
         for i in (0..BHASH_WORDS).step_by(2) {
-            let (l, r) = blowfish.bc_encrypt(cdata[i], cdata[i + 1]);
+            let [l, r] = blowfish.bc_encrypt([cdata[i], cdata[i + 1]]);
             cdata[i] = l;
             cdata[i + 1] = r;
         }

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2022-02-17)
+### Fixed
+- Minimal versions build ([#273])
+
+[#273]: https://github.com/RustCrypto/password-hashes/pull/273
+
 ## 0.10.0 (2021-11-25)
 ### Changed
 - Migrate from `crypto-mac` to `digest` v0.10 ([#254])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -12,10 +12,10 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-digest = { version = "0.10", features = ["mac"] }
+digest = { version = "0.10.3", features = ["mac"] }
 
 # optional dependencies
-rayon = { version = "1", optional = true }
+rayon = { version = "1.2", optional = true }
 password-hash = { version = "0.3", default-features = false, optional = true, features = ["rand_core"]  }
 hmac = { version = "0.12", default-features = false, optional = true }
 sha1 = { version = "0.10", package = "sha-1", default-features = false, optional = true }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -57,7 +57,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/pbkdf2/0.10.0"
+    html_root_url = "https://docs.rs/pbkdf2/0.10.1"
 )]
 
 #[cfg(feature = "std")]

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-02-17)
+### Changed
+- Bump `salsa20` dependency to v0.10, edition to 2021, and MSRV to 1.56 ([#273])
+
+[#273]: https://github.com/RustCrypto/password-hashes/pull/273
+
 ## 0.8.1 (2021-11-25)
 ### Changed
 - Bump `sha2` dependency to v0.10, `pbkdf2` to v0.10, `hmac` to v0.12 ([#254])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "scrypt"
-version = "0.8.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
+description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-description = "Scrypt password-based key derivation function"
+edition = "2021"
+rust-version = "1.56"
+readme = "README.md"
 documentation = "https://docs.rs/scrypt"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/scrypt"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography"]
-edition = "2018"
-readme = "README.md"
 
 [dependencies]
-hmac = "0.12"
-pbkdf2 = { version = "0.10", default-features = false, path = "../pbkdf2" }
-salsa20 = { version = "0.9", default-features = false, features = ["expose-core"] }
+hmac = "0.12.1"
+pbkdf2 = { version = "0.10.1", default-features = false, path = "../pbkdf2" }
+salsa20 = { version = "0.10.2", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 
 # optional dependencies

--- a/scrypt/README.md
+++ b/scrypt/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the [scrypt key derivation function][1].
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/scrypt/badge.svg
 [docs-link]: https://docs.rs/scrypt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/scrypt/badge.svg?branch=master&event=push

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -47,7 +47,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/scrypt/0.8.1"
+    html_root_url = "https://docs.rs/scrypt/0.9.0"
 )]
 
 #[macro_use]

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -3,10 +3,7 @@ use core::mem::size_of;
 use crate::errors::InvalidParams;
 
 #[cfg(feature = "simple")]
-use {
-    core::convert::{TryFrom, TryInto},
-    password_hash::{errors::InvalidValue, Error, ParamsString, PasswordHash},
-};
+use password_hash::{errors::InvalidValue, Error, ParamsString, PasswordHash};
 
 const RECOMMENDED_LOG_N: u8 = 15;
 const RECOMMENDED_R: u32 = 8;

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -1,7 +1,6 @@
 //! Implementation of the `password-hash` crate API.
 
 use crate::{scrypt, Params};
-use core::convert::TryInto;
 use password_hash::{Decimal, Error, Ident, Output, PasswordHash, PasswordHasher, Result, Salt};
 
 /// Algorithm identifier


### PR DESCRIPTION
Also bumps MSRV and edition to 1.56 and 2021 respectively for `bcrypt-pbkdf` and `scrypt`.