### PR TITLE
pbkdf2: use helper macro to simplify tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "balloon-hash"
@@ -49,6 +49,22 @@ dependencies = [
  "pbkdf2",
  "sha2",
  "zeroize",
+]
+
+[[package]]
+name = "belt-block"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
+
+[[package]]
+name = "belt-hash"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb51c5f2d38f4751a11964ac3988a05812fdec736b15bc0424f2cec697a85728"
+dependencies = [
+ "belt-block",
+ "digest",
 ]
 
 [[package]]
@@ -250,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "log"
@@ -302,6 +318,7 @@ dependencies = [
 name = "pbkdf2"
 version = "0.13.0-rc.0"
 dependencies = [
+ "belt-hash",
  "digest",
  "hex-literal",
  "hmac",
@@ -341,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -583,18 +600,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -29,6 +29,7 @@ hex-literal = "1"
 sha1 = "0.11.0-rc.0"
 sha2 = "0.11.0-rc.0"
 streebog = "0.11.0-rc.0"
+belt-hash = "0.2.0-rc.0"
 
 [features]
 default = ["hmac"]

--- a/pbkdf2/tests/mod.rs
+++ b/pbkdf2/tests/mod.rs
@@ -1,117 +1,93 @@
 #![cfg(feature = "hmac")]
+use belt_hash::BeltHash;
 use hex_literal::hex;
-use pbkdf2::pbkdf2_hmac_array as f;
 use sha1::Sha1;
 use streebog::Streebog512;
 
-/// Tests from RFC 6070:
+macro_rules! test {
+    (
+        $hash:ty;
+        $($password:expr, $salt:expr, $rounds:expr, $($expected_hash:literal)*;)*
+    ) => {
+        $({
+            const EXPECTED_HASH: &[u8] = &hex_literal::hex!($($expected_hash)*);
+            const N: usize = EXPECTED_HASH.len();
+
+            let hash = pbkdf2::pbkdf2_hmac_array::<$hash, N>($password, $salt, $rounds);
+            assert_eq!(hash[..], EXPECTED_HASH[..]);
+        })*
+    };
+}
+
+/// Test vectors from RFC 6070:
 /// https://www.rfc-editor.org/rfc/rfc6070
 #[test]
-fn rfc6070() {
-    assert_eq!(
-        f::<Sha1, 20>(b"password", b"salt", 1),
-        hex!("0c60c80f961f0e71f3a9b524af6012062fe037a6"),
-    );
-    assert_eq!(
-        f::<Sha1, 20>(b"password", b"salt", 2),
-        hex!("ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"),
-    );
-    assert_eq!(
-        f::<Sha1, 20>(b"password", b"salt", 4096),
-        hex!("4b007901b765489abead49d926f721d065a429c1"),
-    );
-    // this test passes, but takes a long time to execute
-    /*
-    assert_eq!(
-        f::<Sha1, 20>(b"password", b"salt", 16777216),
-        hex!("eefe3d61cd4da4e4e9945b3d6ba2158c2634e984"),
-    );
-    */
-    assert_eq!(
-        f::<Sha1, 25>(
-            b"passwordPASSWORDpassword",
-            b"saltSALTsaltSALTsaltSALTsaltSALTsalt",
-            4096
-        ),
-        hex!("3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"),
-    );
-    assert_eq!(
-        f::<Sha1, 16>(b"pass\0word", b"sa\0lt", 4096),
-        hex!("56fa6aa75548099dcc37d7f03425e0c3"),
+fn pbkdf2_rfc6070() {
+    test!(
+        Sha1;
+        b"password", b"salt", 1, "0c60c80f961f0e71f3a9b524af6012062fe037a6";
+        b"password", b"salt", 2, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957";
+        b"password", b"salt", 4096, "4b007901b765489abead49d926f721d065a429c1";
+        // this test passes, but takes a long time to execute
+        // b"password", b"salt", 16777216, "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984";
+        b"passwordPASSWORDpassword", b"saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096,
+            "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038";
+        b"pass\0word", b"sa\0lt", 4096, "56fa6aa75548099dcc37d7f03425e0c3";
     );
 }
 
 /// Test vectors from R 50.1.111-2016:
-/// https://tc26.ru/standard/rs/Р 50.1.111-2016.pdf
+/// https://tc26.ru/standard/rs/Р%2050.1.111-2016.pdf
 #[test]
-fn gost() {
-    assert_eq!(
-        f::<Streebog512, 64>(b"password", b"salt", 1),
-        hex!(
+fn pbkdf2_streebog() {
+    test!(
+        Streebog512;
+        b"password", b"salt", 1,
             "64770af7f748c3b1c9ac831dbcfd85c2"
             "6111b30a8a657ddc3056b80ca73e040d"
             "2854fd36811f6d825cc4ab66ec0a68a4"
-            "90a9e5cf5156b3a2b7eecddbf9a16b47"
-        ),
-    );
-
-    assert_eq!(
-        f::<Streebog512, 64>(b"password", b"salt", 2),
-        hex!(
+            "90a9e5cf5156b3a2b7eecddbf9a16b47";
+        b"password", b"salt", 2,
             "5a585bafdfbb6e8830d6d68aa3b43ac0"
             "0d2e4aebce01c9b31c2caed56f0236d4"
             "d34b2b8fbd2c4e89d54d46f50e47d45b"
-            "bac301571743119e8d3c42ba66d348de"
-        ),
-    );
-
-    assert_eq!(
-        f::<Streebog512, 64>(b"password", b"salt", 4096),
-        hex!(
+            "bac301571743119e8d3c42ba66d348de";
+        b"password", b"salt", 4096,
             "e52deb9a2d2aaff4e2ac9d47a41f34c2"
             "0376591c67807f0477e32549dc341bc7"
             "867c09841b6d58e29d0347c996301d55"
-            "df0d34e47cf68f4e3c2cdaf1d9ab86c3"
-        ),
-    );
-
-    // this test passes, but takes a long time to execute
-    /*
-    assert_eq!(
-        f::<Streebog512, 64>(b"password", b"salt", 16777216),
-        hex!(
-            "49e4843bba76e300afe24c4d23dc7392"
-            "def12f2c0e244172367cd70a8982ac36"
-            "1adb601c7e2a314e8cb7b1e9df840e36"
-            "ab5615be5d742b6cf203fb55fdc48071"
-        ),
-    );
-    */
-
-    assert_eq!(
-        f::<Streebog512, 100>(
-            b"passwordPASSWORDpassword",
-            b"saltSALTsaltSALTsaltSALTsaltSALTsalt",
-            4096,
-        ),
-        hex!(
+            "df0d34e47cf68f4e3c2cdaf1d9ab86c3";
+        // this test passes, but takes a long time to execute
+        // b"password", b"salt", 16777216,
+        //     "49e4843bba76e300afe24c4d23dc7392"
+        //     "def12f2c0e244172367cd70a8982ac36"
+        //     "1adb601c7e2a314e8cb7b1e9df840e36"
+        //     "ab5615be5d742b6cf203fb55fdc48071";
+        b"passwordPASSWORDpassword", b"saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096,
             "b2d8f1245fc4d29274802057e4b54e0a"
             "0753aa22fc53760b301cf008679e58fe"
             "4bee9addcae99ba2b0b20f431a9c5e50"
             "f395c89387d0945aedeca6eb4015dfc2"
             "bd2421ee9bb71183ba882ceebfef259f"
             "33f9e27dc6178cb89dc37428cf9cc52a"
-            "2baa2d3a"
-        ),
-    );
-
-    assert_eq!(
-        f::<Streebog512, 64>(b"pass\0word", b"sa\0lt", 4096),
-        hex!(
+            "2baa2d3a";
+        b"pass\0word", b"sa\0lt", 4096,
             "50df062885b69801a3c10248eb0a27ab"
             "6e522ffeb20c991c660f001475d73a4e"
             "167f782c18e97e92976d9c1d970831ea"
-            "78ccb879f67068cdac1910740844e830"
-        ),
+            "78ccb879f67068cdac1910740844e830";
+    );
+}
+
+/// Test vector from STB 4.101.45-2013 (page 33):
+/// https://apmi.bsu.by/assets/files/std/bign-spec294.pdf
+#[test]
+fn pbkdf2_belt() {
+    test!(
+        BeltHash;
+        &hex!("42313934 42414338 30413038 46353342"),
+        &hex!("BE329713 43FC9A48"),
+        10_000,
+        "3D331BBB B1FBBB40 E4BF22F6 CB9A689E F13A77DC 09ECF932 91BFE424 39A72E7D";
     );
 }


### PR DESCRIPTION
Additionally, adds a test vector for `belt-hash`.