### PR TITLE
pbkdf2: make public PBKDF2 Ident values

### DIFF
--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -95,10 +95,7 @@ pub use password_hash;
 mod simple;
 
 #[cfg(feature = "simple")]
-pub use crate::simple::{Algorithm, Params, Pbkdf2, PBKDF2_SHA256_IDENT, PBKDF2_SHA512_IDENT};
-
-#[cfg(all(feature = "simple", feature = "sha1"))]
-pub use crate::simple::PBKDF2_SHA1_IDENT;
+pub use crate::simple::{Algorithm, Params, Pbkdf2};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -95,10 +95,10 @@ pub use password_hash;
 mod simple;
 
 #[cfg(feature = "simple")]
-pub use crate::simple::{Algorithm, Params, Pbkdf2, PBKDF2_SHA256, PBKDF2_SHA512};
+pub use crate::simple::{Algorithm, Params, Pbkdf2, PBKDF2_SHA256_IDENT, PBKDF2_SHA512_IDENT};
 
 #[cfg(all(feature = "simple", feature = "sha1"))]
-pub use crate::simple::PBKDF2_SHA1;
+pub use crate::simple::PBKDF2_SHA1_IDENT;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -95,7 +95,10 @@ pub use password_hash;
 mod simple;
 
 #[cfg(feature = "simple")]
-pub use crate::simple::{Algorithm, Params, Pbkdf2};
+pub use crate::simple::{Algorithm, Params, Pbkdf2, PBKDF2_SHA256, PBKDF2_SHA512};
+
+#[cfg(all(feature = "simple", feature = "sha1"))]
+pub use crate::simple::PBKDF2_SHA1;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -11,16 +11,6 @@ use sha2::{Sha256, Sha512};
 #[cfg(feature = "sha1")]
 use sha1::Sha1;
 
-/// PBKDF2 (SHA-1)
-#[cfg(feature = "sha1")]
-pub const PBKDF2_SHA1_IDENT: Ident = Ident::new_unwrap("pbkdf2");
-
-/// PBKDF2 (SHA-256)
-pub const PBKDF2_SHA256_IDENT: Ident = Ident::new_unwrap("pbkdf2-sha256");
-
-/// PBKDF2 (SHA-512)
-pub const PBKDF2_SHA512_IDENT: Ident = Ident::new_unwrap("pbkdf2-sha512");
-
 /// PBKDF2 type for use with [`PasswordHasher`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
