### PR TITLE
Bump `base64ct` to v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
 name = "bcrypt-pbkdf"

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -348,7 +348,7 @@ mod tests {
     const EXAMPLE_PASSWORD: &[u8] = b"hunter42";
 
     /// Example salt value. Don't use a static salt value!!!
-    const EXAMPLE_SALT: &str = "examplesalt";
+    const EXAMPLE_SALT: &str = "examplesaltvalue";
 
     #[test]
     fn decoded_salt_too_short() {

--- a/balloon-hash/tests/balloon.rs
+++ b/balloon-hash/tests/balloon.rs
@@ -82,7 +82,7 @@ fn hash_simple_retains_configured_params() {
     const EXAMPLE_PASSWORD: &[u8] = b"hunter42";
 
     /// Example salt value. Don't use a static salt value!!!
-    const EXAMPLE_SALT: &str = "examplesalt";
+    const EXAMPLE_SALT: &str = "examplesaltvalue";
 
     // Non-default but valid parameters
     let t_cost = 4;


### PR DESCRIPTION
This version added a check that encoded Base64 is canonical, i.e. that the decoded value will round-trip back to the encoded value.

Some of the test vectors did not have this property and have been fixed.