### PR TITLE
wip: add sha256-crypt

### DIFF
--- a/sha-crypt/src/defs.rs
+++ b/sha-crypt/src/defs.rs
@@ -1,5 +1,8 @@
-/// Block size
-pub const BLOCK_SIZE: usize = 64;
+/// Block size for SHA512
+pub const BLOCK_SIZE_SHA512: usize = 64;
+
+/// Block size for SHA256
+pub const BLOCK_SIZE_SHA256: usize = 32;
 
 /// Maximum length of a salt
 #[cfg(feature = "simple")]
@@ -8,8 +11,8 @@ pub const SALT_MAX_LEN: usize = 16;
 /// Encoding table.
 pub static TAB: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-/// Inverse encoding map.
-pub const MAP: [(u8, u8, u8, u8); 22] = [
+/// Inverse encoding map for SHA512.
+pub const MAP_SHA512: [(u8, u8, u8, u8); 22] = [
     (42, 21, 0, 4),
     (1, 43, 22, 4),
     (23, 2, 44, 4),
@@ -32,4 +35,19 @@ pub const MAP: [(u8, u8, u8, u8); 22] = [
     (19, 61, 40, 4),
     (41, 20, 62, 4),
     (63, 0, 0, 2),
+];
+
+/// Inverse encoding map for SHA256.
+pub const MAP_SHA256: [(u8, u8, u8, u8); 11] = [
+    (20, 10, 0, 4),
+    (11, 1, 21, 4),
+    (2, 22, 12, 4),
+    (23, 13, 3, 4),
+    (14, 4, 24, 4),
+    (5, 25, 15, 4),
+    (26, 16, 6, 4),
+    (17, 7, 27, 4),
+    (8, 28, 18, 4),
+    (29, 19, 9, 4),
+    (30, 31, 0, 3),
 ];

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -50,13 +50,13 @@ mod errors;
 mod params;
 
 pub use crate::{
-    defs::BLOCK_SIZE,
+    defs::{BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512},
     errors::CryptError,
-    params::{Sha512Params, ROUNDS_DEFAULT, ROUNDS_MAX, ROUNDS_MIN},
+    params::{Sha256Params, Sha512Params, ROUNDS_DEFAULT, ROUNDS_MAX, ROUNDS_MIN},
 };
 
 use alloc::{string::String, vec::Vec};
-use sha2::{Digest, Sha512};
+use sha2::{Digest, Sha256, Sha512};
 
 #[cfg(feature = "simple")]
 use {
@@ -72,6 +72,11 @@ use {
 static SHA512_SALT_PREFIX: &str = "$6$";
 #[cfg(feature = "simple")]
 static SHA512_ROUNDS_PREFIX: &str = "rounds=";
+
+#[cfg(feature = "simple")]
+static SHA256_SALT_PREFIX: &str = "$5$";
+#[cfg(feature = "simple")]
+static SHA256_ROUNDS_PREFIX: &str = "rounds=";
 
 /// The SHA512 crypt function returned as byte vector
 ///
@@ -91,7 +96,7 @@ pub fn sha512_crypt(
     password: &[u8],
     salt: &[u8],
     params: &Sha512Params,
-) -> Result<[u8; BLOCK_SIZE], CryptError> {
+) -> Result<[u8; BLOCK_SIZE_SHA512], CryptError> {
     let pw_len = password.len();
 
     let salt_len = salt.len();
@@ -176,6 +181,109 @@ pub fn sha512_crypt(
     Ok(digest_c)
 }
 
+/// The SHA256 crypt function returned as byte vector
+///
+/// If the provided hash is longer than defs::SALT_MAX_LEN character, it will
+/// be stripped down to defs::SALT_MAX_LEN characters.
+///
+/// # Arguments
+/// - `password` - The password to process as a byte vector
+/// - `salt` - The salt value to use as a byte vector
+/// - `params` - The Sha256Params to use
+///   **WARNING: Make sure to compare this value in constant time!**
+///
+/// # Returns
+/// - `Ok(())` if calculation was successful
+/// - `Err(errors::CryptError)` otherwise
+pub fn sha256_crypt(
+    password: &[u8],
+    salt: &[u8],
+    params: &Sha256Params,
+) -> Result<[u8; BLOCK_SIZE_SHA256], CryptError> {
+    let pw_len = password.len();
+
+    let salt_len = salt.len();
+    let salt = match salt_len {
+        0..=15 => &salt[0..salt_len],
+        _ => &salt[0..16],
+    };
+    let salt_len = salt.len();
+
+    if params.rounds < ROUNDS_MIN || params.rounds > ROUNDS_MAX {
+        return Err(CryptError::RoundsError);
+    }
+
+    let digest_a = sha256crypt_intermediate(password, salt);
+
+    // 13.
+    let mut hasher_alt = Sha256::default();
+
+    // 14.
+    for _ in 0..pw_len {
+        hasher_alt.update(password);
+    }
+
+    // 15.
+    let dp = hasher_alt.finalize();
+
+    // 16.
+    // Create byte sequence P.
+    let p_vec = produce_byte_seq(pw_len, &dp);
+
+    // 17.
+    hasher_alt = Sha256::default();
+
+    // 18.
+    // For every character in the password add the entire password.
+    for _ in 0..(16 + digest_a[0] as usize) {
+        hasher_alt.update(salt);
+    }
+
+    // 19.
+    // Finish the digest.
+    let ds = hasher_alt.finalize();
+
+    // 20.
+    // Create byte sequence S.
+    let s_vec = produce_byte_seq(salt_len, &ds);
+
+    let mut digest_c = digest_a;
+    // Repeatedly run the collected hash value through SHA256 to burn
+    // CPU cycles
+    for i in 0..params.rounds as usize {
+        // new hasher
+        let mut hasher = Sha256::default();
+
+        // Add key or last result
+        if (i & 1) != 0 {
+            hasher.update(&p_vec);
+        } else {
+            hasher.update(&digest_c);
+        }
+
+        // Add salt for numbers not divisible by 3
+        if i % 3 != 0 {
+            hasher.update(&s_vec);
+        }
+
+        // Add key for numbers not divisible by 7
+        if i % 7 != 0 {
+            hasher.update(&p_vec);
+        }
+
+        // Add key or last result
+        if (i & 1) != 0 {
+            hasher.update(&digest_c);
+        } else {
+            hasher.update(&p_vec);
+        }
+
+        digest_c.clone_from_slice(&hasher.finalize());
+    }
+
+    Ok(digest_c)
+}
+
 /// Same as sha512_crypt except base64 representation will be returned.
 ///
 /// # Arguments
@@ -193,9 +301,31 @@ pub fn sha512_crypt_b64(
     params: &Sha512Params,
 ) -> Result<String, CryptError> {
     let output = sha512_crypt(password, salt, params)?;
-    let r = String::from_utf8(b64::encode(&output))?;
+    let r = String::from_utf8(b64::encode_sha512(&output))?;
     Ok(r)
 }
+
+/// Same as sha256_crypt except base64 representation will be returned.
+///
+/// # Arguments
+/// - `password` - The password to process as a byte vector
+/// - `salt` - The salt value to use as a byte vector
+/// - `params` - The Sha256Params to use
+///   **WARNING: Make sure to compare this value in constant time!**
+///
+/// # Returns
+/// - `Ok(())` if calculation was successful
+/// - `Err(errors::CryptError)` otherwise
+pub fn sha256_crypt_b64(
+    password: &[u8],
+    salt: &[u8],
+    params: &Sha256Params,
+) -> Result<String, CryptError> {
+    let output = sha256_crypt(password, salt, params)?;
+    let r = String::from_utf8(b64::encode_sha256(&output))?;
+    Ok(r)
+}
+
 
 /// Simple interface for generating a SHA512 password hash.
 ///
@@ -228,7 +358,43 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, Cr
     }
     result.push_str(&salt);
     result.push('$');
-    let s = String::from_utf8(b64::encode(&out))?;
+    let s = String::from_utf8(b64::encode_sha512(&out))?;
+    result.push_str(&s);
+    Ok(result)
+}
+
+/// Simple interface for generating a SHA256 password hash.
+///
+/// The salt will be chosen randomly. The output format will conform to [1].
+///
+///  `$<ID>$<SALT>$<HASH>`
+///
+/// # Returns
+/// - `Ok(String)` containing the full SHA256 password hash format on success
+/// - `Err(CryptError)` if something went wrong.
+///
+/// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
+pub fn sha256_simple(password: &str, params: &Sha256Params) -> Result<String, CryptError> {
+    let rng = thread_rng();
+
+    let salt: String = rng
+        .sample_iter(&ShaCryptDistribution)
+        .take(SALT_MAX_LEN)
+        .collect();
+
+    let out = sha256_crypt(password.as_bytes(), salt.as_bytes(), params)?;
+
+    let mut result = String::new();
+    result.push_str(SHA256_SALT_PREFIX);
+    if params.rounds != ROUNDS_DEFAULT {
+        result.push_str(&format!("{}{}", SHA256_ROUNDS_PREFIX, params.rounds));
+        result.push('$');
+    }
+    result.push_str(&salt);
+    result.push('$');
+    let s = String::from_utf8(b64::encode_sha256(&out))?;
     result.push_str(&s);
     Ok(result)
 }
@@ -303,7 +469,88 @@ pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError
         Err(e) => return Err(CheckError::Crypt(e)),
     };
 
-    let hash = b64::decode(hash.as_bytes())?;
+    let hash = b64::decode_sha512(hash.as_bytes())?;
+
+    use subtle::ConstantTimeEq;
+    if output.ct_eq(&hash).into() {
+        Ok(())
+    } else {
+        Err(CheckError::HashMismatch)
+    }
+}
+
+
+/// Checks that given password matches provided hash.
+///
+/// # Arguments
+/// - `password` - expected password
+/// - `hashed_value` - the hashed value which should be used for checking,
+/// should be of format mentioned in [1]: `$6$<SALT>$<PWD>`
+///
+/// # Return
+/// `OK(())` if password matches otherwise Err(CheckError) in case of invalid
+/// format or password mismatch.
+///
+/// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
+#[cfg(feature = "simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
+pub fn sha256_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
+    let mut iter = hashed_value.split('$');
+
+    // Check that there are no characters before the first "$"
+    if iter.next() != Some("") {
+        return Err(CheckError::InvalidFormat(
+            "Should start with '$".to_string(),
+        ));
+    }
+
+    if iter.next() != Some("5") {
+        return Err(CheckError::InvalidFormat(format!(
+            "does not contain SHA256 identifier: '{}'",
+            SHA256_SALT_PREFIX
+        )));
+    }
+
+    let mut next = iter.next().ok_or_else(|| {
+        CheckError::InvalidFormat("Does not contain a rounds or salt nor hash string".to_string())
+    })?;
+    let rounds = if next.starts_with(SHA256_ROUNDS_PREFIX) {
+        let rounds = next;
+        next = iter.next().ok_or_else(|| {
+            CheckError::InvalidFormat("Does not contain a salt nor hash string".to_string())
+        })?;
+
+        rounds[SHA256_ROUNDS_PREFIX.len()..].parse().map_err(|_| {
+            CheckError::InvalidFormat(format!(
+                "{} specifier need to be a number",
+                SHA256_ROUNDS_PREFIX
+            ))
+        })?
+    } else {
+        ROUNDS_DEFAULT
+    };
+
+    let salt = next;
+
+    let hash = iter
+        .next()
+        .ok_or_else(|| CheckError::InvalidFormat("Does not contain a hash string".to_string()))?;
+
+    // Make sure there is no trailing data after the final "$"
+    if iter.next() != None {
+        return Err(CheckError::InvalidFormat(
+            "Trailing characters present".to_string(),
+        ));
+    }
+
+    let params = Sha256Params { rounds };
+
+    let output = match sha256_crypt(password.as_bytes(), salt.as_bytes(), &params) {
+        Ok(v) => v,
+        Err(e) => return Err(CheckError::Crypt(e)),
+    };
+
+    let hash = b64::decode_sha256(hash.as_bytes())?;
 
     use subtle::ConstantTimeEq;
     if output.ct_eq(&hash).into() {
@@ -343,7 +590,7 @@ fn produce_byte_seq(len: usize, fill_from: &[u8]) -> Vec<u8> {
     seq
 }
 
-fn sha512crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE] {
+fn sha512crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA512] {
     let pw_len = password.len();
 
     let mut hasher = Sha512::default();
@@ -362,11 +609,54 @@ fn sha512crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE] {
     let digest_b = hasher_alt.finalize();
 
     // 9.
-    for _ in 0..(pw_len / BLOCK_SIZE) {
+    for _ in 0..(pw_len / BLOCK_SIZE_SHA512) {
         hasher.update(&digest_b);
     }
     // 10.
-    hasher.update(&digest_b[..(pw_len % BLOCK_SIZE)]);
+    hasher.update(&digest_b[..(pw_len % BLOCK_SIZE_SHA512)]);
+
+    // 11
+    let mut n = pw_len;
+    for _ in 0..pw_len {
+        if n == 0 {
+            break;
+        }
+        if (n & 1) != 0 {
+            hasher.update(&digest_b);
+        } else {
+            hasher.update(password);
+        }
+        n >>= 1;
+    }
+
+    // 12.
+    hasher.finalize().as_slice().try_into().unwrap()
+}
+
+fn sha256crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA256] {
+    let pw_len = password.len();
+
+    let mut hasher = Sha256::default();
+    hasher.update(password);
+    hasher.update(salt);
+
+    // 4.
+    let mut hasher_alt = Sha256::default();
+    // 5.
+    hasher_alt.update(password);
+    // 6.
+    hasher_alt.update(salt);
+    // 7.
+    hasher_alt.update(password);
+    // 8.
+    let digest_b = hasher_alt.finalize();
+
+    // 9.
+    for _ in 0..(pw_len / BLOCK_SIZE_SHA256) {
+        hasher.update(&digest_b);
+    }
+    // 10.
+    hasher.update(&digest_b[..(pw_len % BLOCK_SIZE_SHA256)]);
 
     // 11
     let mut n = pw_len;

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -36,3 +36,28 @@ impl Sha512Params {
         }
     }
 }
