### PR TITLE
scrypt: fix clippy; bump to v0.11.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.10.0"
+version = "0.11.0-pre"
 dependencies = [
  "hmac",
  "password-hash",

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.10.0"
+version = "0.11.0-pre"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/scrypt/benches/lib.rs
+++ b/scrypt/benches/lib.rs
@@ -10,7 +10,7 @@ pub fn scrypt_15_8_1(bh: &mut Bencher) {
     let password = b"my secure password";
     let salt = b"salty salt";
     let mut buf = [0u8; 32];
-    let params = scrypt::Params::new(15, 8, 1).unwrap();
+    let params = scrypt::Params::recommended();
     bh.iter(|| {
         scrypt::scrypt(password, salt, &params, &mut buf).unwrap();
         test::black_box(&buf);


### PR DESCRIPTION
Followup to #255.

This fixes a clippy error and bumps the version to v0.11.0-pre as #255 contained a breaking change.