### PR TITLE
password-auth: rename `Error` (back) to `VerifyError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "password-auth"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "argon2",
  "getrandom",

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 with support for Argon2, PBKDF2, and scrypt password hashing algorithms

--- a/password-auth/src/errors.rs
+++ b/password-auth/src/errors.rs
@@ -3,34 +3,6 @@
 use alloc::string::ToString;
 use core::fmt;
 
-/// Error type.
-#[derive(Clone, Copy, Debug)]
-pub enum Error {
-    /// Password hash parsing errors.
-    Parse(ParseError),
-
-    /// Password is invalid.
-    PasswordInvalid,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Parse(err) => write!(f, "{err}"),
-            Self::PasswordInvalid => write!(f, "password is invalid"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
-
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Error {
-        Error::Parse(err)
-    }
-}
-
 /// Password hash parse errors.
 // This type has no public constructor and deliberately keeps
 // `password_hash::Error` out of the public API so it can evolve
@@ -59,5 +31,33 @@ impl fmt::Display for ParseError {
     }
 }
 
+/// Password verification errors.
+#[derive(Clone, Copy, Debug)]
+pub enum VerifyError {
+    /// Password hash parsing errors.
+    Parse(ParseError),
+
+    /// Password is invalid.
+    PasswordInvalid,
+}
+
+impl fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(err) => write!(f, "{err}"),
+            Self::PasswordInvalid => write!(f, "password is invalid"),
+        }
+    }
+}
+
+impl From<ParseError> for VerifyError {
+    fn from(err: ParseError) -> VerifyError {
+        VerifyError::Parse(err)
+    }
+}
+
 #[cfg(feature = "std")]
 impl std::error::Error for ParseError {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VerifyError {}

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -23,7 +23,7 @@ extern crate std;
 
 mod errors;
 
-pub use crate::errors::{Error, ParseError};
+pub use crate::errors::{ParseError, VerifyError};
 
 use alloc::string::{String, ToString};
 use password_hash::{ParamsString, PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
@@ -78,7 +78,7 @@ fn generate_phc_hash<'a>(
 /// - `Ok(())` if the password hash verified successfully
 /// - `Err(VerifyError)` if the hash didn't parse successfully or the password
 ///   failed to verify against the hash.
-pub fn verify_password(password: impl AsRef<[u8]>, hash: &str) -> Result<(), Error> {
+pub fn verify_password(password: impl AsRef<[u8]>, hash: &str) -> Result<(), VerifyError> {
     let hash = PasswordHash::new(hash).map_err(ParseError::new)?;
 
     let algs: &[&dyn PasswordVerifier] = &[
@@ -91,7 +91,7 @@ pub fn verify_password(password: impl AsRef<[u8]>, hash: &str) -> Result<(), Err
     ];
 
     hash.verify_password(algs, password)
-        .map_err(|_| Error::PasswordInvalid)
+        .map_err(|_| VerifyError::PasswordInvalid)
 }
 
 /// Determine if the given password hash is using the recommended algorithm and


### PR DESCRIPTION
The name better captures the intent: errors relating to `verify_password`.

Using the same name should ease upgrades as well.