+
+/// Algorithm parameters.
+#[derive(Debug, Clone)]
+pub struct Sha256Params {
+    pub(crate) rounds: usize,
+}
+
+impl Default for Sha256Params {
+    fn default() -> Self {
+        Sha256Params {
+            rounds: ROUNDS_DEFAULT,
+        }
+    }
+}
+
+impl Sha256Params {
+    /// Create new algorithm parameters.
+    pub fn new(rounds: usize) -> Result<Sha256Params, errors::CryptError> {
+        if (ROUNDS_MIN..=ROUNDS_MAX).contains(&rounds) {
+            Ok(Sha256Params { rounds })
+        } else {
+            Err(errors::CryptError::RoundsError)
+        }
+    }
+}

--- a/sha-crypt/tests/lib.rs
+++ b/sha-crypt/tests/lib.rs
@@ -1,12 +1,13 @@
-use sha_crypt::{sha512_crypt_b64, Sha512Params, ROUNDS_MAX, ROUNDS_MIN};
+use sha_crypt::{sha256_crypt_b64, sha512_crypt_b64, Sha256Params, Sha512Params, ROUNDS_MAX, ROUNDS_MIN};
 
 #[cfg(feature = "simple")]
-use sha_crypt::{sha512_check, sha512_simple};
+use sha_crypt::{sha256_check, sha256_simple, sha512_check, sha512_simple};
 
 struct TestVector {
     input: &'static str,
     salt: &'static str,
-    result: &'static str,
+    result_sha256: &'static str,
+    result_sha512: &'static str,
     rounds: usize,
 }
 
