### PR TITLE
argon2 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "base64ct",
  "blake2",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-03-18)
+### Changed
+- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
+- 2021 edition upgrade ([#284])
+
+[#283]: https://github.com/RustCrypto/password-hashes/pull/283
+[#284]: https://github.com/RustCrypto/password-hashes/pull/284
+
 ## 0.3.4 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#273])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/argon2/src/block.rs
+++ b/argon2/src/block.rs
@@ -56,7 +56,7 @@ impl Block {
             // block_tmp = ref_block + prev_block + next_block
         }
 
-        /// Designed by the Lyra PHC team
+        /// Note: designed by the Lyra PHC team
         fn blake2_mult(x: u64, y: u64) -> u64 {
             let m = 0xFFFFFFFF;
             let xy = Wrapping((x & m) * (y & m)) * Wrapping(2);
@@ -64,7 +64,6 @@ impl Block {
         }
 
         /// Blake2 round function
-        // TODO(tarcieri): use the `blake2` crate
         macro_rules! blake2_round {
             (
                 $v0:expr, $v1:expr, $v2:expr, $v3:expr, $v4:expr, $v5:expr, $v6:expr, $v7:expr,

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -6,8 +6,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/argon2/0.4.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![warn(rust_2018_idioms, missing_docs)]
 


### PR DESCRIPTION
### Changed
- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
- 2021 edition upgrade ([#284])

[#283]: https://github.com/RustCrypto/password-hashes/pull/283
[#284]: https://github.com/RustCrypto/password-hashes/pull/284