### PR TITLE
yescrypt: replace `u*_t` and `size_t` aliases with Rust types

### DIFF
--- a/yescrypt/src/common.rs
+++ b/yescrypt/src/common.rs
@@ -8,9 +8,7 @@
     unused_mut
 )]
 
-use crate::{size_t, uint32_t, uint64_t};
-
-pub(crate) unsafe fn blkcpy(mut dst: *mut uint32_t, mut src: *const uint32_t, mut count: size_t) {
+pub(crate) unsafe fn blkcpy(mut dst: *mut u32, mut src: *const u32, mut count: usize) {
     loop {
         let fresh0 = src;
         src = src.offset(1);
@@ -24,7 +22,7 @@ pub(crate) unsafe fn blkcpy(mut dst: *mut uint32_t, mut src: *const uint32_t, mu
     }
 }
 
-pub(crate) unsafe fn blkxor(mut dst: *mut uint32_t, mut src: *const uint32_t, mut count: size_t) {
+pub(crate) unsafe fn blkxor(mut dst: *mut u32, mut src: *const u32, mut count: usize) {
     loop {
         let fresh2 = src;
         src = src.offset(1);
@@ -38,28 +36,28 @@ pub(crate) unsafe fn blkxor(mut dst: *mut uint32_t, mut src: *const uint32_t, mu
     }
 }
 
-pub(crate) unsafe fn integerify(mut B: *const uint32_t, mut r: usize) -> uint64_t {
-    let mut X: *const uint32_t = &*B.offset(
+pub(crate) unsafe fn integerify(mut B: *const u32, mut r: usize) -> u64 {
+    let mut X: *const u32 = &*B.offset(
         (2usize)
             .wrapping_mul(r)
             .wrapping_sub(1usize)
             .wrapping_mul(16usize) as isize,
-    ) as *const uint32_t;
-    return ((*X.offset(13 as libc::c_int as isize) as uint64_t) << 32 as libc::c_int)
+    ) as *const u32;
+    return ((*X.offset(13 as libc::c_int as isize) as u64) << 32 as libc::c_int)
         .wrapping_add(*X.offset(0 as libc::c_int as isize) as libc::c_ulong);
 }
 
 #[inline]
-pub(crate) unsafe fn le32dec(mut pp: *const u32) -> uint32_t {
+pub(crate) unsafe fn le32dec(mut pp: *const u32) -> u32 {
     u32::from_le_bytes(pp.cast::<[u8; 4]>().read())
 }
 
 #[inline]
-pub(crate) unsafe fn le32enc(mut pp: *mut u32, mut x: uint32_t) {
+pub(crate) unsafe fn le32enc(mut pp: *mut u32, mut x: u32) {
     pp.cast::<[u8; 4]>().write(x.to_le_bytes());
 }
 
-unsafe fn memxor(mut dst: *mut libc::c_uchar, mut src: *mut libc::c_uchar, mut size: size_t) {
+unsafe fn memxor(mut dst: *mut libc::c_uchar, mut src: *mut libc::c_uchar, mut size: usize) {
     loop {
         let fresh10 = size;
         size = size.wrapping_sub(1);
@@ -86,7 +84,7 @@ pub(crate) fn prev_power_of_two(mut x: u64) -> u64 {
     x
 }
 
-pub(crate) fn wrap(mut x: uint64_t, mut i: uint64_t) -> uint64_t {
-    let mut n: uint64_t = prev_power_of_two(i);
+pub(crate) fn wrap(mut x: u64, mut i: u64) -> u64 {
+    let mut n: u64 = prev_power_of_two(i);
     (x & n.wrapping_sub(1)).wrapping_add(i.wrapping_sub(n))
 }

--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -53,44 +53,39 @@ use crate::{
 };
 use alloc::{vec, vec::Vec};
 use core::ptr;
-use libc::{free, malloc, memcpy};
-
-type uint8_t = libc::c_uchar;
-type uint32_t = libc::c_uint;
-type uint64_t = libc::c_ulong;
-type size_t = usize;
+use libc::{c_void, free, malloc, memcpy};
 
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct Local {
-    pub base: *mut libc::c_void,
-    pub aligned: *mut libc::c_void,
-    pub base_size: size_t,
-    pub aligned_size: size_t,
+    pub base: *mut c_void,
+    pub aligned: *mut c_void,
+    pub base_size: usize,
+    pub aligned_size: usize,
 }
 
-type Flags = uint32_t;
+type Flags = u32;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct Params {
     pub flags: Flags,
-    pub N: uint64_t,
-    pub r: uint32_t,
-    pub p: uint32_t,
-    pub t: uint32_t,
-    pub g: uint32_t,
-    pub NROM: uint64_t,
+    pub N: u64,
+    pub r: u32,
+    pub p: u32,
+    pub t: u32,
+    pub g: u32,
+    pub NROM: u64,
 }
 
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct PwxformCtx {
-    pub S: *mut uint32_t,
-    pub S0: *mut [uint32_t; 2],
-    pub S1: *mut [uint32_t; 2],
-    pub S2: *mut [uint32_t; 2],
-    pub w: size_t,
+    pub S: *mut u32,
+    pub S0: *mut [u32; 2],
+    pub S1: *mut [u32; 2],
+    pub S2: *mut [u32; 2],
+    pub w: usize,
 }
 
 /// yescrypt Key Derivation Function (KDF)
@@ -141,15 +136,15 @@ pub fn yescrypt_kdf(
 
 unsafe fn yescrypt_kdf_inner(
     local: *mut Local,
-    mut passwd: *const uint8_t,
-    mut passwdlen: size_t,
-    salt: *const uint8_t,
-    saltlen: size_t,
+    mut passwd: *const u8,
+    mut passwdlen: usize,
+    salt: *const u8,
+    saltlen: usize,
     params: &Params,
-    buf: *mut uint8_t,
-    buflen: size_t,
-) -> libc::c_int {
-    let mut dk: [uint8_t; 32] = [0; 32];
+    buf: *mut u8,
+    buflen: usize,
+) -> i32 {
+    let mut dk: [u8; 32] = [0; 32];
     if params.g != 0 {
         return -1;
     }
@@ -202,23 +197,23 @@ unsafe fn yescrypt_kdf_inner(
 
 unsafe fn yescrypt_kdf_body(
     local: *mut Local,
-    mut passwd: *const uint8_t,
-    mut passwdlen: size_t,
-    salt: *const uint8_t,
-    saltlen: size_t,
+    mut passwd: *const u8,
+    mut passwdlen: usize,
+    salt: *const u8,
+    saltlen: usize,
     flags: Flags,
     N: u64,
-    r: uint32_t,
-    p: uint32_t,
-    t: uint32_t,
+    r: u32,
+    p: u32,
+    t: u32,
     NROM: u64,
-    buf: *mut uint8_t,
-    buflen: size_t,
-) -> libc::c_int {
-    let mut retval: libc::c_int = -1;
-    let mut V: *mut uint32_t;
-    let mut sha256: [uint32_t; 8] = [0; 8];
-    let mut dk: [uint8_t; 32] = [0; 32];
+    buf: *mut u8,
+    buflen: usize,
+) -> i32 {
+    let mut retval: i32 = -1;
+    let mut V: *mut u32;
+    let mut sha256: [u32; 8] = [0; 8];
+    let mut dk: [u8; 32] = [0; 32];
 
     match flags & 0x3 {
         0 => {
@@ -245,30 +240,25 @@ unsafe fn yescrypt_kdf_body(
         }
     }
     if !(!(buflen > (1usize << 32).wrapping_sub(1).wrapping_mul(32))
-        && !((r as uint64_t).wrapping_mul(p as uint64_t) >= (1 << 30) as libc::c_ulong)
+        && !((r as u64).wrapping_mul(p as u64) >= (1 << 30) as u64)
         && !(N & N.wrapping_sub(1) != 0 || N <= 1 || r < 1 || p < 1)
-        && !(r as libc::c_ulong
-            > (18446744073709551615 as libc::c_ulong)
-                .wrapping_div(128 as libc::c_ulong)
-                .wrapping_div(p as libc::c_ulong)
-            || N > (18446744073709551615 as libc::c_ulong)
-                .wrapping_div(128 as libc::c_ulong)
-                .wrapping_div(r as libc::c_ulong))
-        && !(N
-            > (18446744073709551615 as libc::c_ulong)
-                .wrapping_div((t as uint64_t).wrapping_add(1))))
+        && !(r as u64
+            > 18446744073709551615_u64
+                .wrapping_div(128_u64)
+                .wrapping_div(p as u64)
+            || N > 18446744073709551615_u64
+                .wrapping_div(128_u64)
+                .wrapping_div(r as u64))
+        && !(N > 18446744073709551615_u64.wrapping_div((t as u64).wrapping_add(1))))
     {
         return -1;
     }
 
     if flags & 0x2 != 0
-        && (N.wrapping_div(p as libc::c_ulong) <= 1
-            || r < ((4 * 2 * 8 + 127) / 128) as libc::c_uint
-            || p as libc::c_ulong
-                > (18446744073709551615 as libc::c_ulong).wrapping_div(3 * (1 << 8) * 2 * 8)
-            || p as libc::c_ulong
-                > (18446744073709551615 as libc::c_ulong)
-                    .wrapping_div(size_of::<PwxformCtx>() as libc::c_ulong))
+        && (N.wrapping_div(p as u64) <= 1
+            || r < ((4 * 2 * 8 + 127) / 128) as u32
+            || p as u64 > 18446744073709551615_u64.wrapping_div(3 * (1 << 8) * 2 * 8)
+            || p as u64 > 18446744073709551615_u64.wrapping_div(size_of::<PwxformCtx>() as u64))
     {
         return -1;
     }
@@ -279,7 +269,7 @@ unsafe fn yescrypt_kdf_body(
 
     let V_size = 128usize.wrapping_mul(r as usize).wrapping_mul(N as usize);
     if flags & 0x1000000 != 0 {
-        V = (*local).aligned as *mut uint32_t;
+        V = (*local).aligned as *mut u32;
         if (*local).aligned_size < V_size {
             if !((*local).base).is_null()
                 || !((*local).aligned).is_null()
@@ -289,33 +279,33 @@ unsafe fn yescrypt_kdf_body(
                 return -1;
             }
             {
-                V = malloc(V_size) as *mut uint32_t;
+                V = malloc(V_size) as *mut u32;
                 if V.is_null() {
                     return -(1);
                 }
-                (*local).aligned = V as *mut libc::c_void;
+                (*local).aligned = V as *mut c_void;
                 (*local).base = (*local).aligned;
                 (*local).aligned_size = V_size;
                 (*local).base_size = (*local).aligned_size;
             }
         }
         if flags & 0x8000000 != 0 {
-            return -(2 as libc::c_int);
+            return -2_i32;
         }
     } else {
-        V = malloc(V_size) as *mut uint32_t;
+        V = malloc(V_size) as *mut u32;
         if V.is_null() {
             return -(1);
         }
     }
 
     let B_size = 128usize.wrapping_mul(r as usize).wrapping_mul(p as usize);
-    let B = malloc(B_size) as *mut uint32_t;
+    let B = malloc(B_size) as *mut u32;
     if B.is_null() {
         return -1;
     }
     'free_b: {
-        let XY = malloc(256usize.wrapping_mul(r as usize)) as *mut uint32_t;
+        let XY = malloc(256usize.wrapping_mul(r as usize)) as *mut u32;
         if XY.is_null() {
             break 'free_b;
         }
@@ -326,7 +316,7 @@ unsafe fn yescrypt_kdf_body(
                 if flags & 0x2 != 0 {
                     S = malloc(
                         (3usize * ((1usize) << 8usize) * 2usize * 8usize).wrapping_mul(p as usize),
-                    ) as *mut uint32_t;
+                    ) as *mut u32;
                     if S.is_null() {
                         break 'free_xy;
                     }
@@ -341,34 +331,25 @@ unsafe fn yescrypt_kdf_body(
 
                 if flags != 0 {
                     HMAC_SHA256_Buf(
-                        b"yescrypt-prehash\0" as *const u8 as *const libc::c_char
-                            as *const libc::c_void,
+                        b"yescrypt-prehash\0" as *const u8 as *const i8 as *const c_void,
                         (if flags & 0x10000000 != 0 {
-                            16 as libc::c_int
+                            16_i32
                         } else {
-                            8 as libc::c_int
-                        }) as size_t,
-                        passwd as *const libc::c_void,
+                            8_i32
+                        }) as usize,
+                        passwd as *const c_void,
                         passwdlen,
-                        sha256.as_mut_ptr() as *mut uint8_t,
+                        sha256.as_mut_ptr() as *mut u8,
                     );
-                    passwd = sha256.as_mut_ptr() as *mut uint8_t;
-                    passwdlen = size_of::<[uint32_t; 8]>();
+                    passwd = sha256.as_mut_ptr() as *mut u8;
+                    passwdlen = size_of::<[u32; 8]>();
                 }
-                PBKDF2_SHA256(
-                    passwd,
-                    passwdlen,
-                    salt,
-                    saltlen,
-                    1,
-                    B as *mut uint8_t,
-                    B_size,
-                );
+                PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, 1, B as *mut u8, B_size);
                 if flags != 0 {
                     blkcpy(
                         sha256.as_mut_ptr(),
                         B,
-                        (size_of::<[uint32_t; 8]>()).wrapping_div(size_of::<uint32_t>()),
+                        (size_of::<[u32; 8]>()).wrapping_div(size_of::<u32>()),
                     );
                 }
                 if flags & 0x2 != 0 {
@@ -380,7 +361,7 @@ unsafe fn yescrypt_kdf_body(
                     }
                     smix(
                         B,
-                        r as size_t,
+                        r as usize,
                         N,
                         p,
                         t,
@@ -388,14 +369,14 @@ unsafe fn yescrypt_kdf_body(
                         V,
                         XY,
                         pwxform_ctx,
-                        sha256.as_mut_ptr() as *mut uint8_t,
+                        sha256.as_mut_ptr() as *mut u8,
                     );
                 } else {
                     for i in 0..p {
                         smix(
                             &mut *B
                                 .add((32usize).wrapping_mul(r as usize).wrapping_mul(i as usize)),
-                            r as size_t,
+                            r as usize,
                             N,
                             1,
                             t,
@@ -412,7 +393,7 @@ unsafe fn yescrypt_kdf_body(
                     PBKDF2_SHA256(
                         passwd,
                         passwdlen,
-                        B as *mut uint8_t,
+                        B as *mut u8,
                         B_size,
                         1,
                         dk.as_mut_ptr(),
@@ -420,79 +401,73 @@ unsafe fn yescrypt_kdf_body(
                     );
                     dkp = dk.as_mut_ptr();
                 }
-                PBKDF2_SHA256(passwd, passwdlen, B as *mut uint8_t, B_size, 1, buf, buflen);
+                PBKDF2_SHA256(passwd, passwdlen, B as *mut u8, B_size, 1, buf, buflen);
                 if flags != 0 && flags & 0x10000000 == 0 {
                     HMAC_SHA256_Buf(
-                        dkp as *const libc::c_void,
+                        dkp as *const c_void,
                         32,
-                        b"Client Key\0" as *const u8 as *const libc::c_char as *const libc::c_void,
+                        b"Client Key\0" as *const u8 as *const i8 as *const c_void,
                         10,
-                        sha256.as_mut_ptr() as *mut uint8_t,
+                        sha256.as_mut_ptr() as *mut u8,
                     );
-                    let mut clen: size_t = buflen;
+                    let mut clen: usize = buflen;
                     if clen > 32 {
                         clen = 32;
                     }
                     SHA256_Buf(
-                        sha256.as_mut_ptr() as *mut uint8_t as *const libc::c_void,
-                        size_of::<[uint32_t; 8]>(),
+                        sha256.as_mut_ptr() as *mut u8 as *const c_void,
+                        size_of::<[u32; 8]>(),
                         dk.as_mut_ptr(),
                     );
-                    memcpy(
-                        buf as *mut libc::c_void,
-                        dk.as_mut_ptr() as *const libc::c_void,
-                        clen as usize,
-                    );
+                    memcpy(buf as *mut c_void, dk.as_mut_ptr() as *const c_void, clen);
                 }
                 retval = 0;
-                free(pwxform_ctx as *mut libc::c_void);
+                free(pwxform_ctx as *mut c_void);
             }
-            free(S as *mut libc::c_void);
+            free(S as *mut c_void);
         }
-        free(XY as *mut libc::c_void);
+        free(XY as *mut c_void);
     }
-    free(B as *mut libc::c_void);
+    free(B as *mut c_void);
     if flags & 0x1000000 == 0 {
-        free(V as *mut libc::c_void);
+        free(V as *mut c_void);
     }
     retval
 }
 
-unsafe fn pwxform(B: *mut uint32_t, ctx: *mut PwxformCtx) {
-    let X: *mut [[uint32_t; 2]; 2] = B as *mut [[uint32_t; 2]; 2];
-    let S0: *mut [uint32_t; 2] = (*ctx).S0;
-    let S1: *mut [uint32_t; 2] = (*ctx).S1;
-    let S2: *mut [uint32_t; 2] = (*ctx).S2;
-    let mut w: size_t = (*ctx).w;
+unsafe fn pwxform(B: *mut u32, ctx: *mut PwxformCtx) {
+    let X: *mut [[u32; 2]; 2] = B as *mut [[u32; 2]; 2];
+    let S0: *mut [u32; 2] = (*ctx).S0;
+    let S1: *mut [u32; 2] = (*ctx).S1;
+    let S2: *mut [u32; 2] = (*ctx).S2;
+    let mut w: usize = (*ctx).w;
     for i in 0..6 {
         for j in 0..4 {
-            let mut xl: uint32_t = (*X.offset(j as isize))[0][0];
-            let mut xh: uint32_t = (*X.offset(j as isize))[0][1];
+            let mut xl: u32 = (*X.offset(j as isize))[0][0];
+            let mut xh: u32 = (*X.offset(j as isize))[0][1];
             let p0 = S0.offset(
-                ((xl & (((1 << 8) - 1) * 2 * 8) as libc::c_uint) as libc::c_ulong)
-                    .wrapping_div(size_of::<[uint32_t; 2]>() as libc::c_ulong)
-                    as isize,
+                ((xl & (((1 << 8) - 1) * 2 * 8) as u32) as u64)
+                    .wrapping_div(size_of::<[u32; 2]>() as u64) as isize,
             );
             let p1 = S1.offset(
-                ((xh & (((1 << 8) - 1) * 2 * 8) as libc::c_uint) as libc::c_ulong)
-                    .wrapping_div(size_of::<[uint32_t; 2]>() as libc::c_ulong)
-                    as isize,
+                ((xh & (((1 << 8) - 1) * 2 * 8) as u32) as u64)
+                    .wrapping_div(size_of::<[u32; 2]>() as u64) as isize,
             );
             for k in 0..2 {
-                let s0 = (((*p0.offset(k as isize))[1] as uint64_t) << 32)
-                    .wrapping_add((*p0.offset(k as isize))[0] as libc::c_ulong);
-                let s1 = (((*p1.offset(k as isize))[1] as uint64_t) << 32)
-                    .wrapping_add((*p1.offset(k as isize))[0] as libc::c_ulong);
+                let s0 = (((*p0.offset(k as isize))[1] as u64) << 32)
+                    .wrapping_add((*p0.offset(k as isize))[0] as u64);
+                let s1 = (((*p1.offset(k as isize))[1] as u64) << 32)
+                    .wrapping_add((*p1.offset(k as isize))[0] as u64);
                 xl = (*X.offset(j as isize))[k as usize][0];
                 xh = (*X.offset(j as isize))[k as usize][1];
-                let mut x = (xh as uint64_t).wrapping_mul(xl as libc::c_ulong);
-                x = (x as libc::c_ulong).wrapping_add(s0) as uint64_t;
+                let mut x = (xh as u64).wrapping_mul(xl as u64);
+                x = x.wrapping_add(s0);
                 x ^= s1;
-                (*X.offset(j as isize))[k as usize][0] = x as uint32_t;
-                (*X.offset(j as isize))[k as usize][1] = (x >> 32) as uint32_t;
+                (*X.offset(j as isize))[k as usize][0] = x as u32;
+                (*X.offset(j as isize))[k as usize][1] = (x >> 32) as u32;
                 if i != 0usize && i != (6 - 1) {
-                    (*S2.offset(w as isize))[0] = x as uint32_t;
-                    (*S2.offset(w as isize))[1] = (x >> 32) as uint32_t;
+                    (*S2.offset(w as isize))[0] = x as u32;
+                    (*S2.offset(w as isize))[1] = (x >> 32) as u32;
                     w = w.wrapping_add(1);
                 }
             }
@@ -504,35 +479,33 @@ unsafe fn pwxform(B: *mut uint32_t, ctx: *mut PwxformCtx) {
     (*ctx).w = w & (((1usize) << 8usize) * 2usize - 1usize);
 }
 
-unsafe fn blockmix_pwxform(B: *mut uint32_t, ctx: *mut PwxformCtx, r: usize) {
-    let mut X: [uint32_t; 16] = [0; 16];
+unsafe fn blockmix_pwxform(B: *mut u32, ctx: *mut PwxformCtx, r: usize) {
+    let mut X: [u32; 16] = [0; 16];
     let r1 = (128usize).wrapping_mul(r).wrapping_div(4 * 2 * 8);
     blkcpy(
         X.as_mut_ptr(),
         &mut *B.offset(
             r1.wrapping_sub(1usize)
-                .wrapping_mul((4usize * 2 * 8).wrapping_div(size_of::<uint32_t>()))
-                as isize,
+                .wrapping_mul((4usize * 2 * 8).wrapping_div(size_of::<u32>())) as isize,
         ),
-        (4usize * 2 * 8).wrapping_div(size_of::<uint32_t>()),
+        (4usize * 2 * 8).wrapping_div(size_of::<u32>()),
     );
     for i in 0..r1 {
         if r1 > 1 {
             blkxor(
                 X.as_mut_ptr(),
                 &mut *B.offset(
-                    i.wrapping_mul((4usize * 2 * 8).wrapping_div(size_of::<uint32_t>())) as isize,
+                    i.wrapping_mul((4usize * 2 * 8).wrapping_div(size_of::<u32>())) as isize,
                 ),
-                (4usize * 2 * 8).wrapping_div(size_of::<uint32_t>()),
+                (4usize * 2 * 8).wrapping_div(size_of::<u32>()),
             );
         }
         pwxform(X.as_mut_ptr(), ctx);
         blkcpy(
-            &mut *B.offset(
-                i.wrapping_mul((4usize * 2 * 8).wrapping_div(size_of::<uint32_t>())) as isize,
-            ),
+            &mut *B
+                .offset(i.wrapping_mul((4usize * 2 * 8).wrapping_div(size_of::<u32>())) as isize),
             X.as_mut_ptr(),
-            (4usize * 2 * 8).wrapping_div(size_of::<uint32_t>()),
+            (4usize * 2 * 8).wrapping_div(size_of::<u32>()),
         );
     }
     let i = r1.wrapping_sub(1).wrapping_mul(4 * 2 * 8).wrapping_div(64);
@@ -542,51 +515,47 @@ unsafe fn blockmix_pwxform(B: *mut uint32_t, ctx: *mut PwxformCtx, r: usize) {
         blkxor(
             &mut *B.offset(i.wrapping_mul(16usize) as isize),
             &mut *B.offset(i.wrapping_sub(1usize).wrapping_mul(16usize) as isize),
-            16 as size_t,
+            16_usize,
         );
         salsa20::salsa20_2(&mut *B.offset(i.wrapping_mul(16) as isize));
     }
 }
 
 unsafe fn smix(
-    B: *mut uint32_t,
+    B: *mut u32,
     r: usize,
     N: u64,
-    p: uint32_t,
-    t: uint32_t,
+    p: u32,
+    t: u32,
     flags: Flags,
-    V: *mut uint32_t,
-    XY: *mut uint32_t,
+    V: *mut u32,
+    XY: *mut u32,
     ctx: *mut PwxformCtx,
-    passwd: *mut uint8_t,
+    passwd: *mut u8,
 ) {
-    let s: size_t = (32 * r) as size_t;
-    let mut Nchunk = N.wrapping_div(p as libc::c_ulong);
+    let s: usize = 32 * r;
+    let mut Nchunk = N.wrapping_div(p as u64);
     let mut Nloop_all = Nchunk;
     if flags & 0x2 != 0 {
         if t <= 1 {
             if t != 0 {
-                Nloop_all = (Nloop_all as libc::c_ulong).wrapping_mul(2) as uint64_t;
+                Nloop_all = Nloop_all.wrapping_mul(2);
             }
             Nloop_all = Nloop_all.wrapping_add(2).wrapping_div(3);
         } else {
-            Nloop_all = (Nloop_all as libc::c_ulong)
-                .wrapping_mul(t.wrapping_sub(1) as libc::c_ulong)
-                as uint64_t;
+            Nloop_all = Nloop_all.wrapping_mul(t.wrapping_sub(1) as u64);
         }
     } else if t != 0 {
         if t == 1 {
-            Nloop_all = (Nloop_all as libc::c_ulong)
-                .wrapping_add(Nloop_all.wrapping_add(1).wrapping_div(2))
-                as uint64_t;
+            Nloop_all = Nloop_all.wrapping_add(Nloop_all.wrapping_add(1).wrapping_div(2));
         }
-        Nloop_all = (Nloop_all as libc::c_ulong).wrapping_mul(t as libc::c_ulong) as uint64_t;
+        Nloop_all = Nloop_all.wrapping_mul(t as u64);
     }
     let mut Nloop_rw = 0;
     if flags & 0x1000000 != 0 {
         Nloop_rw = Nloop_all;
     } else if flags & 0x2 != 0 {
-        Nloop_rw = Nloop_all.wrapping_div(p as libc::c_ulong);
+        Nloop_rw = Nloop_all.wrapping_div(p as u64);
     }
     Nchunk &= !(1);
     Nloop_all = Nloop_all.wrapping_add(1);
@@ -600,10 +569,8 @@ unsafe fn smix(
         } else {
             N.wrapping_sub(Vchunk)
         };
-        let Bp: *mut uint32_t =
-            &mut *B.offset((i as usize).wrapping_mul(s) as isize) as *mut uint32_t;
-        let Vp: *mut uint32_t =
-            &mut *V.offset((Vchunk as usize).wrapping_mul(s) as isize) as *mut uint32_t;
+        let Bp: *mut u32 = &mut *B.offset((i as usize).wrapping_mul(s) as isize) as *mut u32;
+        let Vp: *mut u32 = &mut *V.offset((Vchunk as usize).wrapping_mul(s) as isize) as *mut u32;
         let mut ctx_i: *mut PwxformCtx = ptr::null_mut();
         if flags & 0x2 != 0 {
             ctx_i = &mut *ctx.offset(i as isize) as *mut PwxformCtx;
@@ -616,15 +583,15 @@ unsafe fn smix(
                 XY,
                 ptr::null_mut(),
             );
-            (*ctx_i).S2 = (*ctx_i).S as *mut [uint32_t; 2];
+            (*ctx_i).S2 = (*ctx_i).S as *mut [u32; 2];
             (*ctx_i).S1 = ((*ctx_i).S2).offset(((1 << 8) * 2) as isize);
             (*ctx_i).S0 = ((*ctx_i).S1).offset(((1 << 8) * 2) as isize);
             (*ctx_i).w = 0;
             if i == 0 {
                 HMAC_SHA256_Buf(
-                    Bp.offset(s.wrapping_sub(16) as isize) as *const libc::c_void,
+                    Bp.offset(s.wrapping_sub(16) as isize) as *const c_void,
                     64,
-                    passwd as *const libc::c_void,
+                    passwd as *const c_void,
                     32,
                     passwd,
                 );
@@ -632,11 +599,10 @@ unsafe fn smix(
         }
         smix1(Bp, r, Np, flags, Vp, XY, ctx_i);
         smix2(Bp, r, prev_power_of_two(Np), Nloop_rw, flags, Vp, XY, ctx_i);
-        Vchunk = (Vchunk as libc::c_ulong).wrapping_add(Nchunk) as uint64_t;
+        Vchunk = Vchunk.wrapping_add(Nchunk);
     }
     for i in 0..p {
-        let Bp_0: *mut uint32_t =
-            &mut *B.offset((i as usize).wrapping_mul(s) as isize) as *mut uint32_t;
+        let Bp_0: *mut u32 = &mut *B.offset((i as usize).wrapping_mul(s) as isize) as *mut u32;
         smix2(
             Bp_0,
             r,
@@ -655,17 +621,17 @@ unsafe fn smix(
 }
 
 unsafe fn smix1(
-    B: *mut uint32_t,
+    B: *mut u32,
     r: usize,
-    N: uint64_t,
+    N: u64,
     flags: Flags,
-    V: *mut uint32_t,
-    XY: *mut uint32_t,
+    V: *mut u32,
+    XY: *mut u32,
     ctx: *mut PwxformCtx,
 ) {
-    let s: size_t = (32usize).wrapping_mul(r);
-    let X: *mut uint32_t = XY;
-    let Y: *mut uint32_t = &mut *XY.offset(s as isize) as *mut uint32_t;
+    let s: usize = (32usize).wrapping_mul(r);
+    let X: *mut u32 = XY;
+    let Y: *mut u32 = &mut *XY.offset(s as isize) as *mut u32;
     for k in 0..(2usize).wrapping_mul(r) {
         for i in 0..16usize {
             *X.offset(k.wrapping_mul(16usize).wrapping_add(i) as isize) = le32dec(
@@ -712,18 +678,18 @@ unsafe fn smix1(
 }
 
 unsafe fn smix2(
-    B: *mut uint32_t,
+    B: *mut u32,
     r: usize,
     N: u64,
     Nloop: u64,
     flags: Flags,
-    V: *mut uint32_t,
-    XY: *mut uint32_t,
+    V: *mut u32,
+    XY: *mut u32,
     ctx: *mut PwxformCtx,
 ) {
-    let s: size_t = (32usize).wrapping_mul(r);
-    let X: *mut uint32_t = XY;
-    let Y: *mut uint32_t = &mut *XY.offset(s as isize) as *mut uint32_t;
+    let s: usize = (32usize).wrapping_mul(r);
+    let X: *mut u32 = XY;
+    let Y: *mut u32 = &mut *XY.offset(s as isize) as *mut u32;
     for k in 0..(2usize).wrapping_mul(r) {
         for i in 0..16usize {
             *X.offset(k.wrapping_mul(16usize).wrapping_add(i) as isize) = le32dec(

--- a/yescrypt/src/salsa20.rs
+++ b/yescrypt/src/salsa20.rs
@@ -1,16 +1,13 @@
 use salsa20::cipher::typenum::Unsigned;
 
-use crate::{
-    common::{blkcpy, blkxor},
-    uint32_t,
-};
+use crate::common::{blkcpy, blkxor};
 
-pub(crate) unsafe fn salsa20_2(B: *mut uint32_t) {
+pub(crate) unsafe fn salsa20_2(B: *mut u32) {
     salsa20::<salsa20::cipher::consts::U1>(B);
 }
 
-unsafe fn salsa20<R: Unsigned>(B: *mut uint32_t) {
-    let mut x: [uint32_t; 16] = [0; 16];
+unsafe fn salsa20<R: Unsigned>(B: *mut u32) {
+    let mut x: [u32; 16] = [0; 16];
     for i in 0..16 {
         x[i * 5 % 16] = *B.offset(i as isize);
     }
@@ -30,8 +27,8 @@ unsafe fn salsa20<R: Unsigned>(B: *mut uint32_t) {
     }
 }
 
-pub(crate) unsafe fn blockmix_salsa8(B: *mut uint32_t, Y: *mut uint32_t, r: usize) {
-    let mut X: [uint32_t; 16] = [0; 16];
+pub(crate) unsafe fn blockmix_salsa8(B: *mut u32, Y: *mut u32, r: usize) {
+    let mut X: [u32; 16] = [0; 16];
     blkcpy(X.as_mut_ptr(), &mut *B.add((2 * r - 1) * 16), 16);
     for i in 0..(2 * r) {
         blkxor(X.as_mut_ptr(), &mut *B.add(i * 16), 16);

--- a/yescrypt/src/sha256.rs
+++ b/yescrypt/src/sha256.rs
@@ -8,10 +8,9 @@
     unused_mut
 )]
 
-use crate::{size_t, uint8_t, uint64_t};
 use libc::memcpy;
 
-pub unsafe fn SHA256_Buf(mut in_0: *const libc::c_void, mut len: size_t, mut digest: *mut uint8_t) {
+pub unsafe fn SHA256_Buf(mut in_0: *const libc::c_void, mut len: usize, mut digest: *mut u8) {
     use sha2::Digest;
     use sha2::digest::array::Array;
     let mut ctx = sha2::Sha256::new();
@@ -26,15 +25,15 @@ pub unsafe fn SHA256_Buf(mut in_0: *const libc::c_void, mut len: size_t, mut dig
 
 pub unsafe fn HMAC_SHA256_Buf(
     mut K: *const libc::c_void,
-    mut Klen: size_t,
+    mut Klen: usize,
     mut in_0: *const libc::c_void,
-    mut len: size_t,
-    mut digest: *mut uint8_t,
+    mut len: usize,
+    mut digest: *mut u8,
 ) {
     use hmac::KeyInit;
     use hmac::Mac;
 
-    let key = &*core::ptr::slice_from_raw_parts(K as *const uint8_t, Klen);
+    let key = &*core::ptr::slice_from_raw_parts(K as *const u8, Klen);
 
     let mut hmac = hmac::Hmac::<sha2::Sha256>::new_from_slice(key)
         .expect("key length should always be valid with hmac");
@@ -48,13 +47,13 @@ pub unsafe fn HMAC_SHA256_Buf(
 }
 
 pub unsafe fn PBKDF2_SHA256(
-    mut passwd: *const uint8_t,
-    mut passwdlen: size_t,
-    mut salt: *const uint8_t,
-    mut saltlen: size_t,
-    mut c: uint64_t,
-    mut buf: *mut uint8_t,
-    mut dkLen: size_t,
+    mut passwd: *const u8,
+    mut passwdlen: usize,
+    mut salt: *const u8,
+    mut saltlen: usize,
+    mut c: u64,
+    mut buf: *mut u8,
+    mut dkLen: usize,
 ) {
     let passwd = core::ptr::slice_from_raw_parts(passwd, passwdlen);
     let salt = core::ptr::slice_from_raw_parts(salt, saltlen);


### PR DESCRIPTION
- `uint8_t` => `u8`
- `uint32_t` => `u32`
- `uint64_t` => `u64`
- `size_t` => `usize`
- `libc::c_char` => `i8`
- `libc::c_int` => `i32`
- `libc::c_uint` => `u32`
- `libc::c_ulong` => `u64`