### PR TITLE
Zeroize sensitive bytes for `balloon-hash`

### DIFF
--- a/.github/workflows/balloon-hash.yml
+++ b/.github/workflows/balloon-hash.yml
@@ -61,4 +61,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
+      - run: cargo test --release --no-default-features --features zeroize
+      - run: cargo test --release --no-default-features --features alloc
+      - run: cargo test --release --no-default-features --features alloc,zeroize
+      - run: cargo test --release --no-default-features --features parallel
+      - run: cargo test --release --no-default-features --features parallel,zeroize
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "password-hash",
  "rayon",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -15,11 +15,11 @@ rust-version = "1.57"
 [dependencies]
 digest = { version = "0.10.3", default-features = false }
 crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array"] }
-zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.4", default-features = false, optional = true }
 rayon = { version = "1.5", optional = true }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.57"
 [dependencies]
 digest = { version = "0.10.3", default-features = false }
 crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array"] }
+zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.4", default-features = false, optional = true }

--- a/balloon-hash/src/balloon.rs
+++ b/balloon-hash/src/balloon.rs
@@ -137,7 +137,7 @@ where
     // for m from 1 to s_cost-1:
     for m in 1..s_cost {
         // buf[m] = hash(cnt++, buf[m-1])
-        Digest::update(&mut digest, &cnt.to_le_bytes());
+        Digest::update(&mut digest, cnt.to_le_bytes());
         cnt += 1;
         Digest::update(&mut digest, &buf[m - 1]);
         buf[m] = digest.finalize_reset();
@@ -157,7 +157,7 @@ where
             };
 
             // buf[m] = hash(cnt++, prev, buf[m])
-            Digest::update(&mut digest, &cnt.to_le_bytes());
+            Digest::update(&mut digest, cnt.to_le_bytes());
             cnt += 1;
             Digest::update(&mut digest, prev);
             Digest::update(&mut digest, &buf[m]);
@@ -167,13 +167,13 @@ where
             // for i from 0 to delta-1:
             for i in 0..DELTA {
                 // block_t idx_block = ints_to_block(t, m, i)
-                Digest::update(&mut digest, &t.to_le_bytes());
-                Digest::update(&mut digest, &(m as u64).to_le_bytes());
-                Digest::update(&mut digest, &i.to_le_bytes());
+                Digest::update(&mut digest, t.to_le_bytes());
+                Digest::update(&mut digest, (m as u64).to_le_bytes());
+                Digest::update(&mut digest, i.to_le_bytes());
                 let idx_block = digest.finalize_reset();
 
                 // int other = to_int(hash(cnt++, salt, idx_block)) mod s_cost
-                Digest::update(&mut digest, &cnt.to_le_bytes());
+                Digest::update(&mut digest, cnt.to_le_bytes());
                 cnt += 1;
                 Digest::update(&mut digest, salt);
 
@@ -194,7 +194,7 @@ where
                 );
 
                 // buf[m] = hash(cnt++, buf[m], buf[other])
-                Digest::update(&mut digest, &cnt.to_le_bytes());
+                Digest::update(&mut digest, cnt.to_le_bytes());
                 cnt += 1;
                 Digest::update(&mut digest, &buf[m]);
                 Digest::update(&mut digest, &buf[other]);

--- a/balloon-hash/src/balloon.rs
+++ b/balloon-hash/src/balloon.rs
@@ -38,16 +38,15 @@ where
     #[cfg(not(feature = "parallel"))]
     let output = {
         let mut output = hash_internal::<D>(pwd, salt, secret, params, memory_blocks, Some(1))?;
+        let mut hash = GenericArray::default();
 
         for thread in 2..=u64::from(params.p_cost.get()) {
-            #[cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
-            let mut hash =
-                hash_internal::<D>(pwd, salt, secret, params, memory_blocks, Some(thread))?;
+            hash = hash_internal::<D>(pwd, salt, secret, params, memory_blocks, Some(thread))?;
             output.iter_mut().zip(&hash).for_each(|(a, b)| *a ^= b);
-            #[cfg(feature = "zeroize")]
-            hash.zeroize();
         }
 
+        #[cfg(feature = "zeroize")]
+        hash.zeroize();
         output
     };
 


### PR DESCRIPTION
Zeroizing the hash output when cloning.

~~I realized by #310 that we don't really zeroize some leftover bytes. Looking at `argon2` I noticed that zeroizing bytes is behind a crate feature, does that make sense? Considering this is relevant for security, it seems to me making this optional wouldn't make sense.~~

~~Other questions that arose:~~
- ~~Currently a lot of types being returned here don't zeroize on drop. For example, using `hash` returns a `GenericArray`. I was thinking of introducing a type that implements `ZeroizeOnDrop`, but realized maybe this type should be shared among a lot of crates. Should we create a tracking issue and discuss this or should I implement something rudimentary in `balloon-hash` for now?~~
- ~~I noticed that `Digest` doesn't do any zeroizing at all. As far as I understand, the hash state shouldn't be leaked either and all of this should be zeroized when everything's done. Again, is a tracking issue for this appropriate?~~

EDIT: Resolved some questions over Zulip, TLDR, I'm not a cryptographer and what I was intending was most likely overkill.