### PR TITLE
fuzz: add upper bound for scrypt's password and salt sizes

### DIFF
--- a/fuzz/fuzz_targets/scrypt.rs
+++ b/fuzz/fuzz_targets/scrypt.rs
@@ -24,14 +24,19 @@ impl<'a> Arbitrary<'a> for ScryptRandParams {
 fuzz_target!(|data: (&[u8], &[u8], ScryptRandParams)| {
     let (password, salt, ScryptRandParams(params)) = data;
 
+    if password.len() > 64 {
+        return;
+    }
+
+    if salt.len() < Salt::MIN_LENGTH || salt.len() > (6 * Salt::MAX_LENGTH) / 8 {
+        return;
+    }
+
     // Check direct hashing
     let mut result = [0u8; 64];
     scrypt(password, salt, &params, &mut result).unwrap();
 
     // Check PHC hashing
-    if salt.len() < Salt::MIN_LENGTH {
-        return;
-    }
     let salt_string = SaltString::encode_b64(salt).unwrap();
     let phc_hash = Scrypt
         .hash_password_customized(

--- a/fuzz/fuzz_targets/scrypt.rs
+++ b/fuzz/fuzz_targets/scrypt.rs
@@ -12,8 +12,8 @@ pub struct ScryptRandParams(pub scrypt::Params);
 impl<'a> Arbitrary<'a> for ScryptRandParams {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let log_n = u.int_in_range(0..=15)?;
-        let r = u.int_in_range(1..=32)?;
-        let p = u.int_in_range(1..=16)?;
+        let r = u.int_in_range(1..=16)?;
+        let p = u.int_in_range(1..=8)?;
         let len = u.int_in_range(10..=64)?;
 
         let params = scrypt::Params::new(log_n, r, p, len).unwrap();


### PR DESCRIPTION
Also change ranges used to generate scrypt parameters to prevent potential timeout issues.

cc @arthurscchan