### PR TITLE
scrypt v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "hmac",
  "password-hash",

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2022-03-18)
+### Changed
+- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
+- Bump `pbkdf2` dependency to v0.11 ([#291])
+
+[#283]: https://github.com/RustCrypto/password-hashes/pull/283
+[#291]: https://github.com/RustCrypto/password-hashes/pull/291
+
 ## 0.9.0 (2022-02-17)
 ### Changed
 - Bump `salsa20` dependency to v0.10, edition to 2021, and MSRV to 1.56 ([#273])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.10.0-pre"
+version = "0.10.0"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/RustCrypto/password-hashes/tree/master/scrypt"
 keywords = ["crypto", "password", "hashing"]
 categories = ["cryptography"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 hmac = "0.12.1"

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -51,7 +51,6 @@
 
 #[macro_use]
 extern crate alloc;
-
 #[cfg(feature = "std")]
 extern crate std;
 


### PR DESCRIPTION
### Changed
- Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])
- Bump `pbkdf2` dependency to v0.11 ([#291])

[#283]: https://github.com/RustCrypto/password-hashes/pull/283
[#291]: https://github.com/RustCrypto/password-hashes/pull/291