### PR TITLE
bcrypt-pbkdf: scrypt: bump cipher to `0.5.0-pre.4`

### DIFF
--- a/.github/workflows/bcrypt-pbkdf.yml
+++ b/.github/workflows/bcrypt-pbkdf.yml
@@ -37,6 +37,8 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
+    # disabled until belt-block gets published
+    if: false
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}

--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -38,6 +38,8 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features simple
 
   minimal-versions:
+    # disabled until belt-block gets published
+    if: false
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}

--- a/.readme/Cargo.toml
+++ b/.readme/Cargo.toml
@@ -12,3 +12,7 @@ password-hash = "0.5"
 argon2 = { path = "../argon2" }
 pbkdf2 = { path = "../pbkdf2", features = ["simple"] }
 scrypt = { path = "../scrypt" }
+
+[patch.crates-io]
+salsa20  = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/hashes.git#e4dcf120629bd6461eff9ca1b281736336de423c"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb6b33ba68af672bcef0f6d1cceeeaf36e4143cd1456cafafda5d7f12d91f14"
 dependencies = [
  "digest",
 ]
@@ -64,14 +65,13 @@ version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
- "crypto-common 0.2.0-pre.5",
+ "crypto-common",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+version = "0.10.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#d6ed7a2f45f53db013824ac0e91419fc4f8a4321"
 dependencies = [
  "byteorder",
  "cipher",
@@ -97,11 +97,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "84fba98785cecd0e308818a87c817576a40f99d8bab6405bf422bacd3efb6c1f"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common",
  "inout",
 ]
 
@@ -176,16 +176,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
@@ -203,7 +193,7 @@ checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common 0.2.0-pre.5",
+ "crypto-common",
  "subtle",
 ]
 
@@ -212,16 +202,6 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -268,11 +248,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "0a2cc35b920cc3b344af824e64e508ffc2c819fc2368ed4d253244446194d2fe"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -445,9 +425,8 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+version = "0.11.0-pre"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#fea3dd013ee9c35fba56903ad44b411957de8cb2"
 dependencies = [
  "cipher",
 ]
@@ -537,12 +516,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,11 @@ exclude = ["benches"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+# https://github.com/RustCrypto/block-ciphers/pull/413
+blowfish = { git = "https://github.com/RustCrypto/block-ciphers.git" }
+
+# https://github.com/RustCrypto/stream-ciphers/pull/345
+# https://github.com/RustCrypto/stream-ciphers/pull/346
+salsa20  = { git = "https://github.com/RustCrypto/stream-ciphers.git" }

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-blowfish = { version = "0.9.1", features = ["bcrypt"] }
+blowfish = { version = "=0.10.0-pre", features = ["bcrypt"] }
 pbkdf2 = { version = "=0.13.0-pre.0", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.72"
 
 [dependencies]
 pbkdf2 = { version = "=0.13.0-pre.0", path = "../pbkdf2" }
-salsa20 = { version = "0.10.2", default-features = false }
+salsa20 = { version = "=0.11.0-pre", default-features = false }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
Depends on:
 - https://github.com/RustCrypto/block-ciphers/pull/413