### PR TITLE
pbkdf2: re-export `hmac`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "base64ct",
  "rand",

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -94,6 +94,9 @@ pub use password_hash;
 #[cfg(feature = "simple")]
 mod simple;
 
+#[cfg(feature = "hmac")]
+pub use hmac;
+
 #[cfg(feature = "simple")]
 pub use crate::simple::{Algorithm, Params, Pbkdf2};
 


### PR DESCRIPTION
Re-exports the crate when the `hmac` feature is enabled