### PR TITLE
pbkdf2: remove default `simple` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.9.0"
+version = "0.10.0-pre"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.0-pre"
 dependencies = [
  "digest",
  "hex-literal",

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ rust-version = "1.57"
 
 [dependencies]
 blowfish = { version = "0.9.1", features = ["bcrypt"] }
-pbkdf2 = { version = "0.11", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "=0.12.0-pre", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.10.2", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -30,7 +30,6 @@ sha2 = "0.10"
 streebog = "0.10"
 
 [features]
-default = ["simple"]
 parallel = ["rayon", "std"]
 simple = ["hmac", "password-hash", "sha2"]
 std = ["password-hash/std"]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.57"
 
 [dependencies]
 hmac = "0.12.1"
-pbkdf2 = { version = "0.11", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "=0.12.0-pre", default-features = false, path = "../pbkdf2" }
 salsa20 = { version = "0.10.2", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
I suspect that most users of this crate care about the low-level `pbkdf2` API as opposed to the higher-level password hashing API which implements the PHC string format.

The `simple` API pulls in quite a few dependencies (to the point I'm encountering dependency conflicts).