### PR TITLE
argon2 v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64ct",
  "blake2",

--- a/argon2/CHANGELOG.md
+++ b/argon2/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.3 (2024-01-20)
+### Fixed
+- Documentation ([#458], [#459])
+- Big endian support  ([#482])
+
+[#458]: https://github.com/RustCrypto/password-hashes/pull/458
+[#459]: https://github.com/RustCrypto/password-hashes/pull/459
+[#482]: https://github.com/RustCrypto/password-hashes/pull/482
+
 ## 0.5.2 (2023-09-03)
 ### Changed
 - Improved `const fn` support ([#450])

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.5.2"
+version = "0.5.3"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/argon2/LICENSE-MIT
+++ b/argon2/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2023 The RustCrypto Project Developers
+Copyright (c) 2021-2024 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Fixed
- Documentation ([#458], [#459])
- Big endian support  ([#482])

[#458]: https://github.com/RustCrypto/password-hashes/pull/458
[#459]: https://github.com/RustCrypto/password-hashes/pull/459
[#482]: https://github.com/RustCrypto/password-hashes/pull/482
