### PR TITLE
Remove crate feature from `argon2::RECOMMENDED_SALT_LEN`

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -107,9 +107,7 @@ pub const MIN_SALT_LEN: usize = 8;
 pub const MAX_SALT_LEN: usize = 0xFFFFFFFF;
 
 /// Recommended salt length for password hashing in bytes.
-#[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
-pub const RECOMMENDED_SALT_LEN: usize = password_hash::Salt::RECOMMENDED_LENGTH;
+pub const RECOMMENDED_SALT_LEN: usize = 16;
 
 /// Maximum secret key length in bytes.
 pub const MAX_SECRET_LEN: usize = 0xFFFFFFFF;


### PR DESCRIPTION
A small follow-up to https://github.com/RustCrypto/password-hashes/pull/306.

The proposition here is to be able to use `RECOMMENDED_SALT_LEN` without having to pull in another dependency. Is that alright?

Sorry for being so brusk, I thought instead of asking with an issue I can simply ask with a PR.