### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 dependencies = [
  "base64ct",
  "blake2",
@@ -43,7 +43,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.1"
 dependencies = [
  "belt-hash",
  "digest",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.1"
+version = "0.12.0-rc.2"
 dependencies = [
  "password-hash",
  "pbkdf2",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 blowfish = { version = "0.10.0-rc.1", features = ["bcrypt"] }
-pbkdf2 = { version = "0.13.0-rc.0", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.1", default-features = false, path = "../pbkdf2" }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.1"
+version = "0.12.0-rc.2"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-pbkdf2 = { version = "0.13.0-rc.0", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.1", default-features = false }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 [dependencies]
 libc = "0.2"
 hmac = { version = "0.13.0-rc.1", default-features = false }
-pbkdf2 = { version = "0.13.0-rc.0", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.1", default-features = false }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 


### PR DESCRIPTION
Releases the following:
- `argon2` v0.6.0-rc.1
- `bcrypt-pbkdf` v0.11.0-rc.1
- `pbkdf2` v0.13.0-rc.1
- `scrypt` v0.12.0-rc.2