### PR TITLE
Add an example of peppering to the docs.

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -64,7 +64,9 @@
 //! # }
 //! ```
 //!
-//! To pepper as well as salt your passwords:
+//! To [pepper] as well as salt your passwords:
+//!
+//! [pepper]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#peppering
 //!
 #![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
 #![cfg_attr(
@@ -86,7 +88,7 @@
 //!
 //! // Argon2 with default params (Argon2id v19) and pepper
 //! let argon2 = Argon2::new_with_secret(
-//!     b"pepper",
+//!     b"secret pepper",
 //!     Algorithm::default(),
 //!     Version::default(),
 //!     Params::default()
@@ -101,15 +103,15 @@
 //! // NOTE: hash params from `parsed_hash` are used instead of what is configured in the
 //! // `Argon2` instance.
 //! let parsed_hash = PasswordHash::new(&password_hash)?;
-//! assert!(Argon2::new_with_secret(
-//!     b"pepper",
+//! let argon2 = Argon2::new_with_secret(
+//!     b"secret pepper",
 //!     Algorithm::default(),
 //!     Version::default(),
-//!     Params::default()
+//!     Params::default(),
 //! )
-//! .unwrap()
-//! .verify_password(password, &parsed_hash)
-//! .is_ok());
+//! .unwrap();
+//! let res = argon2.verify_password(password, &parsed_hash);
+//! assert!(res.is_ok());
 //! # Ok(())
 //! # }
 //! ```

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -64,6 +64,56 @@
 //! # }
 //! ```
 //!
+//! To pepper as well as salt your passwords:
+//!
+#![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "password-hash", feature = "std")),
+    doc = "```ignore"
+)]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use argon2::{
+//!     password_hash::{
+//!         // `OsRng` requires enabled `std` crate feature
+//!         rand_core::OsRng,
+//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
+//!     },
+//!     Algorithm, Argon2, Params, Version
+//! };
+//!
+//! let password = b"hunter42"; // Bad password; don't actually use!
+//! let salt = SaltString::generate(&mut OsRng);
+//!
+//! // Argon2 with default params (Argon2id v19) and pepper
+//! let argon2 = Argon2::new_with_secret(
+//!     b"pepper",
+//!     Algorithm::default(),
+//!     Version::default(),
+//!     Params::default()
+//! )
+//! .unwrap();
+//!
+//! // Hash password to PHC string ($argon2id$v=19$...)
+//! let password_hash = argon2.hash_password(password, &salt)?.to_string();
+//!
+//! // Verify password against PHC string.
+//! //
+//! // NOTE: hash params from `parsed_hash` are used instead of what is configured in the
+//! // `Argon2` instance.
+//! let parsed_hash = PasswordHash::new(&password_hash)?;
+//! assert!(Argon2::new_with_secret(
+//!     b"pepper",
+//!     Algorithm::default(),
+//!     Version::default(),
+//!     Params::default()
+//! )
+//! .unwrap()
+//! .verify_password(password, &parsed_hash)
+//! .is_ok());
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ### Key Derivation
 //!
 //! This API is useful for transforming a password into cryptographic keys for


### PR DESCRIPTION
This patch adds an example of peppering as well as salting a password to the library's documentation home page (right under the existing example of salting). I think this is useful because although the `new_with_secret()` method is public & documented, it's purpose is not clear to the general user.

In fact, it took me a while to [spelunk](https://github.com/RustCrypto/password-hashes/issues/194) [through](https://github.com/RustCrypto/traits/issues/694) the [project](https://github.com/RustCrypto/traits/pull/699) to figure it out.