### PR TITLE
scrypt: make `Params` output len customization optional

### DIFF
--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -84,6 +84,12 @@ pub use crate::simple::{ALG_ID, Scrypt};
 /// `Ok(())` if calculation is successful and `Err(InvalidOutputLen)` if
 /// `output` does not satisfy the following condition:
 /// `output.len() > 0 && output.len() <= (2^32 - 1) * 32`.
+///
+/// # Note about output lengths
+/// The output size is determined entirely by size of the `output` parameter.
+///
+/// If the length of the [`Params`] have been customized using the [`Params::new_with_output_len`]
+/// constructor, that length is ignored and the length of `output` is used instead.
 pub fn scrypt(
     password: &[u8],
     salt: &[u8],

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -36,8 +36,9 @@ impl PasswordHasher for Scrypt {
         let salt = salt.into();
         let mut salt_arr = [0u8; 64];
         let salt_bytes = salt.decode_b64(&mut salt_arr)?;
+        let len = params.len.unwrap_or(Params::RECOMMENDED_LEN);
 
-        let output = Output::init_with(params.len, |out| {
+        let output = Output::init_with(len, |out| {
             scrypt(password, salt_bytes, &params, out).map_err(|_| {
                 let provided = if out.is_empty() {
                     Ordering::Less

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -69,7 +69,7 @@ fn test_scrypt() {
     let tests = tests();
     for t in tests.iter() {
         let mut result = vec![0u8; t.expected.len()];
-        let params = Params::new(t.log_n, t.r, t.p, t.expected.len()).unwrap();
+        let params = Params::new(t.log_n, t.r, t.p).unwrap();
         scrypt(
             t.password.as_bytes(),
             t.salt.as_bytes(),


### PR DESCRIPTION
This more or less goes back to the original API prior to when #255 added output length customization, adding a separate constructor function for adding length customization.

This keeps the output length out-of-the-way for users of the low-level `scrypt::scrypt` API. We've had several complaints about this (#415, #449, #596, #601), and hopefully this addresses them.

Additionally, since this functionality is only relevant to users of the `password-hash` API, it's feature-gated on that as well.