### PR TITLE
sha-crypt v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "rand",
  "sha2",

--- a/sha-crypt/CHANGELOG.md
+++ b/sha-crypt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-03-18)
+### Changed
+- 2021 edition upgrade; MSRV 1.56 ([#284])
+
+[#284]: https://github.com/RustCrypto/password-hashes/pull/284
+
 ## 0.3.2 (2021-11-25)
 ### Changed
 - Bump `sha2` dependency to v0.10 ([#254])

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -32,8 +32,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/sha-crypt/0.3.2"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- 2021 edition upgrade; MSRV 1.56 ([#284])

[#284]: https://github.com/RustCrypto/password-hashes/pull/284