### PR TITLE
balloon-hash v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "crypto-bigint",
  "digest",

--- a/balloon-hash/CHANGELOG.md
+++ b/balloon-hash/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2022-03-18)
+### Changed
+- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
+- 2021 edition upgrade ([#284])
+
+[#283]: https://github.com/RustCrypto/password-hashes/pull/283
+[#284]: https://github.com/RustCrypto/password-hashes/pull/284
+
 ## 0.1.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#273])

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/balloon-hash/0.2.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![warn(rust_2018_idioms, missing_docs)]
 


### PR DESCRIPTION
### Changed
- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
- 2021 edition upgrade ([#284])

[#283]: https://github.com/RustCrypto/password-hashes/pull/283
[#284]: https://github.com/RustCrypto/password-hashes/pull/284