### PR TITLE
Enable alloc feature of password-hash if enabled for argon2/balloon-hash

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -29,7 +29,7 @@ password-hash = { version = "0.5", features = ["rand_core"] }
 
 [features]
 default = ["alloc", "password-hash", "rand"]
-alloc = []
+alloc = ["password-hash/alloc"]
 std = ["alloc", "password-hash/std"]
 
 rand = ["password-hash/rand_core"]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -27,7 +27,7 @@ sha2 = "0.10"
 
 [features]
 default = ["alloc", "password-hash", "rand"]
-alloc = []
+alloc = ["password-hash/alloc"]
 parallel = ["rayon", "std"]
 rand = ["password-hash/rand_core"]
 std = ["alloc", "password-hash/std"]


### PR DESCRIPTION
Hi there!

This PR enables the `password-hash/alloc` feature if the `argon2/alloc` or `balloon-hash/alloc` features are enabled.

Prior to this PR, if a user adds argon2 as a dependency with the `alloc` feature enabled, but not the `std` feature (which is the case with the default feature set), then the `alloc` feature of `password-hash` is not enabled. This means that feature-gated types such as `PasswordHashString` are not available in the `password-hash` re-export, so users wishing to use these types will have to add `password-hash` as a separate dependency.

Thanks! :)