### PR TITLE
argon2: fix big endian support

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -48,16 +48,48 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.65.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            rust: 1.65.0 # MSRV
+            deps: sudo apt update && sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            rust: stable
+            deps: sudo apt update && sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            rust: 1.65.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            rust: stable
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: ${{ matrix.deps }}
       - run: cargo test --no-default-features
       - run: cargo test --no-default-features --features password-hash
       - run: cargo test
       - run: cargo test --all-features
+
+  cross:
+    strategy:
+      matrix:
+        include:
+          - target: powerpc-unknown-linux-gnu
+            rust: 1.65.0 # MSRV
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ${{ matrix.deps }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - uses: RustCrypto/actions/cross-install@master
+      - run: cross test --release --target ${{ matrix.target }} --all-features

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -307,11 +307,14 @@ fn salt_bad_length() {
     let ret = ctx.hash_password_into(b"password", &too_short_salt, &mut out);
     assert_eq!(ret, Err(Error::SaltTooShort));
 
-    // 4 GiB of RAM seems big, but as long as we ask for a zero-initialized vector
-    // optimizations kicks in an nothing is really allocated
-    let too_long_salt = vec![0u8; argon2::MAX_SALT_LEN + 1];
-    let ret = ctx.hash_password_into(b"password", &too_long_salt, &mut out);
-    assert_eq!(ret, Err(Error::SaltTooLong));
+    #[cfg(target_pointer_width = "64")] // MAX_SALT_LEN + 1 is too big for 32-bit targets
+    {
+        // 4 GiB of RAM seems big, but as long as we ask for a zero-initialized vector
+        // optimizations kicks in an nothing is really allocated
+        let too_long_salt = vec![0u8; argon2::MAX_SALT_LEN + 1];
+        let ret = ctx.hash_password_into(b"password", &too_long_salt, &mut out);
+        assert_eq!(ret, Err(Error::SaltTooLong));
+    }
 }
 
 #[test]
@@ -321,11 +324,14 @@ fn output_bad_length() {
     let ret = ctx.hash_password_into(b"password", b"diffsalt", &mut out);
     assert_eq!(ret, Err(Error::OutputTooShort));
 
-    // 4 GiB of RAM seems big, but as long as we ask for a zero-initialized vector
-    // optimizations kicks in an nothing is really allocated
-    let mut out = vec![0u8; Params::MAX_OUTPUT_LEN + 1];
-    let ret = ctx.hash_password_into(b"password", b"diffsalt", &mut out);
-    assert_eq!(ret, Err(Error::OutputTooLong));
+    #[cfg(target_pointer_width = "64")] // MAX_SALT_LEN + 1 is too big for 32-bit targets
+    {
+        // 4 GiB of RAM seems big, but as long as we ask for a zero-initialized vector
+        // optimizations kicks in an nothing is really allocated
+        let mut out = vec![0u8; Params::MAX_OUTPUT_LEN + 1];
+        let ret = ctx.hash_password_into(b"password", b"diffsalt", &mut out);
+        assert_eq!(ret, Err(Error::OutputTooLong));
+    }
 }
 
 // =======================================


### PR DESCRIPTION
This was broken in #247, which added unsafe pointer casts to access the contents of a block, which only works on little endian targets.

This reverts back to something closer to the previous code, which used `u64::{from_le_bytes, to_le_bytes}` instead.

It also adds cross tests for PPC32 to spot future regressions.

Fixes #481.