@@ -37,7 +27,7 @@ impl PasswordHasher for Pbkdf2 {
         params: Params,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>> {
-        let algorithm = Algorithm::try_from(alg_id.unwrap_or(PBKDF2_SHA256_IDENT))?;
+        let algorithm = Algorithm::try_from(alg_id.unwrap_or(Algorithm::PBKDF2_SHA256_IDENT))?;
 
         // Versions unsupported
         if version.is_some() {
@@ -90,6 +80,16 @@ pub enum Algorithm {
 }
 
 impl Algorithm {
+    /// PBKDF2 (SHA-1) algorithm identifier
+    #[cfg(feature = "sha1")]
+    pub const PBKDF2_SHA1_IDENT: Ident<'static> = Ident::new_unwrap("pbkdf2");
+
+    /// PBKDF2 (SHA-256) algorithm identifier
+    pub const PBKDF2_SHA256_IDENT: Ident<'static> = Ident::new_unwrap("pbkdf2-sha256");
+
+    /// PBKDF2 (SHA-512) algorithm identifier
+    pub const PBKDF2_SHA512_IDENT: Ident<'static> = Ident::new_unwrap("pbkdf2-sha512");
+
     /// Parse an [`Algorithm`] from the provided string.
     pub fn new(id: impl AsRef<str>) -> Result<Self> {
         id.as_ref().parse()
@@ -99,9 +99,9 @@ impl Algorithm {
     pub fn ident(&self) -> Ident<'static> {
         match self {
             #[cfg(feature = "sha1")]
-            Algorithm::Pbkdf2Sha1 => PBKDF2_SHA1_IDENT,
-            Algorithm::Pbkdf2Sha256 => PBKDF2_SHA256_IDENT,
-            Algorithm::Pbkdf2Sha512 => PBKDF2_SHA512_IDENT,
+            Algorithm::Pbkdf2Sha1 => Self::PBKDF2_SHA1_IDENT,
+            Algorithm::Pbkdf2Sha256 => Self::PBKDF2_SHA256_IDENT,
+            Algorithm::Pbkdf2Sha512 => Self::PBKDF2_SHA512_IDENT,
         }
     }
 
@@ -143,9 +143,9 @@ impl<'a> TryFrom<Ident<'a>> for Algorithm {
     fn try_from(ident: Ident<'a>) -> Result<Algorithm> {
         match ident {
             #[cfg(feature = "sha1")]
-            PBKDF2_SHA1_IDENT => Ok(Algorithm::Pbkdf2Sha1),
-            PBKDF2_SHA256_IDENT => Ok(Algorithm::Pbkdf2Sha256),
-            PBKDF2_SHA512_IDENT => Ok(Algorithm::Pbkdf2Sha512),
+            Self::PBKDF2_SHA1_IDENT => Ok(Algorithm::Pbkdf2Sha1),
+            Self::PBKDF2_SHA256_IDENT => Ok(Algorithm::Pbkdf2Sha256),
+            Self::PBKDF2_SHA512_IDENT => Ok(Algorithm::Pbkdf2Sha512),
             _ => Err(Error::Algorithm),
         }
     }

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -13,13 +13,13 @@ use sha1::Sha1;
 
 /// PBKDF2 (SHA-1)
 #[cfg(feature = "sha1")]
-pub const PBKDF2_SHA1: Ident = Ident::new_unwrap("pbkdf2");
+pub const PBKDF2_SHA1_IDENT: Ident = Ident::new_unwrap("pbkdf2");
 
 /// PBKDF2 (SHA-256)
-pub const PBKDF2_SHA256: Ident = Ident::new_unwrap("pbkdf2-sha256");
+pub const PBKDF2_SHA256_IDENT: Ident = Ident::new_unwrap("pbkdf2-sha256");
 
 /// PBKDF2 (SHA-512)
-pub const PBKDF2_SHA512: Ident = Ident::new_unwrap("pbkdf2-sha512");
+pub const PBKDF2_SHA512_IDENT: Ident = Ident::new_unwrap("pbkdf2-sha512");
 
 /// PBKDF2 type for use with [`PasswordHasher`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -37,7 +37,7 @@ impl PasswordHasher for Pbkdf2 {
         params: Params,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>> {
-        let algorithm = Algorithm::try_from(alg_id.unwrap_or(PBKDF2_SHA256))?;
+        let algorithm = Algorithm::try_from(alg_id.unwrap_or(PBKDF2_SHA256_IDENT))?;
 
         // Versions unsupported
         if version.is_some() {
@@ -99,9 +99,9 @@ impl Algorithm {
     pub fn ident(&self) -> Ident<'static> {
         match self {
             #[cfg(feature = "sha1")]
-            Algorithm::Pbkdf2Sha1 => PBKDF2_SHA1,
-            Algorithm::Pbkdf2Sha256 => PBKDF2_SHA256,
-            Algorithm::Pbkdf2Sha512 => PBKDF2_SHA512,
+            Algorithm::Pbkdf2Sha1 => PBKDF2_SHA1_IDENT,
+            Algorithm::Pbkdf2Sha256 => PBKDF2_SHA256_IDENT,
+            Algorithm::Pbkdf2Sha512 => PBKDF2_SHA512_IDENT,
         }
     }
 
@@ -143,9 +143,9 @@ impl<'a> TryFrom<Ident<'a>> for Algorithm {
     fn try_from(ident: Ident<'a>) -> Result<Algorithm> {
         match ident {
             #[cfg(feature = "sha1")]
-            PBKDF2_SHA1 => Ok(Algorithm::Pbkdf2Sha1),
-            PBKDF2_SHA256 => Ok(Algorithm::Pbkdf2Sha256),
-            PBKDF2_SHA512 => Ok(Algorithm::Pbkdf2Sha512),
+            PBKDF2_SHA1_IDENT => Ok(Algorithm::Pbkdf2Sha1),
+            PBKDF2_SHA256_IDENT => Ok(Algorithm::Pbkdf2Sha256),
+            PBKDF2_SHA512_IDENT => Ok(Algorithm::Pbkdf2Sha512),
             _ => Err(Error::Algorithm),
         }
     }


### PR DESCRIPTION
For RustCrypto members

Thank you for developing a awesome crate!

I have a question.

Why do the other crates maintained by this repository have published Ident values, but not in `pbkdf2`?

Looking at the code, it seems that there is an intention to publish it, but it is not available because there is no `use` declaration.

If you just forgot to publish it, I would appreciate it if you could merge this PR and make it available.
