### PR TITLE
argon2 v0.5.0

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/password-auth.yml
+++ b/.github/workflows/password-auth.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.5.0-pre.0"
+version = "0.5.0"
 dependencies = [
  "base64ct",
  "blake2",

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Collection of password hashing algorithms, otherwise known as password-based key
 
 ## Supported Algorithms
 
-| Algorithm      | Crate            | Crates.io                                                                                               | Documentation |          MSRV           |
-|----------------|------------------|---------------------------------------------------------------------------------------------------------|---------------|-------------------------|
-| [Argon2]       | [`argon2`]       | [![crates.io](https://img.shields.io/crates/v/argon2.svg)](https://crates.io/crates/argon2)             | [![Documentation](https://docs.rs/argon2/badge.svg)](https://docs.rs/argon2) | ![MSRV 1.57][msrv-1.57] |
-| [Balloon]      | [`balloon‑hash`] | [![crates.io](https://img.shields.io/crates/v/balloon-hash.svg)](https://crates.io/crates/balloon-hash) | [![Documentation](https://docs.rs/balloon-hash/badge.svg)](https://docs.rs/balloon-hash) | ![MSRV 1.57][msrv-1.57] |
-| [bcrypt‑pbkdf] | [`bcrypt‑pbkdf`] | [![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) | ![MSRV 1.57][msrv-1.57] |
-| [PBKDF2]       | [`pbkdf2`]       | [![crates.io](https://img.shields.io/crates/v/pbkdf2.svg)](https://crates.io/crates/pbkdf2)             | [![Documentation](https://docs.rs/pbkdf2/badge.svg)](https://docs.rs/pbkdf2) | ![MSRV 1.57][msrv-1.57] |
-| [scrypt]       | [`scrypt`]       | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt)             | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) | ![MSRV 1.57][msrv-1.57] |
-| [SHA-crypt]    | [`sha‑crypt`]    | [![crates.io](https://img.shields.io/crates/v/sha-crypt.svg)](https://crates.io/crates/sha-crypt)       | [![Documentation](https://docs.rs/sha-crypt/badge.svg)](https://docs.rs/sha-crypt) | ![MSRV 1.56][msrv-1.56] |
+| Algorithm      | Crate            | Crates.io                                                                                              | Documentation | MSRV                    |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------|---------------|-------------------------|
+| [Argon2]       | [`argon2`]       | [![crates.io](https://img.shields.io/crates/v/argon2.svg)](https://crates.io/crates/argon2)            | [![Documentation](https://docs.rs/argon2/badge.svg)](https://docs.rs/argon2) | ![MSRV 1.65][msrv-1.65] |
+| [Balloon]      | [`balloon‑hash`] | [![crates.io](https://img.shields.io/crates/v/balloon-hash.svg)](https://crates.io/crates/balloon-hash) | [![Documentation](https://docs.rs/balloon-hash/badge.svg)](https://docs.rs/balloon-hash) | ![MSRV 1.65][msrv-1.65] |
+| [bcrypt‑pbkdf] | [`bcrypt‑pbkdf`] | [![crates.io](https://img.shields.io/crates/v/bcrypt-pbkdf.svg)](https://crates.io/crates/bcrypt-pbkdf) | [![Documentation](https://docs.rs/bcrypt-pbkdf/badge.svg)](https://docs.rs/bcrypt-pbkdf) | ![MSRV 1.60][msrv-1.60] |
+| [PBKDF2]       | [`pbkdf2`]       | [![crates.io](https://img.shields.io/crates/v/pbkdf2.svg)](https://crates.io/crates/pbkdf2)            | [![Documentation](https://docs.rs/pbkdf2/badge.svg)](https://docs.rs/pbkdf2) | ![MSRV 1.60][msrv-1.60] |
+| [scrypt]       | [`scrypt`]       | [![crates.io](https://img.shields.io/crates/v/scrypt.svg)](https://crates.io/crates/scrypt)            | [![Documentation](https://docs.rs/scrypt/badge.svg)](https://docs.rs/scrypt) | ![MSRV 1.60][msrv-1.60] |
+| [SHA-crypt]    | [`sha‑crypt`]    | [![crates.io](https://img.shields.io/crates/v/sha-crypt.svg)](https://crates.io/crates/sha-crypt)      | [![Documentation](https://docs.rs/sha-crypt/badge.svg)](https://docs.rs/sha-crypt) | ![MSRV 1.60][msrv-1.60] |
 
 Please see the [OWASP Password Storage Cheat Sheet] for assistance in selecting an appropriate algorithm for your use case.
 
@@ -67,8 +67,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [deps-image]: https://deps.rs/repo/github/RustCrypto/password-hashes/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/password-hashes
-[msrv-1.56]: https://img.shields.io/badge/rustc-1.56.0+-blue.svg
-[msrv-1.57]: https://img.shields.io/badge/rustc-1.57.0+-blue.svg
+[msrv-1.60]: https://img.shields.io/badge/rustc-1.60.0+-blue.svg
+[msrv-1.65]: https://img.shields.io/badge/rustc-1.65.0+-blue.svg
 
 [//]: # (crates)
 

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2023-03-04)
+### Added
+- Key derivation usage example ([#366])
+- Inherent constants for `Params` recommendations ([#387])
+
+### Changed
+- Merge `Argon2` and `Instance` structs ([#247])
+- Refactor `ParamsBuilder` to make it more ergonomic ([#247])
+- Bump `password-hash` dependency to v0.5 ([#383])
+- Adopt OWASP recommended default `Params` ([#386])
+- MSRV 1.65 ([#391])
+
+### Fixed
+- Erroneous docs for `m_cost` and `Block` ([#247])
+- Allow `zeroize` in heapless environments (i.e. without `alloc`) ([#374])
+
+### Removed
+- `Memory` struct ([#247])
+- Unsound `parallel` feature - see [#380] ([#247])
+
+[#247]: https://github.com/RustCrypto/password-hashes/pull/247
+[#366]: https://github.com/RustCrypto/password-hashes/pull/366
+[#374]: https://github.com/RustCrypto/password-hashes/pull/374
+[#380]: https://github.com/RustCrypto/password-hashes/pull/380
+[#383]: https://github.com/RustCrypto/password-hashes/pull/383
+[#386]: https://github.com/RustCrypto/password-hashes/pull/386
+[#387]: https://github.com/RustCrypto/password-hashes/pull/387
+[#391]: https://github.com/RustCrypto/password-hashes/pull/391
+
 ## 0.4.1 (2022-06-27)
 ### Added
 - `argon2::RECOMMENDED_SALT_LEN` ([#307])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.5.0-pre.0"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
@@ -13,7 +13,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [dependencies]
 base64ct = "1"

--- a/argon2/README.md
+++ b/argon2/README.md
@@ -27,7 +27,7 @@ ones without `alloc` support.
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -59,7 +59,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/argon2/badge.svg
 [docs-link]: https://docs.rs/argon2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/argon2/badge.svg?branch=master&event=push

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["crypto", "password", "hashing"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [dependencies]
 password-hash = { version = "0.5", features = ["alloc", "rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 # optional dependencies
-argon2 = { version = "=0.5.0-pre.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
+argon2 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
 pbkdf2 = { version = "=0.12.0-pre", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
 scrypt =  { version = "=0.11.0-pre", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
 

--- a/password-auth/README.md
+++ b/password-auth/README.md
@@ -14,7 +14,7 @@ with support for [Argon2], [PBKDF2], and [scrypt] password hashing algorithms.
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/password-auth/badge.svg
 [docs-link]: https://docs.rs/password-auth/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/password-auth/badge.svg?branch=master&event=push


### PR DESCRIPTION
### Added
- Key derivation usage example ([#366])
- Inherent constants for `Params` recommendations ([#387])

### Changed
- Merge `Argon2` and `Instance` structs ([#247])
- Refactor `ParamsBuilder` to make it more ergonomic ([#247])
- Bump `password-hash` dependency to v0.5 ([#383])
- Adopt OWASP recommended default `Params` ([#386])
- MSRV 1.65 ([#391])

### Fixed
- Erroneous docs for `m_cost` and `Block` ([#247])
- Allow `zeroize` in heapless environments (i.e. without `alloc`) ([#374])

### Removed
- `Memory` struct ([#247])
- Unsound `parallel` feature - see [#380] ([#247])

[#247]: https://github.com/RustCrypto/password-hashes/pull/247
[#366]: https://github.com/RustCrypto/password-hashes/pull/366
[#374]: https://github.com/RustCrypto/password-hashes/pull/374
[#380]: https://github.com/RustCrypto/password-hashes/pull/380
[#383]: https://github.com/RustCrypto/password-hashes/pull/383
[#386]: https://github.com/RustCrypto/password-hashes/pull/386
[#387]: https://github.com/RustCrypto/password-hashes/pull/387
[#391]: https://github.com/RustCrypto/password-hashes/pull/391