### PR TITLE
Argon2: Fix `Params` docs

### DIFF
--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -12,7 +12,7 @@ use password_hash::{ParamsString, PasswordHash};
 /// These are parameters which can be encoded into a PHC hash string.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Params {
-    /// Memory size, expressed in kibibytes, between 1 and (2^32)-1.
+    /// Memory size, expressed in kibibytes, between 8 and (2^32)-1.
     ///
     /// Value is an integer in decimal (1 to 10 digits).
     m_cost: u32,
@@ -100,9 +100,9 @@ impl Params {
     /// Create new parameters.
     ///
     /// # Arguments
-    /// - `m_cost`: memory size in 1 KiB blocks. Between 1 and (2^32)-1.
+    /// - `m_cost`: memory size in 1 KiB blocks. Between 8 and (2^32)-1.
     /// - `t_cost`: number of iterations. Between 1 and (2^32)-1.
-    /// - `p_cost`: degree of parallelism. Between 1 and 255.
+    /// - `p_cost`: degree of parallelism. Between 1 and (2^24)-1.
     /// - `output_len`: size of the KDF output in bytes. Default 32.
     pub const fn new(
         m_cost: u32,
@@ -154,7 +154,7 @@ impl Params {
         })
     }
 
-    /// Memory size, expressed in kibibytes. Between 1 and (2^32)-1.
+    /// Memory size, expressed in kibibytes. Between 8 and (2^32)-1.
     ///
     /// Value is an integer in decimal (1 to 10 digits).
     pub const fn m_cost(&self) -> u32 {
@@ -168,7 +168,7 @@ impl Params {
         self.t_cost
     }
 
-    /// Degree of parallelism. Between 1 and 255.
+    /// Degree of parallelism. Between 1 and (2^24)-1.
     ///
     /// Value is an integer in decimal (1 to 3 digits).
     pub const fn p_cost(&self) -> u32 {
@@ -432,7 +432,7 @@ impl ParamsBuilder {
         Self::DEFAULT
     }
 
-    /// Set memory size, expressed in kibibytes, between 1 and (2^32)-1.
+    /// Set memory size, expressed in kibibytes, between 8 and (2^32)-1.
     pub fn m_cost(&mut self, m_cost: u32) -> &mut Self {
         self.m_cost = m_cost;
         self
@@ -444,7 +444,7 @@ impl ParamsBuilder {
         self
     }
 
-    /// Set degree of parallelism, between 1 and 255.
+    /// Set degree of parallelism, between 1 and (2^24)-1.
     pub fn p_cost(&mut self, p_cost: u32) -> &mut Self {
         self.p_cost = p_cost;
         self


### PR DESCRIPTION
* The minimum value of `m_cost` is 8 ( 8*`MIN_OUTPUT_LEN`), not 1.
* The maximum value of `p_cost` is (2^24)-1, not 255.

These are defined in [RFC 9106](https://datatracker.ietf.org/doc/html/rfc9106), and [`MIN_M_COST`](https://docs.rs/argon2/0.5.2/argon2/struct.Params.html#associatedconstant.MIN_M_COST) and [`MAX_P_COST`](https://docs.rs/argon2/0.5.2/argon2/struct.Params.html#associatedconstant.MAX_P_COST) are also like that.

See also: #451, #452