### PR TITLE
Cut pre.1 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "argon2"
-version = "0.6.0-pre.0"
+version = "0.6.0-pre.1"
 dependencies = [
  "base64ct",
  "blake2",
@@ -22,7 +22,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.5.0-pre.0"
+version = "0.5.0-pre.1"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -41,7 +41,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -313,7 +313,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "password-auth"
-version = "1.1.0-pre.0"
+version = "1.1.0-pre.1"
 dependencies = [
  "argon2",
  "getrandom",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -442,7 +442,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-pre.0"
+version = "0.12.0-pre.1"
 dependencies = [
  "password-hash",
  "pbkdf2",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.6.0-pre.0"
+version = "0.6.0-pre.1"
 dependencies = [
  "base64ct",
  "rand",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-pre.0"
+version = "0.6.0-pre.1"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.5.0-pre.0"
+version = "0.5.0-pre.1"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rust-version = "1.72"
 
 [dependencies]
 blowfish = { version = "=0.10.0-pre.1", features = ["bcrypt"] }
-pbkdf2 = { version = "=0.13.0-pre.0", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "=0.13.0-pre.1", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "1.1.0-pre.0"
+version = "1.1.0-pre.1"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 including support for Argon2, PBKDF2, and scrypt password hashing algorithms
@@ -21,9 +21,9 @@ password-hash = { version = "0.6.0-rc.0", features = ["alloc", "rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 # optional dependencies
-argon2 = { version = "=0.6.0-pre.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
-pbkdf2 = { version = "=0.13.0-pre.0", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
-scrypt = { version = "=0.12.0-pre.0", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
+argon2 = { version = "=0.6.0-pre.1", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
+pbkdf2 = { version = "=0.13.0-pre.1", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
+scrypt = { version = "=0.12.0-pre.1", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
 
 [features]
 default = ["argon2", "std"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-pre.0"
+version = "0.12.0-pre.1"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-pbkdf2 = { version = "=0.13.0-pre.0", path = "../pbkdf2" }
+pbkdf2 = { version = "=0.13.0-pre.1", path = "../pbkdf2" }
 salsa20 = { version = "=0.11.0-pre.1", default-features = false }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.6.0-pre.0"
+version = "0.6.0-pre.1"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library


### PR DESCRIPTION
Cuts the following prereleases:

- `argon2` v0.6.0-pre.1
- `balloon-hash` v0.5.0-pre.1
- `bcrypt-pbkdf` v0.11.0-pre.1
- `password-auth` v1.1.0-pre.1
- `pbkdf2` v0.13.0-pre.1
- `scrypt` v0.12.0-pre.1
- `sha-crypt` v0.6.0-pre.1