### PR TITLE
WIP: use base64ct for sha-crypt base64 en-/decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "argon2"
 version = "0.5.0-pre"
 dependencies = [
- "base64ct",
+ "base64ct 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
  "hex-literal",
  "password-hash",
@@ -37,6 +37,11 @@ name = "base64ct"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
+
+[[package]]
+name = "base64ct"
+version = "1.5.2"
+source = "git+https://github.com/ibotty/rustcrypto-formats.git?branch=shacrypt#64577eb34b3ec68a836e9f3b0abb8bbc4dffce4a"
 
 [[package]]
 name = "bcrypt-pbkdf"
@@ -281,7 +286,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
- "base64ct",
+ "base64ct 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core",
  "subtle",
 ]
@@ -400,6 +405,7 @@ dependencies = [
 name = "sha-crypt"
 version = "0.4.0"
 dependencies = [
+ "base64ct 1.5.2 (git+https://github.com/ibotty/rustcrypto-formats.git?branch=shacrypt)",
  "rand",
  "sha2",
  "subtle",

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { version = "0.10", default-features = false }
 # optional dependencies
 rand = { version = "0.8", optional = true }
 subtle = { version = ">=2, <2.5", optional = true, default-features = false }
+base64ct = { git = "https://github.com/ibotty/rustcrypto-formats", branch = "shacrypt" }
 
 [features]
 default = ["simple"]

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = { version = "0.10", default-features = false }
 # optional dependencies
 rand = { version = "0.8", optional = true }
 subtle = { version = ">=2, <2.5", optional = true, default-features = false }
-base64ct = { git = "https://github.com/ibotty/rustcrypto-formats", branch = "shacrypt" }
+base64ct = { git = "https://github.com/ibotty/rustcrypto-formats", rev = "c0df69f7028cba1016018d7a57a89fb95cd22f83" }
 
 [features]
 default = ["simple"]

--- a/sha-crypt/src/b64.rs
+++ b/sha-crypt/src/b64.rs
@@ -1,64 +1,41 @@
 //! Base64 encoding support
 
-use crate::defs::{MAP, TAB};
+use crate::defs::{BLOCK_SIZE, MAP_SHA512, PW_SIZE_SHA512};
 use alloc::vec::Vec;
+use base64ct::{Base64ShaCrypt, Encoding};
+
 
 #[cfg(feature = "simple")]
 use crate::errors::DecodeError;
 
-pub fn encode(source: &[u8]) -> Vec<u8> {
-    let mut out: Vec<u8> = vec![];
-    for entry in &MAP {
-        let mut w: usize = 0;
-        if entry.3 > 2 {
-            w |= source[entry.2 as usize] as usize;
-            w <<= 8;
-            w |= source[entry.1 as usize] as usize;
-            w <<= 8;
-        }
-        w |= source[entry.0 as usize] as usize;
-
-        for _ in 0..entry.3 {
-            out.push(TAB[(w & 0x3f) as usize]);
-            w >>= 6;
-        }
+pub fn encode_sha512(source: &[u8]) -> Vec<u8> {
+    const BUF_SIZE: usize = PW_SIZE_SHA512;
+    let mut transposed = [0u8; BLOCK_SIZE];
+    for (i, &ti) in MAP_SHA512.iter().enumerate() {
+        transposed[i] = source[ti as usize];
     }
-    out
+    let mut buf = [0u8; BUF_SIZE];
+    Base64ShaCrypt::encode(&transposed, &mut buf).unwrap();
+    buf.to_vec()
 }
 
 #[cfg(feature = "simple")]
-pub fn decode(source: &[u8]) -> Result<Vec<u8>, DecodeError> {
-    let mut out: [u8; 64] = [0; 64];
+pub fn decode_sha512(source: &[u8]) -> Result<Vec<u8>, DecodeError> {
+    const BUF_SIZE: usize = 86;
+    let mut buf = [0u8; BUF_SIZE];
+    Base64ShaCrypt::decode(&source, &mut buf).map_err(|_| DecodeError)?;
 
-    for iter in MAP.iter().enumerate() {
-        let (i, entry) = iter;
-
-        let mut w: usize = 0;
-
-        for k in (0..entry.3).rev() {
-            let byte = source.get(i * 4 + k as usize).ok_or(DecodeError)?;
-            let pos = TAB.iter().position(|x| x == byte).ok_or(DecodeError)?;
-            w <<= 6;
-            w |= pos as usize;
-        }
-
-        out[entry.0 as usize] = (w & 0xff) as u8;
-        w >>= 8;
-
-        if entry.3 > 2 {
-            out[entry.1 as usize] = (w & 0xff) as u8;
-            w >>= 8;
-            out[entry.2 as usize] = (w & 0xff) as u8;
-        }
+    let mut transposed = [0u8; BLOCK_SIZE];
+    for (i, &ti) in MAP_SHA512.iter().enumerate() {
+        transposed[ti as usize] = buf[i];
     }
-
-    Ok(out.to_vec())
+    Ok(transposed.to_vec())
 }
 
 mod tests {
     #[cfg(feature = "simple")]
     #[test]
-    fn test_encode_decode() {
+    fn test_encode_decode_sha512() {
         let original: [u8; 64] = [
             0x0b, 0x5b, 0xdf, 0x7d, 0x92, 0xe2, 0xfc, 0xbd, 0xab, 0x57, 0xcb, 0xf3, 0xe0, 0x03,
             0x16, 0x62, 0xd3, 0x6e, 0xa0, 0x57, 0x44, 0x8c, 0xca, 0x35, 0xec, 0x80, 0x75, 0x2a,
@@ -67,8 +44,8 @@ mod tests {
             0x5f, 0xaf, 0x1a, 0xe5, 0x08, 0xe7, 0x7d, 0xd4,
         ];
 
-        let e = super::encode(&original);
-        let d = super::decode(&e).unwrap();
+        let e = super::encode_sha512(&original);
+        let d = super::decode_sha512(&e).unwrap();
 
         for i in 0..d.len() {
             assert_eq!(&original[i], &d[i]);

--- a/sha-crypt/src/defs.rs
+++ b/sha-crypt/src/defs.rs
@@ -1,35 +1,39 @@
-/// Block size
+/// Block size for SHA512
 pub const BLOCK_SIZE: usize = 64;
+
+/// PWD part length of the password string of sha-512
+pub const PW_SIZE_SHA512: usize = 86;
 
 /// Maximum length of a salt
 #[cfg(feature = "simple")]
 pub const SALT_MAX_LEN: usize = 16;
 
 /// Encoding table.
+#[cfg(feature = "simple")]
 pub static TAB: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-/// Inverse encoding map.
-pub const MAP: [(u8, u8, u8, u8); 22] = [
-    (42, 21, 0, 4),
-    (1, 43, 22, 4),
-    (23, 2, 44, 4),
-    (45, 24, 3, 4),
-    (4, 46, 25, 4),
-    (26, 5, 47, 4),
-    (48, 27, 6, 4),
-    (7, 49, 28, 4),
-    (29, 8, 50, 4),
-    (51, 30, 9, 4),
-    (10, 52, 31, 4),
-    (32, 11, 53, 4),
-    (54, 33, 12, 4),
-    (13, 55, 34, 4),
-    (35, 14, 56, 4),
-    (57, 36, 15, 4),
-    (16, 58, 37, 4),
-    (38, 17, 59, 4),
-    (60, 39, 18, 4),
-    (19, 61, 40, 4),
-    (41, 20, 62, 4),
-    (63, 0, 0, 2),
+/// Inverse encoding map for SHA512.
+pub const MAP_SHA512: [u8; 64] = [
+    42, 21, 0,
+    1, 43, 22,
+    23, 2, 44,
+    45, 24, 3,
+    4, 46, 25,
+    26, 5, 47,
+    48, 27, 6,
+    7, 49, 28,
+    29, 8, 50,
+    51, 30, 9,
+    10, 52, 31,
+    32, 11, 53,
+    54, 33, 12,
+    13, 55, 34,
+    35, 14, 56,
+    57, 36, 15,
+    16, 58, 37,
+    38, 17, 59,
+    60, 39, 18,
+    19, 61, 40,
+    41, 20, 62,
+    63,
 ];

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -193,7 +193,7 @@ pub fn sha512_crypt_b64(
     params: &Sha512Params,
 ) -> Result<String, CryptError> {
     let output = sha512_crypt(password, salt, params)?;
-    let r = String::from_utf8(b64::encode(&output))?;
+    let r = String::from_utf8(b64::encode_sha512(&output))?;
     Ok(r)
 }
 
@@ -228,7 +228,7 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> Result<String, Cr
     }
     result.push_str(&salt);
     result.push('$');
-    let s = String::from_utf8(b64::encode(&out))?;
+    let s = String::from_utf8(b64::encode_sha512(&out))?;
     result.push_str(&s);
     Ok(result)
 }
@@ -303,7 +303,7 @@ pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError
         Err(e) => return Err(CheckError::Crypt(e)),
     };
 
-    let hash = b64::decode(hash.as_bytes())?;
+    let hash = b64::decode_sha512(hash.as_bytes())?;
 
     use subtle::ConstantTimeEq;
     if output.ct_eq(&hash).into() {


### PR DESCRIPTION
This needs RustCrypto/formats#738 so it points the `base64ct` dependency to the PR's repo instead.  If accepted and a new release of `base64ct` is done, this should be updated.