### PR TITLE
Add const initializer to argon2::Block

### DIFF
--- a/argon2/src/block.rs
+++ b/argon2/src/block.rs
@@ -53,6 +53,11 @@ impl Block {
     /// Memory block size in bytes
     pub const SIZE: usize = 1024;
 
+    /// Returns a Block initialized with zeros.
+    pub const fn new() -> Self {
+        Self([0u64; Self::SIZE / 8])
+    }
+
     pub(crate) fn as_bytes(&self) -> &[u8; Self::SIZE] {
         unsafe { &*(self.0.as_ptr() as *const [u8; Self::SIZE]) }
     }


### PR DESCRIPTION
For `#![no_std]` environments, adding the const initializer makes it possible to write

```rust
static mut ARGON2_MEMBLOCK: [argon2::Block; MEM_BLOCK_COUNT] = [argon2::Block::new(); MEM_BLOCK_COUNT];
```

Previously, without a const initializer for `argon2::Block`, doing the same would require code like the following:

```rust
static mut MEM_BLOCKS: [MaybeUninit<argon2::Block>; MEM_BLOCK_COUNT] = unsafe {MaybeUninit::uninit().assume_init()};

// Initialize blocks when they are actually used
```

Unfortunately, the compiler is not able to optimize the initialization properly, resulting in an extra 1KB of space wasted on the stack, which becomes an issue in memory-constrained embedded systems. The following program is an illustration of this:

```rust
#![no_std]

use core::mem::MaybeUninit;
use core::panic::PanicInfo;

// Arbitrary values
const SALTED_PWD_LEN: usize = 32;
const MEM_BLOCK_COUNT: usize = 81;

static mut MEM_BLOCKS: [MaybeUninit<argon2::Block>; MEM_BLOCK_COUNT] = unsafe {MaybeUninit::uninit().assume_init()};

#[panic_handler]
fn panic_handler(_panic: &PanicInfo<'_>) -> ! {
    loop {}
}

pub fn argon2_wrapper(pwd: &[u8], salt: &[u8]) {
    let argon2 = argon2::Argon2::new(
        argon2::Algorithm::Argon2id,
        argon2::Version::V0x13,
        argon2::Params::new(MEM_BLOCK_COUNT.try_into().unwrap(), 47, 1, Some(SALTED_PWD_LEN)).unwrap()
    );
    let mut out = [0x00; SALTED_PWD_LEN];
    let mem_blocks_ref = unsafe {
        for maybeuninit_block in &mut MEM_BLOCKS {
            maybeuninit_block.write(argon2::Block::default());
        }
        // We are transmuting a live reference (-> NonNull), so as_mut() is Some()
        (&mut MEM_BLOCKS as *mut [MaybeUninit<argon2::Block>; MEM_BLOCK_COUNT]
            as *mut [argon2::Block; MEM_BLOCK_COUNT]).as_mut().unwrap()
    };
    argon2.hash_password_into_with_memory(pwd, salt, &mut out, mem_blocks_ref).unwrap();
}
```

When compiled with `cargo build --release --target thumbv7em-none-eabi`, the resulting assembly initializes each `argon2::Block` on the stack and them `memcpy`s it into the global array:

<img width="743" alt="image" src="https://github.com/RustCrypto/password-hashes/assets/14067959/ae8dbf1a-cace-4df3-849c-c92fd741c558">

Thus, adding a const initializer for `argon2::Block` makes using the crate in embedded environments easier, as well as saving stack space. The particular project that I extracted this code from was very tight on memory space, almost needing to account for every single available RAM byte that the particular microcontroller we were using had available.

The `argon2` crate was the only instance I found of a custom `argon2::Block` type, but if there are others, I think they should all get a const initializer as well.