### PR TITLE
pbkdf2 v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "71acf5509fc522cce1b100ac0121c635129bfd4d91cdf036bcc9b9935f97ccf5"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.8.1"
+version = "0.9.0-pre"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0-pre"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.8.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,9 +14,9 @@ rust-version = "1.57"
 
 [dependencies]
 blowfish = { version = "0.9.1", features = ["bcrypt"] }
-pbkdf2 = { version = "=0.11.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.11", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.10.2", default-features = false }
-zeroize = { version = ">=1, <1.6", default-features = false, optional = true }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3.3"

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -7,8 +7,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/bcrypt-pbkdf/0.8.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 
 extern crate alloc;

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-03-28)
+### Changed
+- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
+- 2021 edition upgrade ([#284])
+
+[#283]: https://github.com/RustCrypto/password-hashes/pull/283
+[#284]: https://github.com/RustCrypto/password-hashes/pull/284
+
 ## 0.10.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#273])

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -56,8 +56,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/pbkdf2/0.11.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 
 #[cfg(feature = "std")]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0-pre"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ rust-version = "1.56"
 
 [dependencies]
 hmac = "0.12.1"
-pbkdf2 = { version = "=0.11.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.11", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.10.2", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -46,8 +46,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/scrypt/0.10.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 
 #[macro_use]


### PR DESCRIPTION
### Changed
- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
- 2021 edition upgrade ([#284])

[#283]: https://github.com/RustCrypto/password-hashes/pull/283
[#284]: https://github.com/RustCrypto/password-hashes/pull/284