### PR TITLE
argon2: followups to #247

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "base64ct",
  "blake2",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.4.1"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-// TODO(tarcieri): safe parallel implementation
-// See: https://github.com/RustCrypto/password-hashes/issues/154
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(


### PR DESCRIPTION
- Bump version to `0.5.0-pre` ([#247](https://github.com/RustCrypto/password-hashes/pull/333) contained breaking changes)
- Use pointer casts to convert `Block` integer array to byte array
- Rename `permutate!` to `permute!` (former isn't in OED, latter is)

cc @Pjottos 