### PR TITLE
bcrypt-pbkdf v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "71acf5509fc522cce1b100ac0121c635129bfd4d91cdf036bcc9b9935f97ccf5"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "blowfish",
  "hex-literal",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-03-18)
+### Changed
+- 2021 edition upgrade ([#284])
+- Bump `pbkdf2` dependency to v0.11; MSRV 1.57 ([#291])
+
+[#284]: https://github.com/RustCrypto/password-hashes/pull/284
+[#291]: https://github.com/RustCrypto/password-hashes/pull/291
+
 ## 0.8.1 (2022-02-20)
 ### Changed
 - Change `passphrase` to be `impl AsRef<[u8]>` allowing non-UTF8 passphrases ([#277])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- 2021 edition upgrade ([#284])
- Bump `pbkdf2` dependency to v0.11; MSRV 1.57 ([#291])

[#284]: https://github.com/RustCrypto/password-hashes/pull/284
[#291]: https://github.com/RustCrypto/password-hashes/pull/291