### PR TITLE
doc: Add a link to scrypt's usage example

### DIFF
--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -7,6 +7,8 @@ use password_hash::{Decimal, Error, Ident, Output, PasswordHash, PasswordHasher,
 pub const ALG_ID: Ident = Ident::new_unwrap("scrypt");
 
 /// scrypt type for use with [`PasswordHasher`].
+///
+/// See the [crate docs](crate) for a usage example.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub struct Scrypt;


### PR DESCRIPTION
I ended up on the [`Scrypt` struct's page] while trying to figure out how to use the crate and it wasn't obvious what the associated function to actually hash a password was. This commit adds a link to the crate-level usage example to (hopefully) prevent folks from getting lost like I did.

[`Scrypt` struct's page]: https://docs.rs/scrypt/0.10.0/scrypt/struct.Scrypt.html