### PR TITLE
scrypt: Update docs for recommended log_n parameter

### DIFF
--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -87,7 +87,7 @@ impl Params {
         })
     }
 
-    /// Recommended values sufficient for most use-cases
+    /// Recommended values according to the [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt)
     /// - `log_n = 17` (`n = 131072`)
     /// - `r = 8`
     /// - `p = 1`

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -88,7 +88,7 @@ impl Params {
     }
 
     /// Recommended values sufficient for most use-cases
-    /// - `log_n = 15` (`n = 32768`)
+    /// - `log_n = 17` (`n = 131072`)
     /// - `r = 8`
     /// - `p = 1`
     pub fn recommended() -> Params {


### PR DESCRIPTION
When updating the parameters in a previous PR (#388) this documentation was missed.