### PR TITLE
argon2: adopt OWASP recommendations

### DIFF
--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -39,7 +39,7 @@ pub struct Params {
 
 impl Params {
     /// Default memory cost.
-    pub const DEFAULT_M_COST: u32 = 4096;
+    pub const DEFAULT_M_COST: u32 = 19 * 1024;
 
     /// Minimum number of 1 KiB memory blocks.
     #[allow(clippy::cast_possible_truncation)]
@@ -49,7 +49,7 @@ impl Params {
     pub const MAX_M_COST: u32 = 0x0FFFFFFF;
 
     /// Default number of iterations (i.e. "time").
-    pub const DEFAULT_T_COST: u32 = 3;
+    pub const DEFAULT_T_COST: u32 = 2;
 
     /// Minimum number of passes.
     pub const MIN_T_COST: u32 = 1;


### PR DESCRIPTION
Adopts the recommended settings from:

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

> Use Argon2id with a minimum configuration of 19 MiB of memory, an
> iteration count of 2, and 1 degree of parallelism.