### PR TITLE
argon2 v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64ct",
  "blake2",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.2 (2023-09-03)
+### Changed
+- Improved `const fn` support ([#450])
+
+### Fixed
+- Max params ([#452])
+
+[#450]: https://github.com/RustCrypto/password-hashes/pull/450
+[#452]: https://github.com/RustCrypto/password-hashes/pull/452
+
 ## 0.5.1 (2023-07-13)
 ### Added
 - Provide `std::error::Error::source` for `argon2::Error` ([#379])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.5.1"
+version = "0.5.2"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants


### PR DESCRIPTION
### Changed
- Improved `const fn` support ([#450])

### Fixed
- Max params ([#452])

[#450]: https://github.com/RustCrypto/password-hashes/pull/450
[#452]: https://github.com/RustCrypto/password-hashes/pull/452