### PR TITLE
balloon-hash v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "crypto-bigint",
  "digest",

--- a/balloon-hash/CHANGELOG.md
+++ b/balloon-hash/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2023-03-04)
+### Changed
+- Bump `crypto-bigint` to v0.5; MSRV 1.65 ([#381])
+- Bump `password-hash` to v0.5 ([#383])
+
+[#381]: https://github.com/RustCrypto/password-hashes/pull/381
+[#383]: https://github.com/RustCrypto/password-hashes/pull/383
+
 ## 0.3.0 (2022-06-27)
 ### Added
 - `Balloon::hash_into` ([#313])

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Bump `crypto-bigint` to v0.5; MSRV 1.65 ([#381])
- Bump `password-hash` to v0.5 ([#383])

[#381]: https://github.com/RustCrypto/password-hashes/pull/381
[#383]: https://github.com/RustCrypto/password-hashes/pull/383