### PR TITLE
Prepare pre.0 prereleases

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.65.0 # MSRV
+            rust: 1.71.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -59,7 +59,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.65.0 # MSRV
+            rust: 1.71.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -80,7 +80,7 @@ jobs:
       matrix:
         include:
           - target: powerpc-unknown-linux-gnu
-            rust: 1.65.0 # MSRV
+            rust: 1.71.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest

--- a/.github/workflows/balloon-hash.yml
+++ b/.github/workflows/balloon-hash.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bcrypt-pbkdf.yml
+++ b/.github/workflows/bcrypt-pbkdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/password-auth.yml
+++ b/.github/workflows/password-auth.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sha-crypt.yml
+++ b/.github/workflows/sha-crypt.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.71.0
+          toolchain: 1.73.0
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0-pre.0"
 dependencies = [
  "base64ct",
  "blake2",
@@ -22,7 +22,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.4.0"
+version = "0.5.0-pre.0"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -41,7 +41,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.10.0"
+version = "0.11.0-pre.0"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -52,20 +52,19 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+version = "0.11.0-pre"
+source = "git+https://github.com/RustCrypto/hashes.git#e4dcf120629bd6461eff9ca1b281736336de423c"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
- "generic-array",
+ "crypto-common 0.2.0-pre.5",
 ]
 
 [[package]]
@@ -102,9 +101,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
 
 [[package]]
 name = "cpufeatures"
@@ -160,11 +165,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.6.0-pre.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1943d7beadd9ce2b25f3bae73b9e9336fccc1edf38bdec1ed58d3aa183989e11"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+ "num-traits",
  "subtle",
 ]
 
@@ -179,13 +185,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "crypto-common"
+version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
  "block-buffer",
- "crypto-common",
+ "const-oid",
+ "crypto-common 0.2.0-pre.5",
  "subtle",
 ]
 
