### PR TITLE
pbkdf2: adopt OWASP recommendations

### DIFF
--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -153,9 +153,9 @@ where
 /// use sha2::Sha256;
 ///
 /// let mut buf = [0u8; 20];
-/// pbkdf2::<Hmac<Sha256>>(b"password", b"salt", 4096, &mut buf)
+/// pbkdf2::<Hmac<Sha256>>(b"password", b"salt", 600_000, &mut buf)
 ///     .expect("HMAC can be initialized with any key length");
-/// assert_eq!(buf, hex!("c5e478d59288c841aa530db6845c4c8d962893a0"));
+/// assert_eq!(buf, hex!("669cfe52482116fda1aa2cbe409b2f56c8e45637"));
 /// ```
 #[inline]
 pub fn pbkdf2<PRF>(

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -27,7 +27,7 @@ impl PasswordHasher for Pbkdf2 {
         params: Params,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>> {
-        let algorithm = Algorithm::try_from(alg_id.unwrap_or(Algorithm::PBKDF2_SHA256_IDENT))?;
+        let algorithm = Algorithm::try_from(alg_id.unwrap_or(Algorithm::default().ident()))?;
 
         // Versions unsupported
         if version.is_some() {
@@ -77,6 +77,18 @@ pub enum Algorithm {
 
     /// PBKDF2 SHA-512
     Pbkdf2Sha512,
+}
+
+impl Default for Algorithm {
+    /// Default suggested by the [OWASP cheat sheet]:
+    ///
+    /// > Use PBKDF2 with a work factor of 600,000 or more and set with an
+    /// > internal hash function of HMAC-SHA-256.
+    ///
+    /// [OWASP cheat sheet]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+    fn default() -> Self {
+        Self::Pbkdf2Sha256
+    }
 }
 
 impl Algorithm {
@@ -160,6 +172,17 @@ pub struct Params {
 
     /// Size of the output (in bytes)
     pub output_length: usize,
+}
+
+impl Params {
+    /// Recommended number of PBKDF2 rounds (used by default).
+    ///
+    /// This number is adopted from the [OWASP cheat sheet]:
+    ///
+    /// > Use PBKDF2 with a work factor of 600,000 or more
+    ///
+    /// [OWASP cheat sheet]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+    pub const RECOMMENDED_ROUNDS: usize = 600_000;
 }
 
 impl Default for Params {


### PR DESCRIPTION
Adopts the recommended settings from:

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

> use PBKDF2 with a work factor of 600,000 or more and set with an
> internal hash function of HMAC-SHA-256.