### PR TITLE
argon2: update version in docs

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argon2 = "0.3"
+//! argon2 = "0.4"
 //! rand_core = { version = "0.6", features = ["std"] }
 //! ```
 //!


### PR DESCRIPTION
The example in the docs for version 0.4 uses version 0.3 of the crate. This updates it.