@@ -232,11 +250,20 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcda354500b318c287a6b91c1cfbc42edd53d52d259a80783ceb5e3986fca2b2"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -279,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,7 +332,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "password-auth"
-version = "1.0.0"
+version = "1.1.0-pre.0"
 dependencies = [
  "argon2",
  "getrandom",
@@ -319,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0-pre.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -424,7 +460,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.11.0"
+version = "0.12.0-pre.0"
 dependencies = [
  "password-hash",
  "pbkdf2",
@@ -434,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 dependencies = [
  "base64ct",
  "rand",
@@ -444,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "3885de8cb916f223718c1ccd47a840b91f806333e76002dc5cb3862154b4fed3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -455,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -466,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.10.2"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7fe6ed8a42cec360e070309427bb7959e102849b0dbaa7de19d5b9860bd536"
+checksum = "906aaaef0b6bfcf186c7aac662b06a11769e688744323aa6ff3b9f96a5c71c09"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ exclude = ["benches"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+blake2 = { git = "https://github.com/RustCrypto/hashes.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,3 @@ exclude = ["benches"]
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-blake2 = { git = "https://github.com/RustCrypto/hashes.git" }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.71"
 
 [dependencies]
 base64ct = "1"
-blake2 = { version = "0.11.0-pre", default-features = false }
+blake2 = { version = "=0.11.0-pre.3", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.5", optional = true }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0-pre.0"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 base64ct = "1"
-blake2 = { version = "0.10.6", default-features = false }
+blake2 = { version = "0.11.0-pre", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.5", optional = true }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
 base64ct = "1"

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.4.0"
+version = "0.5.0-pre.0"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,8 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-digest = { version = "0.10.7", default-features = false }
-crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array"] }
+digest = { version = "=0.11.0-pre.8", default-features = false }
+crypto-bigint = { version = "=0.6.0-pre.12", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies
 password-hash = { version = "0.5", default-features = false, optional = true }
@@ -23,7 +23,7 @@ zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "0.10"
+sha2 = "=0.11.0-pre.3"
 
 [features]
 default = ["alloc", "password-hash", "rand"]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.73"
 
 [dependencies]
 digest = { version = "=0.11.0-pre.8", default-features = false }

--- a/balloon-hash/tests/balloon.rs
+++ b/balloon-hash/tests/balloon.rs
@@ -1,5 +1,5 @@
 use balloon_hash::{Algorithm, Balloon, Params};
-use digest::generic_array::GenericArray;
+use digest::array::Array;
 use hex_literal::hex;
 
 struct TestVector {
@@ -60,7 +60,7 @@ fn test_vectors() {
             None,
         );
 
-        let mut memory = vec![GenericArray::default(); balloon.params.s_cost.get() as usize];
+        let mut memory = vec![Array::default(); balloon.params.s_cost.get() as usize];
 
         assert_eq!(
             balloon

--- a/balloon-hash/tests/balloon_m.rs
+++ b/balloon-hash/tests/balloon_m.rs
@@ -1,5 +1,5 @@
 use balloon_hash::{Algorithm, Balloon, Params};
-use digest::generic_array::GenericArray;
+use digest::array::Array;
 use hex_literal::hex;
 
 struct TestVector {
@@ -91,10 +91,10 @@ fn test_vectors() {
         );
 
         #[cfg(not(feature = "parallel"))]
-        let mut memory = vec![GenericArray::default(); balloon.params.s_cost.get() as usize];
+        let mut memory = vec![Array::default(); balloon.params.s_cost.get() as usize];
         #[cfg(feature = "parallel")]
         let mut memory = vec![
-            GenericArray::default();
+            Array::default();
             (balloon.params.s_cost.get() * balloon.params.p_cost.get()) as usize
         ];
 

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.10.0"
+version = "0.11.0-pre.0"
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ rust-version = "1.60"
 
 [dependencies]
 blowfish = { version = "0.9.1", features = ["bcrypt"] }
-pbkdf2 = { version = "0.12", default-features = false, path = "../pbkdf2" }
-sha2 = { version = "0.10.5", default-features = false }
+pbkdf2 = { version = "=0.13.0-pre.0", default-features = false, path = "../pbkdf2" }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RustCrypto/password-hashes/tree/master/bcrypt-p
 keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.72"
 
 [dependencies]
 blowfish = { version = "0.9.1", features = ["bcrypt"] }

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -24,7 +24,7 @@ use blowfish::Blowfish;
 use sha2::{
     digest::{
         crypto_common::{Key, KeyInit, KeySizeUser},
-        generic_array::typenum::U32,
+        typenum::U32,
         FixedOutput, MacMarker, Output, OutputSizeUser, Update,
     },
     Digest, Sha512,
@@ -204,7 +204,7 @@ pub fn bcrypt_pbkdf_with_memory(
 mod test {
     use super::bhash;
     use hex_literal::hex;
-    use sha2::digest::generic_array::GenericArray;
+    use sha2::digest::array::Array;
 
     #[test]
     fn test_bhash() {
@@ -257,8 +257,8 @@ mod test {
         ];
 
         for t in tests.iter() {
-            let hpass = GenericArray::from_slice(&t.hpass);
-            let hsalt = GenericArray::from_slice(&t.hsalt);
+            let hpass = Array::from_slice(&t.hpass);
+            let hsalt = Array::from_slice(&t.hsalt);
             let out = bhash(hpass, hsalt);
             assert_eq!(out[..], t.out[..]);
         }

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "password", "hashing"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
 password-hash = { version = "0.5", features = ["alloc", "rand_core"] }

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "1.0.0"
+version = "1.1.0-pre.0"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 including support for Argon2, PBKDF2, and scrypt password hashing algorithms
@@ -20,9 +20,9 @@ password-hash = { version = "0.5", features = ["alloc", "rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 # optional dependencies
-argon2 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
-pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
-scrypt =  { version = "0.11", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
+argon2 = { version = "=0.6.0-pre.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
+pbkdf2 = { version = "=0.13.0-pre.0", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
+scrypt =  { version = "=0.12.0-pre.0", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
 
 [features]
 default = ["argon2", "std"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.72"
 
 [dependencies]
 digest = { version = "=0.11.0-pre.8", features = ["mac"] }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0-pre.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -13,21 +13,21 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-digest = { version = "0.10.7", features = ["mac"] }
+digest = { version = "=0.11.0-pre.8", features = ["mac"] }
 
 # optional dependencies
 rayon = { version = "1.7", optional = true }
 password-hash = { version = "0.5", default-features = false, optional = true, features = ["rand_core"]  }
-hmac = { version = "0.12", default-features = false, optional = true }
-sha1 = { version = "0.10", default-features = false, optional = true }
-sha2 = { version = "0.10", default-features = false, optional = true }
+hmac = { version = "=0.13.0-pre.3", default-features = false, optional = true }
+sha1 = { version = "=0.11.0-pre.3", default-features = false, optional = true }
+sha2 = { version = "=0.11.0-pre.3", default-features = false, optional = true }
 
 [dev-dependencies]
-hmac = "0.12"
+hmac = "=0.13.0-pre.3"
 hex-literal = "0.4.0"
-sha1 = "0.10"
-sha2 = "0.10"
-streebog = "0.10"
+sha1 = "=0.11.0-pre.3"
+sha2 = "=0.11.0-pre.3"
+streebog = "=0.11.0-pre.3"
 
 [features]
 default = ["hmac"]

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -103,13 +103,13 @@ pub use crate::simple::{Algorithm, Params, Pbkdf2};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use digest::{generic_array::typenum::Unsigned, FixedOutput, InvalidLength, KeyInit, Update};
+use digest::{typenum::Unsigned, FixedOutput, InvalidLength, KeyInit, Update};
 
 #[cfg(feature = "hmac")]
 use digest::{
     block_buffer::Eager,
-    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore},
-    generic_array::typenum::{IsLess, Le, NonZero, U256},
+    core_api::{BlockSizeUser, BufferKindUser, FixedOutputCore, UpdateCore},
+    typenum::{IsLess, Le, NonZero, U256},
     HashMarker,
 };
 
@@ -233,7 +233,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "hmac")))]
 pub fn pbkdf2_hmac<D>(password: &[u8], salt: &[u8], rounds: u32, res: &mut [u8])
 where
-    D: CoreProxy,
+    D: hmac::EagerHash,
     D::Core: Sync
         + HashMarker
         + UpdateCore
@@ -265,7 +265,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "hmac")))]
 pub fn pbkdf2_hmac_array<D, const N: usize>(password: &[u8], salt: &[u8], rounds: u32) -> [u8; N]
 where
-    D: CoreProxy,
+    D: hmac::EagerHash,
     D::Core: Sync
         + HashMarker
         + UpdateCore

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RustCrypto/password-hashes/tree/master/scrypt"
 keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.72"
 
 [dependencies]
 pbkdf2 = { version = "=0.13.0-pre.0", path = "../pbkdf2" }

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.11.0"
+version = "0.12.0-pre.0"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,9 +13,9 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-pbkdf2 = { version = "0.12", path = "../pbkdf2" }
+pbkdf2 = { version = "=0.13.0-pre.0", path = "../pbkdf2" }
 salsa20 = { version = "0.10.2", default-features = false }
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.5", default-features = false, features = ["rand_core"], optional = true }

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.72"
 
 [dependencies]
 sha2 = { version = "=0.11.0-pre.3", default-features = false }

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
 
 # optional dependencies
 rand = { version = "0.8", optional = true }


### PR DESCRIPTION
Prepare releases of:
  - balloon-hash `0.5.0-pre.0`
  - bcrypt-pbkdf `0.11.0-pre.0`
  - password-auth `1.1.0-pre.0`
  - pbkdf2 `0.13.0-pre.0`
  - scrypt `0.12.0-pre.0`
  - sha-crypt `0.6.0-pre.0`
  - argon2 `0.6.0-pre.0`
  
This brings:
 - digest `=0.11.0-pre.8`
 - sha1 `=0.11.0-pre.3`
 - sha2 `=0.11.0-pre.3`
 - hmac `=0.13.0-pre.3`
 - blake2 `=0.11.0-pre3`