### PR TITLE
argon2 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64ct",
  "blake2",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2022-06-27)
+### Added
+- `argon2::RECOMMENDED_SALT_LEN` ([#307])
+
+[#307]: https://github.com/RustCrypto/password-hashes/pull/307
+
 ## 0.4.0 (2022-03-18)
 ### Changed
 - Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants


### PR DESCRIPTION
### Added
- `argon2::RECOMMENDED_SALT_LEN` ([#307])

[#307]: https://github.com/RustCrypto/password-hashes/pull/307