### PR TITLE
sha-crypt: enable passwords longer than 64 bytes in length

### DIFF
--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -120,7 +120,7 @@ pub fn sha512_crypt(
 
     // 16.
     // Create byte sequence P.
-    let p_vec = produce_byte_seq(pw_len, &dp, BLOCK_SIZE);
+    let p_vec = produce_byte_seq(pw_len, &dp);
 
     // 17.
     hasher_alt = Sha512::default();
@@ -137,7 +137,7 @@ pub fn sha512_crypt(
 
     // 20.
     // Create byte sequence S.
-    let s_vec = produce_byte_seq(salt_len, &ds, BLOCK_SIZE);
+    let s_vec = produce_byte_seq(salt_len, &ds);
 
     let mut digest_c = digest_a;
     // Repeatedly run the collected hash value through SHA512 to burn
@@ -330,15 +330,15 @@ impl Distribution<char> for ShaCryptDistribution {
     }
 }
 
-fn produce_byte_seq(len: usize, fill_from: &[u8], bs: usize) -> Vec<u8> {
+fn produce_byte_seq(len: usize, fill_from: &[u8]) -> Vec<u8> {
+    let bs = fill_from.len();
     let mut seq: Vec<u8> = vec![0; len];
     let mut offset: usize = 0;
     for _ in 0..(len / bs) {
-        let from_slice = &fill_from[..offset + bs];
-        seq[offset..offset + bs].clone_from_slice(from_slice);
+        seq[offset..offset + bs].clone_from_slice(fill_from);
         offset += bs;
     }
-    let from_slice = &fill_from[..offset + (len % bs)];
+    let from_slice = &fill_from[..(len % bs)];
     seq[offset..offset + (len % bs)].clone_from_slice(from_slice);
     seq
 }

--- a/sha-crypt/tests/lib.rs
+++ b/sha-crypt/tests/lib.rs
@@ -32,6 +32,54 @@ const TEST_VECTORS: &[TestVector] = &[
             "lQ8jolhgVRVhY4b5pZKaysCLi0QBxGoNeKQzQ3glMhwllF7oGDZxUhx1yxdYcz/e1JSbq3y6JMxxl8audkUEm0",
         rounds: 5_000,
     },
+    // 63 length password
+    TestVector {
+        input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        salt: "kf8.jB3ZLrhG2/n1",
+        result:
+            "BZk4ni5Rx3KgyM7vd48EpPgr8AoICCq5HRQPu6vNf6t6xnJ3xNu7MMMBXh/3eUZ5ql.mBqjNhlYUWHBqjKRkU/",
+        rounds: 5_000,
+    },
+    // 64 length password
+    TestVector {
+        input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 64 length
+        salt: "JKb8lkbDWryxdaRL",
+        result:
+            "dLVyYl.G1KhMak97BNNO7vV2upvwcQ3hKrQjO8xn.V/ucmN4ogytaGbIEfBrNv4YLtbpjgV240ldDgkP9M9S7.",
+        rounds: 5_000,
+    },
+    // 65 length password
+    TestVector {
+        input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 65 length
+        salt: "JmlLQtPDXkxMbdFc",
+        result:
+            "lO/BGRK6dKXMaRafyLMZl9wkxvdCobed0ppRHYJtCfatf6yGLghCs.rq.ifz4YezxCHmQG7lpqm4W46xsNnBm0",
+        rounds: 5_000,
+    },
+    // 127 length password
+    TestVector {
+        input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        salt: "/1VCrzVUrr9Nmmkl",
+        result:
+            "zp5KH/GGAMr3pQap8GbQ2Qgp3EjvI4o7kurGx9YNtwzN5eKvuWGuR/LNMa5qANyeHl2ROMMd0WkX24ttkiGIE1",
+        rounds: 5_000,
+    },
+    // 128 length password
+    TestVector {
+        input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        salt: "mpyXfdM3cczHJWG6",
+        result:
+            "vvNL55Todp53rsMLKgBJHsCC2lKj4AwYWWF/ywz7UVqBxj7F00UUI2an7R5amwBTL4DibkvKMb3Oj5dk4I1Y4.",
+        rounds: 5_000,
+    },
+    // 129 length password 
+    TestVector {
+        input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        salt: "idU8Ptdv2tVGArtN",
+        result:
+            "uM8hU3Ot4nmDtcMvMyccUW2vT6uI2cM6MpWDslBlyO0jghVdKYB7RafnmQQPrA8QMauX8qrnX5Fs9ST5y/zUS1",
+        rounds: 5_000,
+    },
 ];
 
 #[test]


### PR DESCRIPTION
1) in produce_byte_seq, the fill_from slice will always be 64 bytes in
   length, due to the SHA512 algorithm digest supplying these bytes

2) produce_byte_seq() was attempting to index the fill_from slice beyond
   the 64 bytes when a password > 64 bytes in length was being used

signed-off-by: Michael Mullin <masmullin@gmail.com>

Addresses: https://github.com/RustCrypto/password-hashes/issues/327