### PR TITLE
password-auth: add `is_hash_obsolete`

### DIFF
--- a/password-auth/README.md
+++ b/password-auth/README.md
@@ -15,8 +15,8 @@ with support for [Argon2], [PBKDF2], and [scrypt] password hashing algorithms.
 ## About
 
 `password-auth` is a high-level password authentication library with a simple
-API which eliminates as much complexity and user choice as possible. It only
-has two functions:
+interface which eliminates as much complexity and user choice as possible.
+The core API consists of two functions:
 
 - [`generate_hash`]: generates a password hash from the provided password. The
 - [`verify_password`]: verifies the provided password against a password hash,

--- a/password-auth/src/errors.rs
+++ b/password-auth/src/errors.rs
@@ -1,0 +1,36 @@
+//! Error types.
+
+use core::fmt;
+
+/// Password hash parse errors.
+#[derive(Clone, Copy, Debug)]
+pub struct ParseError(password_hash::Error);
+
+impl ParseError {
+    /// Create a new parse error.
+    pub(crate) fn new(err: password_hash::Error) -> Self {
+        Self(err)
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {}
+
+/// Password hash verification errors.
+#[derive(Clone, Copy, Debug)]
+pub struct VerifyError;
+
+impl fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("password verification error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VerifyError {}


### PR DESCRIPTION
Adds a method for interrogating whether a given password hash is using the recommended algorithm and parameters.

This can be used by password hash upgrade systems to determine whether a particular hash should be upgraded/recomputed.

It additionally adds a `ParseError` type which wraps `password_hash::Error`. This is only used by `is_hash_obsolete` for now but it might be good for future versions to use this error type to capture parse errors in `verify_password`.

However, that would be a breaking change, which is avoided for now.

Closes #426