### PR TITLE
Add explicit zeroize features

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -38,6 +38,7 @@ std = ["alloc", "password-hash?/std"]
 
 rand = ["password-hash?/rand_core"]
 simple = ["password-hash"]
+zeroize = ["dep:zeroize"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -32,6 +32,7 @@ alloc = ["password-hash/alloc"]
 parallel = ["rayon", "std"]
 rand = ["password-hash/rand_core"]
 std = ["alloc", "password-hash/std"]
+zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -26,3 +26,4 @@ hex-literal = "0.4.0"
 default = ["alloc", "std"]
 alloc = []
 std = []
+zeroize = ["dep:zeroize"]


### PR DESCRIPTION
During a recent code audit on another project, I noticed that the `argon2`, `balloon-hash` and `bcrypt-pbkdf` crates implemented in this code repository do not explicitly declare their `zeroize` feature variants for memory sanitization behavior.
Fix this by adding explicit `Cargo.toml` `[feature]` entries for this `zeroize` flag.

By my current understanding, the relevant optional security hardening functionality which is gated by this feature flag can already be used by other crates today if they opt-in to its use in their `[dependencies]` reference, without requiring this patch because the relevant functionality gets picked up as an "implicit feature". 

However, by not explicitly announcing this optional security feature, some consumers will either miss that it exists, or do not regard it as a reliable stable functionality (which this PR assumes it is). See also [Rust RFC3491](https://rust-lang.github.io/rfcs/3491-remove-implicit-features.html) which will remove this implicit feature behavior in the future.

Prior example of this change: see [sha1-checked](https://github.com/RustCrypto/hashes/blob/4f3cd253b944fa3d89ea0b75e2e3831346b98b17/sha1-checked/Cargo.toml#L34).

Thanks to @hko-s for helping to debug this.

I do not consider this a direct security issue (as covered by `SECURITY.md`), because the hardening effect of memory sanitization is optional anyway and not guaranteed in existing documentation.