### PR TITLE
password-auth v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "password-auth"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "getrandom",

--- a/password-auth/CHANGELOG.md
+++ b/password-auth/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-06-24)
+### Added
+- `is_hash_obsolete` ([#428])
+
+### Changed
+- Replace `VerifyError` with `Error` enum ([#429])
+
+[#428]: https://github.com/RustCrypto/password-hashes/pull/428
+[#429]: https://github.com/RustCrypto/password-hashes/pull/429
+
 ## 0.1.1 (2023-06-01)
 ### Changed
 - Improve documentation ([#419])

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "0.2.0-pre"
+version = "0.2.0"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 with support for Argon2, PBKDF2, and scrypt password hashing algorithms


### PR DESCRIPTION
### Added
- `is_hash_obsolete` ([#428])

### Changed
- Replace `VerifyError` with `Error` enum ([#429])

[#428]: https://github.com/RustCrypto/password-hashes/pull/428
[#429]: https://github.com/RustCrypto/password-hashes/pull/429