### PR TITLE
sha-crypt: relax `subtle` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "base64ct",
  "rand",

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library
@@ -20,7 +20,7 @@ sha2 = { version = "0.10", default-features = false }
 
 # optional dependencies
 rand = { version = "0.8", optional = true }
-subtle = { version = ">=2, <2.5", optional = true, default-features = false }
+subtle = { version = "2", optional = true, default-features = false }
 base64ct = "1.5.3"
 
 [features]


### PR DESCRIPTION
It was pinned to preserve MSRV, but that creates huge compatibility headaches for downstream users