@@ -14,21 +15,28 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "Hello world!",
         salt: "saltstring",
-        result:
+        result_sha256:
+            "5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5",
+        result_sha512:
             "svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1",
         rounds: 5_000,
     },
     TestVector {
         input: "Hello world!",
         salt: "saltstringsaltstring",
-        result:
+        result_sha256: "3xv.VbSHBb41AL9AvLeujZkZRBAwqFMz2.opqey6IcA",
+        // result here: 3xv.VbSHBb41AL9AvLeujZkZRBAwqFMz2.opqey6Icw
+
+        result_sha512:
             "OW1/O6BYHV6BcXZu8QVeXbDWra3Oeqh0sbHbbMCVNSnCM/UrjmM0Dp8vOuZeHBy/YTBmSK6H9qs/y3RnOaw5v.",
         rounds: 10_000,
     },
     TestVector {
         input: "This is just a test",
         salt: "toolongsaltstring",
-        result:
+        result_sha256:
+            "Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5",
+        result_sha512:
             "lQ8jolhgVRVhY4b5pZKaysCLi0QBxGoNeKQzQ3glMhwllF7oGDZxUhx1yxdYcz/e1JSbq3y6JMxxl8audkUEm0",
         rounds: 5_000,
     },
@@ -36,7 +44,9 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         salt: "kf8.jB3ZLrhG2/n1",
-        result:
+        result_sha256: "DjWX2SQlslxT/jON7Gof6T4UodbHrqW0Lwl7xLT2gu8",
+        // result here: DjWX2SQlslxT/jON7Gof6T4UodbHrqW0Lwl7xLT2gue
+        result_sha512:
             "BZk4ni5Rx3KgyM7vd48EpPgr8AoICCq5HRQPu6vNf6t6xnJ3xNu7MMMBXh/3eUZ5ql.mBqjNhlYUWHBqjKRkU/",
         rounds: 5_000,
     },
