### PR TITLE
pbkdf2 v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.0-pre"
+version = "0.12.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.60"
 
 [dependencies]
 blowfish = { version = "0.9.1", features = ["bcrypt"] }
-pbkdf2 = { version = "=0.12.0-pre", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.12", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.10.5", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 
 # optional dependencies
 argon2 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
-pbkdf2 = { version = "=0.12.0-pre", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
+pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
 scrypt =  { version = "=0.11.0-pre", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
 
 [features]

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,15 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.12.0 (2023-03-04)
 ### Changed
-- `simple` feature is no longer enabled by default ([#336])
 - Add new wrapper functions: `pbkdf2_array`, `pbkdf2_hmac`, and
-`pbkdf2_hmac_array`. `pbkdf2` and `pbkdf2_array` now return
-`Result<(), InvalidLength>` instead of unwrapping it internally. ([#337])
+  `pbkdf2_hmac_array`. `pbkdf2` and `pbkdf2_array` now return
+  `Result<(), InvalidLength>` instead of unwrapping it internally. ([#337])
+- Use `sha1` dependency directly ([#363])
+- Make `Ident` values inherent constants of `Algorithm` ([#375])
+- Bump `password-hash` to v0.5 ([#383])
+- Adopt OWASP recommended default `Params` ([#389])
+
+### Removed
+- `simple` feature is no longer enabled by default ([#336])
 
 [#336]: https://github.com/RustCrypto/password-hashes/pull/336
 [#337]: https://github.com/RustCrypto/password-hashes/pull/337
+[#363]: https://github.com/RustCrypto/password-hashes/pull/363
+[#375]: https://github.com/RustCrypto/password-hashes/pull/375
+[#383]: https://github.com/RustCrypto/password-hashes/pull/383
+[#389]: https://github.com/RustCrypto/password-hashes/pull/389
 
 ## 0.11.0 (2022-03-28)
 ### Changed

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.12.0-pre"
+version = "0.12.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -31,9 +31,10 @@ streebog = "0.10"
 
 [features]
 default = ["hmac"]
+std = ["password-hash/std"]
+
 parallel = ["rayon", "std"]
 simple = ["hmac", "password-hash", "sha2"]
-std = ["password-hash/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-pbkdf2 = { version = "=0.12.0-pre", path = "../pbkdf2" }
+pbkdf2 = { version = "0.12", path = "../pbkdf2" }
 salsa20 = { version = "0.10.2", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
### Changed
- Add new wrapper functions: `pbkdf2_array`, `pbkdf2_hmac`, and
  `pbkdf2_hmac_array`. `pbkdf2` and `pbkdf2_array` now return
  `Result<(), InvalidLength>` instead of unwrapping it internally. ([#337])
- Use `sha1` dependency directly ([#363])
- Make `Ident` values inherent constants of `Algorithm` ([#375])
- Bump `password-hash` to v0.5 ([#383])
- Adopt OWASP recommended default `Params` ([#389])

### Removed
- `simple` feature is no longer enabled by default ([#336])

[#336]: https://github.com/RustCrypto/password-hashes/pull/336
[#337]: https://github.com/RustCrypto/password-hashes/pull/337
[#363]: https://github.com/RustCrypto/password-hashes/pull/363
[#375]: https://github.com/RustCrypto/password-hashes/pull/375
[#383]: https://github.com/RustCrypto/password-hashes/pull/383
[#389]: https://github.com/RustCrypto/password-hashes/pull/389