### PR TITLE
argon2: only enable password-hash dependency if its explicit

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -33,10 +33,10 @@ password-hash = { version = "0.6.0-rc.0", features = ["rand_core"] }
 
 [features]
 default = ["alloc", "password-hash", "rand"]
-alloc = ["password-hash/alloc"]
-std = ["alloc", "password-hash/std"]
+alloc = ["password-hash?/alloc"]
+std = ["alloc", "password-hash?/std"]
 
-rand = ["password-hash/rand_core"]
+rand = ["password-hash?/rand_core"]
 simple = ["password-hash"]
 
 [lints.rust.unexpected_cfgs]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -30,8 +30,11 @@
 //! password-based authentication. Do not use this API to derive cryptographic
 //! keys: see the "key derivation" usage example below.
 //!
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+#![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "password-hash", feature = "std")),
+    doc = "```ignore"
+)]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use argon2::{
 //!     password_hash::{
@@ -65,8 +68,11 @@
 //! This API is useful for transforming a password into cryptographic keys for
 //! e.g. password-based encryption.
 //!
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+#![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "password-hash", feature = "std")),
+    doc = "```ignore"
+)]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use argon2::Argon2;
 //!


### PR DESCRIPTION
A missing weak feature specifier `?` was causing `password-hash` to always become part of a crate's build tree if someone had specified `default-features = false, features = ["alloc"]` in their `Cargo.toml`.

Due to https://github.com/rust-lang/cargo/issues/10801 `password-hash` will still always appear in the lockfile, but it won't be compiled anymore when a downstream crate has only enabled the `alloc` or `std` features.