### PR TITLE
Annotate `Algorithm::as_str` returning static str

### DIFF
--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -63,7 +63,7 @@ impl Algorithm {
     }
 
     /// Get the identifier string for this PBKDF2 [`Algorithm`].
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Algorithm::Argon2d => "argon2d",
             Algorithm::Argon2i => "argon2i",


### PR DESCRIPTION
Previously `Algorithm::as_str` used no lifetime specifier on the returned `as_str`, so the returned value inherited the lifetime of `&self`.

But the returned value are static value and could use the lifetime `'static` instead.