@@ -44,7 +54,8 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 64 length
         salt: "JKb8lkbDWryxdaRL",
-        result:
+        result_sha256: "X2024tVMdQy9vnRU/dnWB0eL4dpfJvgD3g9o0eE95d7",
+        result_sha512:
             "dLVyYl.G1KhMak97BNNO7vV2upvwcQ3hKrQjO8xn.V/ucmN4ogytaGbIEfBrNv4YLtbpjgV240ldDgkP9M9S7.",
         rounds: 5_000,
     },
@@ -52,7 +63,9 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 65 length
         salt: "JmlLQtPDXkxMbdFc",
-        result:
+        result_sha256: "MVZTo9AdKikQwK5sBlSQ/X7mUH19GoFGrmRr0XxcUr6",
+        // result here: MVZTo9AdKikQwK5sBlSQ/X7mUH19GoFGrmRr0XxcUrc
+        result_sha512:
             "lO/BGRK6dKXMaRafyLMZl9wkxvdCobed0ppRHYJtCfatf6yGLghCs.rq.ifz4YezxCHmQG7lpqm4W46xsNnBm0",
         rounds: 5_000,
     },
@@ -60,7 +73,8 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         salt: "/1VCrzVUrr9Nmmkl",
-        result:
+        result_sha256: "SzBUUlAa0OOcJ4RkWAEcxPCu9KvgM3XV2Wt1Or7Qnm9",
+        result_sha512:
             "zp5KH/GGAMr3pQap8GbQ2Qgp3EjvI4o7kurGx9YNtwzN5eKvuWGuR/LNMa5qANyeHl2ROMMd0WkX24ttkiGIE1",
         rounds: 5_000,
     },
