### PR TITLE
balloon-hash v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crypto-bigint",
  "digest",

--- a/balloon-hash/CHANGELOG.md
+++ b/balloon-hash/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2022-06-27)
+### Added
+- `Balloon::hash_into` ([#313])
+
+### Changed
+- Make `Error` enum non-exhaustive ([#313])
+
+[#313]: https://github.com/RustCrypto/password-hashes/pull/313
+
 ## 0.2.1 (2022-06-16)
 ### Added
 - `zeroize` feature ([#312])

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.2.1"
+version = "0.3.0"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- `Balloon::hash_into` ([#313])

### Changed
- Make `Error` enum non-exhaustive ([#313])

[#313]: https://github.com/RustCrypto/password-hashes/pull/313