### PR TITLE
bcrypt-pbkdf v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "blowfish",
  "hex-literal",

--- a/bcrypt-pbkdf/CHANGELOG.md
+++ b/bcrypt-pbkdf/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2023-03-04)
+### Added
+- Support for `alloc`-free usage ([#372])
+
+### Changed
+- Bump `pbkdf2` dependency to v0.12; MSRV 1.60 ([#393])
+
+[#372]: https://github.com/RustCrypto/password-hashes/pull/372
+[#393]: https://github.com/RustCrypto/password-hashes/pull/393
+
 ## 0.9.0 (2022-03-18)
 ### Changed
 - 2021 edition upgrade ([#284])

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0"
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/bcrypt-pbkdf/README.md
+++ b/bcrypt-pbkdf/README.md
@@ -7,7 +7,8 @@
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 
-Pure Rust implementation of the bcrypt-pbkdf password-based key derivation function.
+Pure Rust implementation of the [`bcrypt_pbkdf`] password-based key derivation
+function, a custom derivative of PBKDF2 [used in OpenSSH].
 
 [Documentation][docs-link]
 
@@ -50,3 +51,8 @@ dual licensed as above, without any additional terms or conditions.
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/bcrypt-pbkdf/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/password-hashes/actions?query=workflow%3Abcrypt-pbkdf
+
+[//]: # (links)
+
+[`bcrypt_pbkdf`]: https://flak.tedunangst.com/post/bcrypt-pbkdf
+[used in OpenSSH]: https://flak.tedunangst.com/post/new-openssh-key-format-and-bcrypt-pbkdf

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -5,6 +5,7 @@
 //! [OpenSSH]: https://flak.tedunangst.com/post/new-openssh-key-format-and-bcrypt-pbkdf
 
 #![no_std]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"


### PR DESCRIPTION
### Added
- Support for `alloc`-free usage ([#372])

### Changed
- Bump `pbkdf2` dependency to v0.12; MSRV 1.60 ([#393])

[#372]: https://github.com/RustCrypto/password-hashes/pull/372
[#393]: https://github.com/RustCrypto/password-hashes/pull/393