@@ -68,7 +82,9 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         salt: "mpyXfdM3cczHJWG6",
-        result:
+        result_sha256: "mDy6Ir4NZkSLjfI1jo.P8FQDl5cf51ZpOYO9VAiYzK2",
+        // result here: mDy6Ir4NZkSLjfI1jo.P8FQDl5cf51ZpOYO9VAiYzKo
+        result_sha512:
             "vvNL55Todp53rsMLKgBJHsCC2lKj4AwYWWF/ywz7UVqBxj7F00UUI2an7R5amwBTL4DibkvKMb3Oj5dk4I1Y4.",
         rounds: 5_000,
     },
@@ -76,7 +92,9 @@ const TEST_VECTORS: &[TestVector] = &[
     TestVector {
         input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         salt: "idU8Ptdv2tVGArtN",
-        result:
+        result_sha256: "mijVpmWD4y0vuT.2Ux0XMwvpis59xfeu3Mhm1TIK7T9",
+        // result here: mijVpmWD4y0vuT.2Ux0XMwvpis59xfeu3Mhm1TIK7Tf
+        result_sha512:
             "uM8hU3Ot4nmDtcMvMyccUW2vT6uI2cM6MpWDslBlyO0jghVdKYB7RafnmQQPrA8QMauX8qrnX5Fs9ST5y/zUS1",
         rounds: 5_000,
     },
@@ -87,9 +105,19 @@ fn test_sha512_crypt() {
     for t in TEST_VECTORS {
         let params = Sha512Params::new(t.rounds).expect("Rounds error");
         let result = sha512_crypt_b64(t.input.as_bytes(), t.salt.as_bytes(), &params).unwrap();
-        assert!(result == t.result);
+        assert!(result == t.result_sha512);
     }
 }
+
+#[test]
+fn test_sha256_crypt() {
+    for t in TEST_VECTORS {
+        let params = Sha256Params::new(t.rounds).expect("Rounds error");
+        let result = sha256_crypt_b64(t.input.as_bytes(), t.salt.as_bytes(), &params).unwrap();
+        assert!(result == t.result_sha256);
+    }
+}
+
 
 #[test]
 fn test_sha512_crypt_invalid_rounds() {
@@ -97,6 +125,15 @@ fn test_sha512_crypt_invalid_rounds() {
     assert!(params.is_err());
 
     let params = Sha512Params::new(ROUNDS_MIN - 1);
+    assert!(params.is_err());
+}
+
+#[test]
+fn test_sha256_crypt_invalid_rounds() {
+    let params = Sha256Params::new(ROUNDS_MAX + 1);
+    assert!(params.is_err());
+
+    let params = Sha256Params::new(ROUNDS_MIN - 1);
     assert!(params.is_err());
 }
 
@@ -110,11 +147,28 @@ fn test_sha512_check() {
 
 #[cfg(feature = "simple")]
 #[test]
+fn test_sha256_check() {
+    let pw = "foobar";
+    let s = "$5$9aEeVXnCiCNHUjO/$FrVBcjyJukRaE6inMYazyQv1DBnwaKfom.71ebgQR/0";
+    assert!(sha256_check(pw, s).is_ok());
+}
+
+#[cfg(feature = "simple")]
+#[test]
 fn test_sha512_check_with_rounds() {
     let pw = "foobar";
     let s = "$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
     assert!(sha512_check(pw, s).is_ok());
 }
+
+#[cfg(feature = "simple")]
+#[test]
+fn test_sha256_check_with_rounds() {
+    let pw = "foobar";
+    let s = "$5$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
+    assert!(sha256_check(pw, s).is_ok());
+}
+
 
 #[cfg(feature = "simple")]
 #[test]
@@ -132,11 +186,34 @@ fn test_sha512_simple_check_roundtrip() {
 
 #[cfg(feature = "simple")]
 #[test]
+fn test_sha256_simple_check_roundtrip() {
+    let pw = "this is my password";
+    let params = Sha256Params::new(5_000).expect("Rounds error");
+
+    let r = sha256_simple(&pw, &params);
+    assert!(r.is_ok());
+    let hash = r.unwrap();
+
+    let c_r = sha256_check(&pw, &hash);
+    assert!(c_r.is_ok());
+}
+
+#[cfg(feature = "simple")]
+#[test]
 fn test_sha512_unexpected_prefix() {
     let pw = "foobar";
     let s = "SHOULDNOTBEHERE$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
     assert!(!sha512_check(pw, s).is_ok());
 }
+
+#[cfg(feature = "simple")]
+#[test]
+fn test_sha256_unexpected_prefix() {
+    let pw = "foobar";
+    let s = "SHOULDNOTBEHERE$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
+    assert!(!sha256_check(pw, s).is_ok());
+}
+
 
 #[cfg(feature = "simple")]
 #[test]
@@ -149,9 +226,27 @@ fn test_sha512_wrong_id() {
 
 #[cfg(feature = "simple")]
 #[test]
+fn test_sha256_wrong_id() {
+    // wrong id '7'
+    let pw = "foobar";
+    let s = "$7$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
+    assert!(!sha256_check(pw, s).is_ok());
+}
+
+#[cfg(feature = "simple")]
+#[test]
 fn test_sha512_missing_trailing_slash() {
     // Missing trailing slash
     let pw = "abc";
     let s = "$6$rounds=656000$Ykk6fjI2sU3/uprV$Z6yV/9Z741lfroSSzB9MwxSRnGeI9Z74hBkgNsHuojQJxZ9XjPkHg9jqqGLvWZ586wqnSSx5vrXZdhrMSZZE4";
     assert!(!sha512_check(pw, s).is_ok());
+}
+
+#[cfg(feature = "simple")]
+#[test]
+fn test_sha256_missing_trailing_slash() {
+    // Missing trailing slash
+    let pw = "abc";
+    let s = "$6$rounds=656000$Ykk6fjI2sU3/uprV$Z6yV/9Z741lfroSSzB9MwxSRnGeI9Z74hBkgNsHuojQJxZ9XjPkHg9jqqGLvWZ586wqnSSx5vrXZdhrMSZZE4";
+    assert!(!sha256_check(pw, s).is_ok());
 }


### PR DESCRIPTION
This does not yet work correctly.  It fails some tests because the b64-functions don't work.  One byte is always wrong.  I triple-checked that I translated the table in https://akkadia.org/drepper/SHA-crypt.txt correctly (search for "base-64 encoded final C digest").  Unfortunately, I cannot find the error in the algorithm.

I would appreciate some help.

I will also have a look if it's possible to refactor the implementations so they share more code.