### PR TITLE
Add PartialEq to scrypt::Params

### DIFF
--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -6,7 +6,7 @@ use crate::errors::InvalidParams;
 use password_hash::{errors::InvalidValue, Error, ParamsString, PasswordHash};
 
 /// The Scrypt parameter values.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Params {
     pub(crate) log_n: u8,
     pub(crate) r: u32,


### PR DESCRIPTION
This allows for PartialEq structs that contain an scrypt Params to also be PartialEq.