### PR TITLE
password-auth v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "password-auth"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "argon2",
  "getrandom",

--- a/password-auth/CHANGELOG.md
+++ b/password-auth/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 (2023-09-03)
+
+No changes from v0.3.0.
+
 ## 0.3.0 (2023-06-24)
 ### Added
 - Derive `Eq`/`PartialEq` on `*Error` ([#433])

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "password-auth"
-version = "0.3.0"
+version = "1.0.0"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
-with support for Argon2, PBKDF2, and scrypt password hashing algorithms
+including support for Argon2, PBKDF2, and scrypt password hashing algorithms
 """
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This release is unchanged from v0.3.0.

The goal of this crate is to provide a facade with simple API which does not contain any re-exports from its dependencies, which is why it's possible to cut a v1.0.0 release.

This allows the underlying `argon2`, `pbkdf2`, and `scrypt` crates to be updated without any user-facing changes.