### PR TITLE
Bump dependencies to latest prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,26 +52,27 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb6b33ba68af672bcef0f6d1cceeeaf36e4143cd1456cafafda5d7f12d91f14"
+checksum = "e6dbf347378982186052c47f25f33fc1a6eb439ee840d778eb3ec132e304379d"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
+checksum = "17092d478f4fadfb35a7e082f62e49f0907fdf048801d9d706277e34f9df8a78"
 dependencies = [
  "crypto-common",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#d6ed7a2f45f53db013824ac0e91419fc4f8a4321"
+version = "0.10.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f27c154f70281cf2775de16a3380c477f9c2c89ec1f122786b5afa7add0c8a3"
 dependencies = [
  "byteorder",
  "cipher",
@@ -97,9 +98,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.4"
+version = "0.5.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fba98785cecd0e308818a87c817576a40f99d8bab6405bf422bacd3efb6c1f"
+checksum = "c71c893d5a1e8257048dbb29954d2e1f85f091a150304f1defe4ca2806da5d3f"
 dependencies = [
  "crypto-common",
  "inout",
@@ -107,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.10.0-pre.2"
+version = "0.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
+checksum = "9adcf94f05e094fca3005698822ec791cb4433ced416afda1c5ca3b8dfc05a2f"
 
 [[package]]
 name = "cpufeatures"
@@ -165,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-pre.12"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1943d7beadd9ce2b25f3bae73b9e9336fccc1edf38bdec1ed58d3aa183989e11"
+checksum = "e43027691f1c055da3da4f7d96af09fcec420d435d5616e51f29afd0811c56a7"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -176,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+checksum = "8c070b79a496dccd931229780ad5bbedd535ceff6c3565605a8e440e18e1aa2b"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -187,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.8"
+version = "0.11.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -230,27 +231,27 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.3"
+version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
+checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda354500b318c287a6b91c1cfbc42edd53d52d259a80783ceb5e3986fca2b2"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "inout"
-version = "0.2.0-pre.4"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2cc35b920cc3b344af824e64e508ffc2c819fc2368ed4d253244446194d2fe"
+checksum = "bbc33218cf9ce7b927426ee4ad3501bcc5d8c26bf5fb4a82849a083715aca427"
 dependencies = [
  "hybrid-array",
 ]
@@ -287,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -425,9 +426,11 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#fea3dd013ee9c35fba56903ad44b411957de8cb2"
+version = "0.11.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4ef53595bd236cf843530a2db25c792acb34e619320d0423e6cbc6d8e3c8c5"
 dependencies = [
+ "cfg-if",
  "cipher",
 ]
 
@@ -459,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3885de8cb916f223718c1ccd47a840b91f806333e76002dc5cb3862154b4fed3"
+checksum = "9540978cef7a8498211c1b1c14e5ce920fe5bd524ea84f4a3d72d4602515ae93"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -470,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -481,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906aaaef0b6bfcf186c7aac662b06a11769e688744323aa6ff3b9f96a5c71c09"
+checksum = "fcb353b35a577917dbcc59b8bef4084ba206b36851577816d5ffe3dac9b0ad54"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,3 @@ exclude = ["benches"]
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-# https://github.com/RustCrypto/block-ciphers/pull/413
-blowfish = { git = "https://github.com/RustCrypto/block-ciphers.git" }
-
-# https://github.com/RustCrypto/stream-ciphers/pull/345
-# https://github.com/RustCrypto/stream-ciphers/pull/346
-salsa20  = { git = "https://github.com/RustCrypto/stream-ciphers.git" }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.71"
 
 [dependencies]
 base64ct = "1"
-blake2 = { version = "=0.11.0-pre.3", default-features = false }
+blake2 = { version = "=0.11.0-pre.4", default-features = false }
 
 # optional dependencies
 password-hash = { version = "=0.6.0-pre.0", optional = true }
@@ -38,6 +38,10 @@ std = ["alloc", "password-hash/std"]
 
 rand = ["password-hash/rand_core"]
 simple = ["password-hash"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(test_large_ram)']
 
 [package.metadata.docs.rs]
 all-features = true

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -452,7 +452,7 @@ ignored_testcase_good!(
 
 // TODO: If version is not provided, verifier incorrectly uses version 0x13
 #[ignore]
-#[cfg(feature = "test_large_ram")]
+#[cfg(test_large_ram)]
 testcase_good!(
     reference_argon2i_v0x10_2_20_1_large_ram,
     Algorithm::Argon2i,
@@ -604,7 +604,7 @@ testcase_good!(
     "$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA"
 );
 
-#[cfg(feature = "test_large_ram")]
+#[cfg(test_large_ram)]
 testcase_good!(
     reference_argon2i_v0x13_2_20_1,
     Algorithm::Argon2i,

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-digest = { version = "=0.11.0-pre.8", default-features = false }
-crypto-bigint = { version = "=0.6.0-pre.12", default-features = false, features = ["hybrid-array"] }
+digest = { version = "=0.11.0-pre.9", default-features = false }
+crypto-bigint = { version = "0.6.0-rc.2", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies
 password-hash = { version = "=0.6.0-pre.0", default-features = false, optional = true }
@@ -24,7 +24,7 @@ zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "=0.11.0-pre.3"
+sha2 = "=0.11.0-pre.4"
 
 [features]
 default = ["alloc", "password-hash", "rand"]

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -193,7 +193,7 @@ where
         output: &mut [u8],
     ) -> Result<()> {
         let output = if output.len() == D::OutputSize::USIZE {
-            Array::from_mut_slice(output)
+            <&mut Array<_, _>>::try_from(output).expect("size mismatch")
         } else {
             return Err(Error::OutputSize {
                 actual: output.len(),

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-blowfish = { version = "=0.10.0-pre", features = ["bcrypt"] }
+blowfish = { version = "=0.10.0-pre.1", features = ["bcrypt"] }
 pbkdf2 = { version = "=0.13.0-pre.0", default-features = false, path = "../pbkdf2" }
-sha2 = { version = "=0.11.0-pre.3", default-features = false }
+sha2 = { version = "=0.11.0-pre.4", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -257,9 +257,9 @@ mod test {
         ];
 
         for t in tests.iter() {
-            let hpass = Array::from_slice(&t.hpass);
-            let hsalt = Array::from_slice(&t.hsalt);
-            let out = bhash(hpass, hsalt);
+            let hpass = Array(t.hpass);
+            let hsalt = Array(t.hsalt);
+            let out = bhash(&hpass, &hsalt);
             assert_eq!(out[..], t.out[..]);
         }
     }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -14,21 +14,21 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-digest = { version = "=0.11.0-pre.8", features = ["mac"] }
+digest = { version = "=0.11.0-pre.9", features = ["mac"] }
 
 # optional dependencies
 rayon = { version = "1.7", optional = true }
-password-hash = { version = "=0.6.0-pre.0", default-features = false, optional = true, features = ["rand_core"]  }
-hmac = { version = "=0.13.0-pre.3", default-features = false, optional = true }
-sha1 = { version = "=0.11.0-pre.3", default-features = false, optional = true }
-sha2 = { version = "=0.11.0-pre.3", default-features = false, optional = true }
+password-hash = { version = "=0.6.0-pre.0", default-features = false, optional = true, features = ["rand_core"] }
+hmac = { version = "=0.13.0-pre.4", default-features = false, optional = true }
+sha1 = { version = "=0.11.0-pre.4", default-features = false, optional = true }
+sha2 = { version = "=0.11.0-pre.4", default-features = false, optional = true }
 
 [dev-dependencies]
-hmac = "=0.13.0-pre.3"
-hex-literal = "0.4.0"
-sha1 = "=0.11.0-pre.3"
-sha2 = "=0.11.0-pre.3"
-streebog = "=0.11.0-pre.3"
+hmac = "=0.13.0-pre.4"
+hex-literal = "0.4"
+sha1 = "=0.11.0-pre.4"
+sha2 = "=0.11.0-pre.4"
+streebog = "=0.11.0-pre.4"
 
 [features]
 default = ["hmac"]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -15,8 +15,8 @@ rust-version = "1.72"
 
 [dependencies]
 pbkdf2 = { version = "=0.13.0-pre.0", path = "../pbkdf2" }
-salsa20 = { version = "=0.11.0-pre", default-features = false }
-sha2 = { version = "=0.11.0-pre.3", default-features = false }
+salsa20 = { version = "=0.11.0-pre.1", default-features = false }
+sha2 = { version = "=0.11.0-pre.4", default-features = false }
 
 # optional dependencies
 password-hash = { version = "=0.6.0-pre.0", default-features = false, features = ["rand_core"], optional = true }

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-sha2 = { version = "=0.11.0-pre.3", default-features = false }
+sha2 = { version = "=0.11.0-pre.4", default-features = false }
 
 # optional dependencies
 rand = { version = "0.8", optional = true }


### PR DESCRIPTION
Also fixes `hybrid-array` deprecations.

Updates the following:

- `blake2` v0.11.0-pre.4
- `blowfish` v0.10.0-pre.1
- `cipher` v0.5.0-pre.6
- `crypto-bigint` v0.6.0-rc.2
- `digest` v0.11.0-pre.9
- `hmac` v0.13.0-pre.4
- `hybrid-array` v0.2.0-rc.9
- `salsa20` v0.11.0-pre.1
- `sha1` v0.11.0-pre.4
- `sha2` v0.11.0-pre.4
- `streebog` v0.11.0-pre.4