### PR TITLE
scrypt: adopt OWASP recommendations

### DIFF
--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -17,7 +17,7 @@ pub struct Params {
 
 impl Params {
     /// Recommended log₂ of the Scrypt parameter `N`: CPU/memory cost.
-    pub const RECOMMENDED_LOG_N: u8 = 15;
+    pub const RECOMMENDED_LOG_N: u8 = 17;
 
     /// Recommended Scrypt parameter `r`: block size.
     pub const RECOMMENDED_R: u32 = 8;


### PR DESCRIPTION
Adopts the recommended settings from:

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

> use scrypt with a minimum CPU/memory cost parameter of (2^17),
> a minimum block size of 8 (1024 bytes), and a parallelization
> parameter of 1.