### PR TITLE
pbkdf2 v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "digest",
  "hex-literal",

--- a/pbkdf2/CHANGELOG.md
+++ b/pbkdf2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2023-03-04)
+### Changed
+- Re-export `hmac` ([#397])
+
+[#397]: https://github.com/RustCrypto/password-hashes/pull/397
+
 ## 0.12.0 (2023-03-04)
 ### Changed
 - Add new wrapper functions: `pbkdf2_array`, `pbkdf2_hmac`, and

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"


### PR DESCRIPTION
### Changed
- Re-export `hmac` ([#397])

[#397]: https://github.com/RustCrypto/password-hashes/pull/397