### PR TITLE
Add BlockArray abstraction to handle fallible allocations

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -144,7 +144,6 @@
 compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 
 #[cfg(feature = "alloc")]
-#[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -286,8 +285,8 @@ impl<'key> Argon2<'key> {
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn hash_password_into(&self, pwd: &[u8], salt: &[u8], out: &mut [u8]) -> Result<()> {
-        let mut blocks = vec![Block::default(); self.params.block_count()];
-        self.hash_password_into_with_memory(pwd, salt, out, &mut blocks)
+        let mut block_array = block::BlockArray::new(self.params.block_count())?;
+        self.hash_password_into_with_memory(pwd, salt, out, block_array.blocks())
     }
 
     /// Hash a password and associated parameters into the provided output buffer.


### PR DESCRIPTION
This resolves #566.

There was an open question regarding alignment. I couldn't demonstrate any significant performance benefit from unaligned allocations, so I skipped that here.

I wasn't sure what error to return. I decided not to introduce a breaking change here with a new error variant, but perhaps that is desired.
