### PR TITLE
scrypt: fixup doc compilation

### DIFF
--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -60,3 +60,4 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+      - run: cargo doc --no-default-features

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -5,7 +5,7 @@ use crate::errors::InvalidParams;
 #[cfg(feature = "simple")]
 use password_hash::{Error, ParamsString, PasswordHash, errors::InvalidValue};
 
-#[cfg(doc)]
+#[cfg(all(feature = "simple", doc))]
 use password_hash::PasswordHasher;
 
 /// The Scrypt parameter values.


### PR DESCRIPTION
When scrypt used a dependency with `default-features = false`, the doc compilation will fail because `password_hash::PasswordHasher` will be unavailable (`password-hash` is only pulled `simple` feature is used).

It did not show up in CI, because `password-hash` is also provided as a `dev-dependency` and is available when `cargo test` evaluates the documentation.

Fixup #602