### PR TITLE
Disable default feature (i.e. alloc) of zeroize in argon2

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -21,7 +21,7 @@ blake2 = { version = "0.10.6", default-features = false }
 
 # optional dependencies
 password-hash = { version = "=0.5.0-pre.0", optional = true }
-zeroize = { version = "1", optional = true }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
zeroize is not used on Vec or String types for argon2, so removing the default alloc feature allows the zeroize feature to be enabled in argon2 for no-std targets.