### PR TITLE
Reduce rust-version

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.63.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.63.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.63"
 
 [dependencies]
 base64ct = "1"

--- a/argon2/README.md
+++ b/argon2/README.md
@@ -27,7 +27,7 @@ ones without `alloc` support.
 
 ## Minimum Supported Rust Version
 
-Rust **1.65** or higher.
+Rust **1.63** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -59,7 +59,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/argon2/badge.svg
 [docs-link]: https://docs.rs/argon2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/argon2/badge.svg?branch=master&event=push


### PR DESCRIPTION
Is there a reason why rust-version for argon2 was at 1.65? I'm compiling with rustc 1.63.0 from Debian bookworm, it compiled fine and I haven't seen any issues at runtime. The increase from 1.60 was done as part of #391 but I couldn't see a reasoning and it was done for the main Cargo.toml as well, maybe it was only relevant for the main crate.