### PR TITLE
`bcrypt-pbkdf` without `alloc`

### DIFF
--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -22,5 +22,6 @@ zeroize = { version = "1", default-features = false, optional = true }
 hex-literal = "0.3.3"
 
 [features]
-default = ["std"]
+default = ["alloc", "std"]
+alloc = []
 std = []

--- a/bcrypt-pbkdf/src/errors.rs
+++ b/bcrypt-pbkdf/src/errors.rs
@@ -9,6 +9,8 @@ pub enum Error {
     InvalidRounds,
     /// The output parameter has an invalid length.
     InvalidOutputLen,
+    /// The manually provided memory was not long enough.
+    InvalidMemoryLen,
 }
 
 impl fmt::Display for Error {
@@ -17,6 +19,7 @@ impl fmt::Display for Error {
             Error::InvalidParamLen => write!(f, "Invalid parameter length"),
             Error::InvalidRounds => write!(f, "Invalid number of rounds"),
             Error::InvalidOutputLen => write!(f, "Invalid output length"),
+            Error::InvalidMemoryLen => write!(f, "Invalid memory length"),
         }
     }
 }

--- a/bcrypt-pbkdf/tests/test_vectors.rs
+++ b/bcrypt-pbkdf/tests/test_vectors.rs
@@ -1,6 +1,6 @@
 extern crate bcrypt_pbkdf;
 
-use bcrypt_pbkdf::bcrypt_pbkdf;
+use bcrypt_pbkdf::bcrypt_pbkdf_with_memory;
 
 #[test]
 fn test_openbsd_vectors() {
@@ -70,7 +70,8 @@ fn test_openbsd_vectors() {
 
     for t in tests.iter() {
         let mut out = vec![0; t.out.len()];
-        bcrypt_pbkdf(t.password, &t.salt[..], t.rounds, &mut out).unwrap();
+        let mut memory = vec![0; (t.out.len() + 32 - 1) / 32 * 32];
+        bcrypt_pbkdf_with_memory(t.password, &t.salt[..], t.rounds, &mut out, &mut memory).unwrap();
         assert_eq!(out, t.out);
     }
 }


### PR DESCRIPTION
I'm using `bcrypt-pbkdf` in an embedded context without a global allocator. To support this, I added a new function `bcrypt_pbkdf_with_memory`, which takes in an additional memory buffer argument (similar to some of the other crates in this repo with an optional alloc feature).