### PR TITLE
Migrate to `doc_auto_cfg`

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -46,4 +46,3 @@ check-cfg = ['cfg(test_large_ram)']
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -11,17 +11,14 @@ use password_hash::Ident;
 
 /// Argon2d algorithm identifier
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 pub const ARGON2D_IDENT: Ident<'_> = Ident::new_unwrap("argon2d");
 
 /// Argon2i algorithm identifier
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 pub const ARGON2I_IDENT: Ident<'_> = Ident::new_unwrap("argon2i");
 
 /// Argon2id algorithm identifier
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 pub const ARGON2ID_IDENT: Ident<'_> = Ident::new_unwrap("argon2id");
 
 /// Argon2 primitive type: variants of the algorithm.
@@ -68,7 +65,6 @@ impl Algorithm {
 
     /// Get the [`Ident`] that corresponds to this Argon2 [`Algorithm`].
     #[cfg(feature = "password-hash")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
     pub const fn ident(&self) -> Ident<'static> {
         match self {
             Algorithm::Argon2d => ARGON2D_IDENT,
@@ -109,7 +105,6 @@ impl FromStr for Algorithm {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl From<Algorithm> for Ident<'static> {
     fn from(alg: Algorithm) -> Ident<'static> {
         alg.ident()
@@ -117,7 +112,6 @@ impl From<Algorithm> for Ident<'static> {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<'a> TryFrom<Ident<'a>> for Algorithm {
     type Error = password_hash::Error;
 

--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -94,7 +94,6 @@ impl From<base64ct::Error> for Error {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl From<Error> for password_hash::Error {
     fn from(err: Error) -> password_hash::Error {
         match err {

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
@@ -165,7 +165,6 @@ pub use crate::{
 };
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 pub use {
     crate::algorithm::{ARGON2D_IDENT, ARGON2I_IDENT, ARGON2ID_IDENT},
     password_hash::{self, PasswordHash, PasswordHasher, PasswordVerifier},
@@ -283,7 +282,6 @@ impl<'key> Argon2<'key> {
 
     /// Hash a password and associated parameters into the provided output buffer.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn hash_password_into(&self, pwd: &[u8], salt: &[u8], out: &mut [u8]) -> Result<()> {
         let blocks_len = self.params.block_count();
         let mut blocks = block::Blocks::new(blocks_len).ok_or(Error::OutOfMemory)?;
@@ -623,8 +621,6 @@ impl<'key> Argon2<'key> {
 }
 
 #[cfg(all(feature = "alloc", feature = "password-hash"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl PasswordHasher for Argon2<'_> {
     type Params = Params;
 

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -346,7 +346,6 @@ param_buf!(
 );
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
     type Error = password_hash::Error;
 
@@ -383,7 +382,6 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl TryFrom<Params> for ParamsString {
     type Error = password_hash::Error;
 
@@ -393,7 +391,6 @@ impl TryFrom<Params> for ParamsString {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl TryFrom<&Params> for ParamsString {
     type Error = password_hash::Error;
 

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -37,4 +37,3 @@ zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/balloon-hash/src/algorithm.rs
+++ b/balloon-hash/src/algorithm.rs
@@ -26,12 +26,10 @@ pub enum Algorithm {
 impl Algorithm {
     /// Balloon algorithm identifier
     #[cfg(feature = "password-hash")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
     pub const BALLOON_IDENT: Ident<'static> = Ident::new_unwrap("balloon");
 
     /// BalloonM algorithm identifier
     #[cfg(feature = "password-hash")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
     pub const BALLOON_M_IDENT: Ident<'static> = Ident::new_unwrap("balloon-m");
 
     /// Parse an [`Algorithm`] from the provided string.
@@ -49,7 +47,6 @@ impl Algorithm {
 
     /// Get the [`Ident`] that corresponds to this Balloon [`Algorithm`].
     #[cfg(feature = "password-hash")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
     pub fn ident(&self) -> Ident<'static> {
         match self {
             Algorithm::Balloon => Self::BALLOON_IDENT,
@@ -83,7 +80,6 @@ impl FromStr for Algorithm {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl From<Algorithm> for Ident<'static> {
     fn from(alg: Algorithm) -> Ident<'static> {
         alg.ident()
@@ -91,7 +87,6 @@ impl From<Algorithm> for Ident<'static> {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<'a> TryFrom<Ident<'a>> for Algorithm {
     type Error = password_hash::Error;
 

--- a/balloon-hash/src/error.rs
+++ b/balloon-hash/src/error.rs
@@ -47,7 +47,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl From<Error> for password_hash::Error {
     fn from(err: Error) -> password_hash::Error {
         match err {

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
@@ -78,7 +78,6 @@ pub use crate::{
 };
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 pub use password_hash::{self, PasswordHash, PasswordHasher, PasswordVerifier};
 
 use core::marker::PhantomData;
@@ -133,7 +132,6 @@ where
 
     /// Hash a password and associated parameters.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn hash(&self, pwd: &[u8], salt: &[u8]) -> Result<Array<u8, D::OutputSize>> {
         let mut output = Array::default();
         self.hash_into(pwd, salt, &mut output)?;
@@ -145,7 +143,6 @@ where
     ///
     /// The `output` has to have the same size as the hash output size: `D::OutputSize`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn hash_into(&self, pwd: &[u8], salt: &[u8], output: &mut [u8]) -> Result<()> {
         #[cfg(not(feature = "parallel"))]
         let mut memory = alloc::vec![Array::default(); self.params.s_cost.get() as usize];
@@ -217,8 +214,6 @@ where
 }
 
 #[cfg(all(feature = "alloc", feature = "password-hash"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<D: Digest + FixedOutputReset> PasswordHasher for Balloon<'_, D>
 where
     Array<u8, D::OutputSize>: ArrayDecoding,

--- a/balloon-hash/src/params.rs
+++ b/balloon-hash/src/params.rs
@@ -53,7 +53,6 @@ impl Default for Params {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
     type Error = password_hash::Error;
 
@@ -83,7 +82,6 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl TryFrom<Params> for ParamsString {
     type Error = password_hash::Error;
 
@@ -93,7 +91,6 @@ impl TryFrom<Params> for ParamsString {
 }
 
 #[cfg(feature = "password-hash")]
-#[cfg_attr(docsrs, doc(cfg(feature = "password-hash")))]
 impl TryFrom<&Params> for ParamsString {
     type Error = password_hash::Error;
 

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -27,3 +27,6 @@ default = ["alloc", "std"]
 alloc = []
 std = []
 zeroize = ["dep:zeroize"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -33,4 +33,3 @@ wasm_js = ["getrandom/wasm_js"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -39,4 +39,3 @@ simple = ["hmac", "password-hash", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -75,7 +75,7 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
@@ -85,7 +85,6 @@
 extern crate alloc;
 
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub use password_hash;
 
 #[cfg(feature = "simple")]
@@ -229,7 +228,6 @@ where
 /// assert_eq!(buf, hex!("669cfe52482116fda1aa2cbe409b2f56c8e45637"));
 /// ```
 #[cfg(feature = "hmac")]
-#[cfg_attr(docsrs, doc(cfg(feature = "hmac")))]
 pub fn pbkdf2_hmac<D>(password: &[u8], salt: &[u8], rounds: u32, res: &mut [u8])
 where
     D: EagerHash + HashMarker + Update + FixedOutput + Default + Clone,
@@ -254,7 +252,6 @@ where
 /// );
 /// ```
 #[cfg(feature = "hmac")]
-#[cfg_attr(docsrs, doc(cfg(feature = "hmac")))]
 pub fn pbkdf2_hmac_array<D, const N: usize>(password: &[u8], salt: &[u8], rounds: u32) -> [u8; N]
 where
     D: EagerHash + HashMarker + Update + FixedOutput + Default + Clone,

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -13,7 +13,6 @@ use sha1::Sha1;
 
 /// PBKDF2 type for use with [`PasswordHasher`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub struct Pbkdf2;
 
 impl PasswordHasher for Pbkdf2 {
@@ -65,11 +64,9 @@ impl PasswordHasher for Pbkdf2 {
 /// <https://en.wikipedia.org/wiki/PBKDF2>
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub enum Algorithm {
     /// PBKDF2 SHA1
     #[cfg(feature = "sha1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sha1")))]
     Pbkdf2Sha1,
 
     /// PBKDF2 SHA-256
@@ -164,7 +161,6 @@ impl<'a> TryFrom<Ident<'a>> for Algorithm {
 }
 
 /// PBKDF2 params
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Number of rounds

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -30,4 +30,3 @@ simple = ["password-hash"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -43,7 +43,7 @@
 //! Memory-Hard Functions](http://www.tarsnap.com/scrypt/scrypt.pdf)
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -137,7 +137,6 @@ impl Default for Params {
 }
 
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
     type Error = password_hash::Error;
 
@@ -173,7 +172,6 @@ impl<'a> TryFrom<&'a PasswordHash<'a>> for Params {
 }
 
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 impl TryFrom<Params> for ParamsString {
     type Error = password_hash::Error;
 

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -11,7 +11,6 @@ pub const ALG_ID: Ident = Ident::new_unwrap("scrypt");
 ///
 /// See the [crate docs](crate) for a usage example.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub struct Scrypt;
 
 impl PasswordHasher for Scrypt {

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -31,4 +31,3 @@ std = []
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -19,7 +19,6 @@ pub enum CryptError {
 
     /// I/O error.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     IoError(io::Error),
 
     /// UTF-8 error.
@@ -40,7 +39,6 @@ impl From<string::FromUtf8Error> for CryptError {
 }
 
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 #[derive(Debug)]
 pub enum CheckError {
     InvalidFormat(String),
@@ -50,7 +48,6 @@ pub enum CheckError {
 
 /// Decoding errors.
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 #[derive(Debug)]
 pub struct DecodeError;
 

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -28,7 +28,7 @@
 //! [3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
@@ -319,7 +319,6 @@ pub fn sha256_crypt_b64(password: &[u8], salt: &[u8], params: &Sha256Params) -> 
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha512_simple(password: &str, params: &Sha512Params) -> String {
     let rng = rand::rng();
 
@@ -355,7 +354,6 @@ pub fn sha512_simple(password: &str, params: &Sha512Params) -> String {
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha256_simple(password: &str, params: &Sha256Params) -> String {
     let rng = rand::rng();
 
@@ -392,7 +390,6 @@ pub fn sha256_simple(password: &str, params: &Sha256Params) -> String {
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let mut iter = hashed_value.split('$');
 
@@ -470,7 +467,6 @@ pub fn sha512_check(password: &str, hashed_value: &str) -> Result<(), CheckError
 ///
 /// [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
 #[cfg(feature = "simple")]
-#[cfg_attr(docsrs, doc(cfg(feature = "simple")))]
 pub fn sha256_check(password: &str, hashed_value: &str) -> Result<(), CheckError> {
     let mut iter = hashed_value.split('$');
 

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -25,4 +25,3 @@ hex-literal = "1"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",


### PR DESCRIPTION
Additionally removes explicit passing of `--cfg docsrs` since it's done automatically by docs.rs.