### PR TITLE
scrypt v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.11.0-pre"
+version = "0.11.0"
 dependencies = [
  "password-hash",
  "pbkdf2",

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -22,7 +22,7 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 # optional dependencies
 argon2 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
 pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
-scrypt =  { version = "=0.11.0-pre", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
+scrypt =  { version = "0.11", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
 
 [features]
 default = ["argon2", "std"]

--- a/scrypt/CHANGELOG.md
+++ b/scrypt/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2023-03-04)
+### Added
+- Ability to use custom output key length ([#255])
+- Inherent constants for `Params` recommendations ([#387])
+
+### Changed
+- Bump `password-hash` to v0.5; MSRV 1.60 ([#383])
+- Adopt OWASP recommendations ([#388])
+- Bump `pbkdf2` to v0.12 ([#393])
+
+[#255]: https://github.com/RustCrypto/password-hashes/pull/255
+[#383]: https://github.com/RustCrypto/password-hashes/pull/383
+[#387]: https://github.com/RustCrypto/password-hashes/pull/387
+[#388]: https://github.com/RustCrypto/password-hashes/pull/388
+[#393]: https://github.com/RustCrypto/password-hashes/pull/393
+
 ## 0.10.0 (2022-03-18)
 ### Changed
 - Bump `password-hash` dependency to v0.4; MSRV 1.57 ([#283])

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.11.0-pre"
+version = "0.11.0"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- Ability to use custom output key length ([#255])
- Inherent constants for `Params` recommendations ([#387])

### Changed
- Bump `password-hash` to v0.5; MSRV 1.60 ([#383])
- Adopt OWASP recommendations ([#388])
- Bump `pbkdf2` to v0.12 ([#393])

[#255]: https://github.com/RustCrypto/password-hashes/pull/255
[#383]: https://github.com/RustCrypto/password-hashes/pull/383
[#387]: https://github.com/RustCrypto/password-hashes/pull/387
[#388]: https://github.com/RustCrypto/password-hashes/pull/388
[#393]: https://github.com/RustCrypto/password-hashes/pull/393