### PR TITLE
2021 edition upgrades

### DIFF
--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Collection of password hashing algorithms, otherwise known as password-based key
 
 ## Supported Algorithms
 
-| Algorithm | Crate            | Crates.io  | Documentation | MSRV |
-|-----------|------------------|:----------:|:-------------:|:----:|
-| [Argon2] | [`argon2`]       | [![crates.io](https://img.shields.io/crates/v/argon2.svg)](https://crates.io/crates/argon2) | [![Documentation](https://docs.rs/argon2/badge.svg)](https://docs.rs/argon2) | ![MSRV 1.51][msrv-1.51] |
-| [Balloon] | [`balloon-hash`] | [![crates.io](https://img.shields.io/crates/v/balloon-hash.svg)](https://crates.io/crates/balloon-hash) | [![Documentation](https://docs.rs/balloon-hash/badge.svg)](https://docs.rs/balloon-hash) | ![MSRV 1.56][msrv-1.56] |
-| [bcrypt-pbkdf] | [`bcrypt-pbkdf`] |[![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) | ![MSRV 1.56][msrv-1.56] |
-| [PBKDF2] | [`pbkdf2`]       | [![crates.io](https://img.shields.io/crates/v/pbkdf2.svg)](https://crates.io/crates/pbkdf2) | [![Documentation](https://docs.rs/pbkdf2/badge.svg)](https://docs.rs/pbkdf2) | ![MSRV 1.51][msrv-1.51] |
-| [scrypt] | [`scrypt`]       | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt) | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) | ![MSRV 1.56][msrv-1.56] |
-| [SHA-crypt] | [`sha-crypt`]    | [![crates.io](https://img.shields.io/crates/v/sha-crypt.svg)](https://crates.io/crates/sha-crypt) | [![Documentation](https://docs.rs/sha-crypt/badge.svg)](https://docs.rs/sha-crypt) | ![MSRV 1.51][msrv-1.51] |
+| Algorithm      | Crate            | Crates.io                                                                                               | Documentation |          MSRV           |
+|----------------|------------------|---------------------------------------------------------------------------------------------------------|---------------|-------------------------|
+| [Argon2]       | [`argon2`]       | [![crates.io](https://img.shields.io/crates/v/argon2.svg)](https://crates.io/crates/argon2)             | [![Documentation](https://docs.rs/argon2/badge.svg)](https://docs.rs/argon2) | ![MSRV 1.57][msrv-1.57] |
+| [Balloon]      | [`balloon‑hash`] | [![crates.io](https://img.shields.io/crates/v/balloon-hash.svg)](https://crates.io/crates/balloon-hash) | [![Documentation](https://docs.rs/balloon-hash/badge.svg)](https://docs.rs/balloon-hash) | ![MSRV 1.57][msrv-1.57] |
+| [bcrypt‑pbkdf] | [`bcrypt‑pbkdf`] | [![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) | ![MSRV 1.57][msrv-1.57] |
+| [PBKDF2]       | [`pbkdf2`]       | [![crates.io](https://img.shields.io/crates/v/pbkdf2.svg)](https://crates.io/crates/pbkdf2)             | [![Documentation](https://docs.rs/pbkdf2/badge.svg)](https://docs.rs/pbkdf2) | ![MSRV 1.57][msrv-1.57] |
+| [scrypt]       | [`scrypt`]       | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt)             | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) | ![MSRV 1.57][msrv-1.57] |
+| [SHA-crypt]    | [`sha‑crypt`]    | [![crates.io](https://img.shields.io/crates/v/sha-crypt.svg)](https://crates.io/crates/sha-crypt)       | [![Documentation](https://docs.rs/sha-crypt/badge.svg)](https://docs.rs/sha-crypt) | ![MSRV 1.56][msrv-1.56] |
 
 Please see the [OWASP Password Storage Cheat Sheet] for assistance in selecting an appropriate algorithm for your use case.
 
@@ -43,23 +43,23 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [deps-image]: https://deps.rs/repo/github/RustCrypto/password-hashes/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/password-hashes
-[msrv-1.51]: https://img.shields.io/badge/rustc-1.51.0+-blue.svg
 [msrv-1.56]: https://img.shields.io/badge/rustc-1.56.0+-blue.svg
+[msrv-1.57]: https://img.shields.io/badge/rustc-1.57.0+-blue.svg
 
 [//]: # (crates)
 
 [`argon2`]: ./argon2
-[`balloon-hash`]: ./balloon-hash
-[`bcrypt-pbkdf`]: ./bcrypt-pbkdf
+[`balloon‑hash`]: ./balloon-hash
+[`bcrypt‑pbkdf`]: ./bcrypt-pbkdf
 [`pbkdf2`]: ./pbkdf2
 [`scrypt`]: ./scrypt
-[`sha-crypt`]: ./sha-crypt
+[`sha‑crypt`]: ./sha-crypt
 
 [//]: # (general links)
 
 [Argon2]: https://en.wikipedia.org/wiki/Argon2
 [Balloon]: https://en.wikipedia.org/wiki/Balloon_hashing
-[bcrypt-pbkdf]: https://flak.tedunangst.com/post/bcrypt-pbkdf
+[bcrypt‑pbkdf]: https://flak.tedunangst.com/post/bcrypt-pbkdf
 [PBKDF2]: https://en.wikipedia.org/wiki/PBKDF2
 [scrypt]: https://en.wikipedia.org/wiki/Scrypt
 [SHA-crypt]: https://www.akkadia.org/drepper/SHA-crypt.txt

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -11,8 +11,9 @@ documentation = "https://docs.rs/argon2"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/argon2"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography", "no-std"]
-edition = "2018"
 readme = "README.md"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 base64ct = "1"

--- a/argon2/README.md
+++ b/argon2/README.md
@@ -11,6 +11,20 @@ Pure Rust implementation of the [Argon2] password hashing function.
 
 [Documentation][docs-link]
 
+# About
+
+Argon2 is a memory-hard [key derivation function] chosen as the winner of
+the [Password Hashing Competition] in July 2015.
+
+It implements the following three three algorithmic variants:
+
+- **Argon2d**: maximizes resistance to GPU cracking attacks
+- **Argon2i**: optimized to resist side-channel attacks
+- **Argon2id**: (default) hybrid version combining both Argon2i and Argon2d
+
+Support is provided for embedded (i.e. `no_std`) environments, including
+ones without `alloc` support.
+
 ## Minimum Supported Rust Version
 
 Rust **1.57** or higher.
@@ -54,3 +68,5 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [Argon2]: https://en.wikipedia.org/wiki/Argon2
+[key derivation function]: https://en.wikipedia.org/wiki/Key_derivation_function
+[Password Hashing Competition]: https://www.password-hashing.net/

--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(feature = "password-hash")]
-use {core::convert::TryFrom, password_hash::Ident};
+use password_hash::Ident;
 
 /// Argon2d algorithm identifier
 #[cfg(feature = "password-hash")]

--- a/argon2/src/block.rs
+++ b/argon2/src/block.rs
@@ -1,7 +1,6 @@
 //! Argon2 memory block functions
 
 use core::{
-    convert::TryInto,
     num::Wrapping,
     ops::{BitXor, BitXorAssign, Index, IndexMut},
     slice,

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -1,20 +1,17 @@
-//! Pure Rust implementation of the [Argon2] password hashing function.
-//!
-//! # About
-//!
-//! Argon2 is a memory-hard [key derivation function] chosen as the winner of
-//! the [Password Hashing Competition] in July 2015.
-//!
-//! It provides three algorithmic variants (chosen via the [`Algorithm`] enum):
-//!
-//! - **Argon2d**: maximizes resistance to GPU cracking attacks
-//! - **Argon2i**: optimized to resist side-channel attacks
-//! - **Argon2id**: (default) hybrid version combining both Argon2i and Argon2d
-//!
-//! Support is provided for embedded (i.e. `no_std`) environments, including
-//! ones without `alloc` support.
-//!
-//! # Usage (simple with default params)
+#![no_std]
+// TODO(tarcieri): safe parallel implementation
+// See: https://github.com/RustCrypto/password-hashes/issues/154
+#![cfg_attr(not(feature = "parallel"), forbid(unsafe_code))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/argon2/0.4.0-pre"
+)]
+#![warn(rust_2018_idioms, missing_docs)]
+
+//! ## Usage (simple with default params)
 //!
 //! Note: this example requires the `rand_core` crate with the `std` feature
 //! enabled for `rand_core::OsRng` (embedded platforms can substitute their
@@ -61,22 +58,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
-//! [Argon2]: https://en.wikipedia.org/wiki/Argon2
-//! [key derivation function]: https://en.wikipedia.org/wiki/Key_derivation_function
-//! [Password Hashing Competition]: https://www.password-hashing.net/
-
-#![no_std]
-// TODO(tarcieri): safe parallel implementation
-// See: https://github.com/RustCrypto/password-hashes/issues/154
-#![cfg_attr(not(feature = "parallel"), forbid(unsafe_code))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/argon2/0.4.0-pre"
-)]
-#![warn(rust_2018_idioms, missing_docs)]
 
 #[cfg(feature = "alloc")]
 #[macro_use]
@@ -115,10 +96,7 @@ use crate::{
 use blake2::{digest::Output, Blake2b512, Digest};
 
 #[cfg(all(feature = "alloc", feature = "password-hash"))]
-use {
-    core::convert::TryFrom,
-    password_hash::{Decimal, Ident, ParamsString, Salt},
-};
+use password_hash::{Decimal, Ident, ParamsString, Salt};
 
 /// Maximum password length in bytes.
 pub const MAX_PWD_LEN: usize = 0xFFFFFFFF;

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -2,13 +2,10 @@
 
 use crate::{Error, Result, SYNC_POINTS};
 use base64ct::{Base64Unpadded as B64, Encoding};
-use core::{convert::TryFrom, str::FromStr};
+use core::str::FromStr;
 
 #[cfg(feature = "password-hash")]
-use {
-    core::convert::TryInto,
-    password_hash::{ParamsString, PasswordHash},
-};
+use password_hash::{ParamsString, PasswordHash};
 
 /// Argon2 password hash parameters.
 ///
@@ -127,7 +124,7 @@ impl Params {
     /// cryptographical standpoint).
     ///
     /// On top of that, this field is not longer part of the argon2 standard
-    /// (see: https://github.com/P-H-C/phc-winner-argon2/pull/173), and should
+    /// (see: <https://github.com/P-H-C/phc-winner-argon2/pull/173>), and should
     /// not be used for any non-legacy work.
     pub fn keyid(&self) -> &[u8] {
         self.keyid.as_bytes()
@@ -138,7 +135,7 @@ impl Params {
     /// Defaults to an empty byte slice.
     ///
     /// This field is not longer part of the argon2 standard
-    /// (see: https://github.com/P-H-C/phc-winner-argon2/pull/173), and should
+    /// (see: <https://github.com/P-H-C/phc-winner-argon2/pull/173>), and should
     /// not be used for any non-legacy work.
     pub fn data(&self) -> &[u8] {
         self.data.as_bytes()

--- a/argon2/src/version.rs
+++ b/argon2/src/version.rs
@@ -1,7 +1,6 @@
 //! Version of the algorithm.
 
 use crate::{Error, Result};
-use core::convert::TryFrom;
 
 /// Version of the algorithm.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -8,9 +8,9 @@ documentation = "https://docs.rs/balloon-hash"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/balloon-hash"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography", "no-std"]
-edition = "2021"
-rust-version = "1.56"
 readme = "README.md"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 digest = { version = "0.10.3", default-features = false }

--- a/balloon-hash/src/algorithm.rs
+++ b/balloon-hash/src/algorithm.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(feature = "password-hash")]
-use {core::convert::TryFrom, password_hash::Ident};
+use password_hash::Ident;
 
 /// Balloon primitive type: variants of the algorithm.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -73,18 +73,18 @@ pub use crate::{
     error::{Error, Result},
     params::Params,
 };
+
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub use password_hash::{self, PasswordHash, PasswordHasher, PasswordVerifier};
+
 use core::marker::PhantomData;
 use crypto_bigint::ArrayDecoding;
 use digest::generic_array::GenericArray;
 use digest::{Digest, FixedOutputReset};
-#[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
-pub use password_hash::{self, PasswordHash, PasswordHasher, PasswordVerifier};
+
 #[cfg(all(feature = "alloc", feature = "password-hash"))]
-use {
-    core::convert::TryFrom,
-    password_hash::{Decimal, Ident, ParamsString, Salt},
-};
+use password_hash::{Decimal, Ident, ParamsString, Salt};
 
 /// Balloon context.
 ///

--- a/balloon-hash/src/params.rs
+++ b/balloon-hash/src/params.rs
@@ -2,11 +2,9 @@
 
 use crate::{Error, Result};
 use core::num::NonZeroU32;
+
 #[cfg(feature = "password-hash")]
-use {
-    core::convert::TryFrom,
-    password_hash::{errors::InvalidValue, ParamsString, PasswordHash},
-};
+use password_hash::{errors::InvalidValue, ParamsString, PasswordHash};
 
 /// Balloon password hash parameters.
 ///

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.8.1" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56"
 readme = "README.md"
 documentation = "https://docs.rs/bcrypt-pbkdf"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-pbkdf"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography"]
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 blowfish = { version = "0.9.1", features = ["bcrypt"] }

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -15,8 +15,11 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod errors;
+
+pub use errors::Error;
+
 use blowfish::Blowfish;
-use core::convert::TryInto;
 use sha2::{
     digest::{
         crypto_common::{Key, KeyInit, KeySizeUser},
@@ -25,12 +28,9 @@ use sha2::{
     },
     Digest, Sha512,
 };
+
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
-
-mod errors;
-
-pub use errors::Error;
 
 const BHASH_WORDS: usize = 8;
 const BHASH_OUTPUT_SIZE: usize = BHASH_WORDS * 4;

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -8,8 +8,9 @@ documentation = "https://docs.rs/pbkdf2"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography", "no-std"]
-edition = "2018"
 readme = "README.md"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 digest = { version = "0.10.3", features = ["mac"] }

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -1,12 +1,7 @@
 //! Implementation of the `password-hash` crate API.
 
 use crate::pbkdf2;
-use core::cmp::Ordering;
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt::{self, Display},
-    str::FromStr,
-};
+use core::{cmp::Ordering, fmt, str::FromStr};
 use hmac::Hmac;
 use password_hash::{
     errors::InvalidValue, Decimal, Error, Ident, Output, ParamsString, PasswordHash,
@@ -123,7 +118,7 @@ impl AsRef<str> for Algorithm {
     }
 }
 
-impl Display for Algorithm {
+impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }

--- a/pbkdf2/tests/simple.rs
+++ b/pbkdf2/tests/simple.rs
@@ -9,7 +9,6 @@ use pbkdf2::{
     password_hash::{PasswordHasher, Salt},
     Algorithm, Params, Pbkdf2,
 };
-use std::convert::TryFrom;
 
 const PASSWORD: &str = "password";
 const SALT_B64: &str = "c2FsdA"; // "salt"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56"
 readme = "README.md"
 documentation = "https://docs.rs/scrypt"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/scrypt"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 hmac = "0.12.1"

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -11,8 +11,9 @@ documentation = "https://docs.rs/sha-crypt"
 repository = "https://github.com/RustCrypto/password-hashes/tree/master/sha-crypt"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "password", "hashing"]
-edition = "2018"
 readme = "README.md"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 sha2 = { version = "0.10", default-features = false }

--- a/sha-crypt/README.md
+++ b/sha-crypt/README.md
@@ -17,7 +17,7 @@ Password hashes using this algorithm start with `$6$` when encoded using the
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sha-crypt/badge.svg
 [docs-link]: https://docs.rs/sha-crypt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/sha-crypt/badge.svg?branch=master&event=push

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -57,7 +57,6 @@ pub use crate::{
 };
 
 use alloc::{string::String, vec::Vec};
-use core::convert::TryInto;
 use sha2::{Digest, Sha512};
 
 #[cfg(feature = "simple")]


### PR DESCRIPTION
Bumps all crates which weren't previously upgraded to the 2021 edition to the 2021 edition.

All crates were already MSRV 1.57 as of #283, except `sha-crypt`.

This commit bumps all crates to the 2021 edition, including `sha-crypt`.