### PR TITLE
feat(scrypt): Add `Params::n` method

### DIFF
--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -102,9 +102,18 @@ impl Params {
 
     /// log₂ of the Scrypt parameter `N`, the work factor.
     ///
-    /// Memory and CPU usage scale linearly with `N`.
+    /// Memory and CPU usage scale linearly with `N`. If you need `N`, use
+    /// [`Params::n`] instead.
     pub const fn log_n(&self) -> u8 {
         self.log_n
+    }
+
+    /// `N` parameter: the work factor.
+    ///
+    /// This method returns the square of [`Params::log_n`]. Memory and CPU
+    /// usage scale linearly with `N`.
+    pub const fn n(&self) -> u64 {
+        1 << self.log_n
     }
 
     /// `r` parameter: resource usage.

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -110,7 +110,7 @@ impl Params {
 
     /// `N` parameter: the work factor.
     ///
-    /// This method returns the square of [`Params::log_n`]. Memory and CPU
+    /// This method returns 2 to the power of [`Params::log_n`]. Memory and CPU
     /// usage scale linearly with `N`.
     pub const fn n(&self) -> u64 {
         1 << self.log_n


### PR DESCRIPTION
Currently, the `N` parameter can be obtained by raising 2 to the power of `Params::log_n`.

```rust
// example of raising 2 to the power of `Params::log_n`
let n = 1 << params.log_n();
```

I think it's easier to read to use a method which gets the `N` parameter directly instead of this way.

```rust
let n = params.n();
```