### PR TITLE
Argon2: add constant for recommended salt length

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -106,6 +106,11 @@ pub const MIN_SALT_LEN: usize = 8;
 /// Maximum salt length in bytes.
 pub const MAX_SALT_LEN: usize = 0xFFFFFFFF;
 
+/// Recommended salt length for password hashing in bytes.
+#[cfg(feature = "password-hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
+pub const RECOMMENDED_SALT_LEN: usize = password_hash::Salt::RECOMMENDED_LENGTH;
+
 /// Maximum secret key length in bytes.
 pub const MAX_SECRET_LEN: usize = 0xFFFFFFFF;
 


### PR DESCRIPTION
The specification of argon2 recommends a salt length of 16 bytes for password hashing (section 3.1).
This pull request introduces a constant `RECOMMENDED_SALT_LEN` to make this recommended salt length accessible to users.
(Also, a slight mistake in the documentation has been corrected.)