### PR TITLE
argon2: fold `compress_avx2` into an inner function

### DIFF
--- a/argon2/src/block.rs
+++ b/argon2/src/block.rs
@@ -66,8 +66,10 @@ impl Block {
         unsafe { &mut *(self.0.as_mut_ptr() as *mut [u8; Self::SIZE]) }
     }
 
+    /// NOTE: do not call this directly. It should only be called via
+    /// `Argon2::compress`.
     #[inline(always)]
-    pub(crate) fn compress_soft(rhs: &Self, lhs: &Self) -> Self {
+    pub(crate) fn compress(rhs: &Self, lhs: &Self) -> Self {
         let r = *rhs ^ lhs;
 
         // Apply permutations rowwise
@@ -101,12 +103,6 @@ impl Block {
 
         q ^= &r;
         q
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn compress_avx2(rhs: &Self, lhs: &Self) -> Self {
-        Self::compress_soft(rhs, lhs)
     }
 }
 
@@ -149,23 +145,5 @@ impl BitXorAssign<&Block> for Block {
 impl Zeroize for Block {
     fn zeroize(&mut self) {
         self.0.zeroize();
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[cfg(target_arch = "x86_64")]
-    #[test]
-    fn compress_avx2() {
-        let mut lhs = Block([0; 128]);
-        lhs.0[0..7].copy_from_slice(&[0, 0, 0, 2048, 4, 2, 1]);
-        let rhs = Block([0; 128]);
-
-        let result = Block::compress_soft(&rhs, &lhs);
-        let result_avx2 = unsafe { Block::compress_avx2(&rhs, &lhs) };
-
-        assert_eq!(result.0, result_avx2.0);
     }
 }

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -455,11 +455,18 @@ impl<'key> Argon2<'key> {
     fn compress(&self, rhs: &Block, lhs: &Block) -> Block {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
+            /// Enable AVX2 optimizations.
+            #[target_feature(enable = "avx2")]
+            unsafe fn compress_avx2(rhs: &Block, lhs: &Block) -> Block {
+                Block::compress(rhs, lhs)
+            }
+
             if self.cpu_feat_avx2.get() {
-                return unsafe { Block::compress_avx2(rhs, lhs) };
+                return unsafe { compress_avx2(rhs, lhs) };
             }
         }
-        Block::compress_soft(rhs, lhs)
+
+        Block::compress(rhs, lhs)
     }
 
     /// Get default configured [`Params`].


### PR DESCRIPTION
This changes `Argon2::compress` to contain all AVX2-related logic, so it doesn't bleed into the `Block` type yet (especially since that lacks any AVX2-specific implementation).