### PR TITLE
password-auth v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "password-auth"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "argon2",
  "getrandom",

--- a/password-auth/CHANGELOG.md
+++ b/password-auth/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2023-06-24)
+### Added
+- Derive `Eq`/`PartialEq` on `*Error` ([#433])
+
+### Changed
+- Rename `Error` (back) to `VerifyError` ([#432])
+
+[#432]: https://github.com/RustCrypto/password-hashes/pull/432
+[#433]: https://github.com/RustCrypto/password-hashes/pull/433
+
 ## 0.2.0 (2023-06-24)
 ### Added
 - `is_hash_obsolete` ([#428])

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 with support for Argon2, PBKDF2, and scrypt password hashing algorithms

--- a/password-auth/README.md
+++ b/password-auth/README.md
@@ -16,6 +16,14 @@ with support for [Argon2], [PBKDF2], and [scrypt] password hashing algorithms.
 
 `password-auth` is a high-level password authentication library with a simple
 interface which eliminates as much complexity and user choice as possible.
+
+It wraps pure Rust implementations of multiple password hashing algorithms
+maintained by the [RustCrypto] organization, with the goal of providing a
+stable interface while allowing the password hashing algorithm implementations
+to evolve at a faster pace.
+
+## Usage
+
 The core API consists of two functions:
 
 - [`generate_hash`]: generates a password hash from the provided password. The


### PR DESCRIPTION
### Added
- Derive `Eq`/`PartialEq` on `*Error` ([#433])

### Changed
- Rename `Error` (back) to `VerifyError` ([#432])

[#432]: https://github.com/RustCrypto/password-hashes/pull/432
[#433]: https://github.com/RustCrypto/password-hashes/pull/433
