### PR TITLE
yescrypt: public `Params` struct

### DIFF
--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -89,7 +89,7 @@ bitflags::bitflags! {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-struct Params {
+pub struct Params {
     pub flags: Flags,
     pub N: u64,
     pub r: u32,
@@ -97,6 +97,21 @@ struct Params {
     pub t: u32,
     pub g: u32,
     pub NROM: u64,
+}
+
+impl Params {
+    /// Initialize params.
+    pub fn new(flags: Flags, n: u64, r: u32, p: u32, t: u32, g: u32) -> Params {
+        Params {
+            flags,
+            N: n,
+            r,
+            p,
+            t,
+            g,
+            NROM: 0,
+        }
+    }
 }
 
 #[derive(Copy, Clone)]
@@ -113,24 +128,9 @@ struct PwxformCtx {
 pub fn yescrypt_kdf(
     passwd: &[u8],
     salt: &[u8],
-    flags: Flags,
-    n: u64,
-    r: u32,
-    p: u32,
-    t: u32,
-    g: u32,
+    params: &Params,
     dst: &mut [u8],
 ) -> Result<(), Error> {
-    let params = Params {
-        flags,
-        N: n,
-        r,
-        p,
-        t,
-        g,
-        NROM: 0,
-    };
-
     let mut local = Local {
         aligned: Vec::new().into_boxed_slice(),
     };

--- a/yescrypt/tests/kats.rs
+++ b/yescrypt/tests/kats.rs
@@ -2,7 +2,7 @@
 //! <https://github.com/openwall/yescrypt/blob/e5873f8/TESTS-OK>
 
 use hex_literal::hex;
-use yescrypt::{Flags, yescrypt_kdf};
+use yescrypt::{Flags, Params, yescrypt_kdf};
 
 #[test]
 fn kat0() {
@@ -10,16 +10,18 @@ fn kat0() {
         "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442"
         "fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906"
     );
+    let params = Params::new(Flags::empty(), 16, 1, 1, 0, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", Flags::empty(), 16, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
 #[test]
 fn kat1() {
     const EXPECTED: [u8; 8] = hex!("77d6576238657b20");
+    let params = Params::new(Flags::empty(), 16, 1, 1, 0, 0);
     let mut actual = [0u8; 8];
-    yescrypt_kdf(b"", b"", Flags::empty(), 16, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -29,8 +31,9 @@ fn kat2() {
         "efad0c23314cb572bc3cfb1543da42f8a8b073004c866b64ab5055a4f09fa5f5"
         "71142ebfe7e05a3b92c432f31dea95ad5f9c854b6456462f4bd0f732b7cdc549"
     );
+    let params = Params::new(Flags::empty(), 4, 1, 1, 0, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", Flags::empty(), 4, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -40,16 +43,18 @@ fn kat3() {
         "85dda48c9ec9de2f7f1ae8b4dfeda51f8b6d56f3081be1a7c0833ba2719a36ab"
         "02885dae36557d342686b17ba75f2c217792de0970ab1d07a9c750936d31426f"
     );
+    let params = Params::new(Flags::WORM, 4, 1, 1, 0, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
 #[test]
 fn kat4() {
     const EXPECTED: [u8; 8] = hex!("85dda48c9ec9de2f");
+    let params = Params::new(Flags::WORM, 4, 1, 1, 0, 0);
     let mut actual = [0u8; 8];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -59,8 +64,9 @@ fn kat5() {
         "4baa8cd8608ba91f3e3439d9ec4fae8f9fc092d9ca22b7377e31ae5b9ad7877c"
         "1168691162dd0e5ef049e570650cbed4384ad60534fb0cbed19ff3f033c94b0c"
     );
+    let params = Params::new(Flags::WORM, 4, 1, 1, 1, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 1, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -70,8 +76,9 @@ fn kat6() {
         "e6e8bba09b6412ffb0b3cc35e37d0b782a47fbaadc57a076d7c6cc2e70919a1b"
         "8d4738c4f83355690742d9bed71c3b8fb0d7eb086ab134c5e55707c2c13c75ef"
     );
+    let params = Params::new(Flags::WORM, 4, 1, 1, 2, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 2, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -81,8 +88,9 @@ fn kat7() {
         "acd9a4201cf4a476ecf7baa6113d86fb65cd07102b4004e4f9d99cd34255a108"
         "997d70ae0a64bf0a4d96c173abf88279c1a94ad9bdf168edfbbd90f66ed5c80d"
     );
+    let params = Params::new(Flags::WORM, 4, 1, 1, 3, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 3, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -90,8 +98,9 @@ fn kat7() {
 fn kat8() {
     const EXPECTED: [u8; 33] =
         hex!("acd9a4201cf4a476ecf7baa6113d86fb65cd07102b4004e4f9d99cd34255a10899");
+    let params = Params::new(Flags::WORM, 4, 1, 1, 3, 0);
     let mut actual = [0u8; 33];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 3, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -99,8 +108,9 @@ fn kat8() {
 fn kat9() {
     const EXPECTED: [u8; 32] =
         hex!("acd9a4201cf4a476ecf7baa6113d86fb65cd07102b4004e4f9d99cd34255a108");
+    let params = Params::new(Flags::WORM, 4, 1, 1, 3, 0);
     let mut actual = [0u8; 32];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 3, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -108,16 +118,18 @@ fn kat9() {
 fn kat10() {
     const EXPECTED: [u8; 31] =
         hex!("acd9a4201cf4a476ecf7baa6113d86fb65cd07102b4004e4f9d99cd34255a1");
+    let params = Params::new(Flags::WORM, 4, 1, 1, 3, 0);
     let mut actual = [0u8; 31];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 3, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
 #[test]
 fn kat11() {
     const EXPECTED: [u8; 1] = hex!("ac");
+    let params = Params::new(Flags::WORM, 4, 1, 1, 3, 0);
     let mut actual = [0u8; 1];
-    yescrypt_kdf(b"", b"", Flags::WORM, 4, 1, 1, 3, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -128,8 +140,9 @@ fn kat12() {
         "c80922bdcc16a3ab5d201d4c6140c671be1f75272ca904739d5ad1ff672b0c21"
     );
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 0, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -137,8 +150,9 @@ fn kat12() {
 fn kat13() {
     const EXPECTED: [u8; 4] = hex!("0cd5af76");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 0, 0);
     let mut actual = [0u8; 4];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -149,8 +163,9 @@ fn kat14() {
         "68ca362c5557cc04b6811e2e730841f526d8f4f7acfbfa9e06fe1f383a71155e"
     );
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 1, 0);
     let mut actual = [0u8; 64];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 1, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -159,8 +174,9 @@ fn kat15() {
     const EXPECTED: [u8; 33] =
         hex!("23b6adf0b60c9a997f58583d80cda48c638cdc2f289edf93a70807725a0d35c468");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 1, 0);
     let mut actual = [0u8; 33];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 1, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -169,8 +185,9 @@ fn kat16() {
     const EXPECTED: [u8; 32] =
         hex!("23b6adf0b60c9a997f58583d80cda48c638cdc2f289edf93a70807725a0d35c4");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 1, 0);
     let mut actual = [0u8; 32];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 1, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -179,8 +196,9 @@ fn kat17() {
     const EXPECTED: [u8; 31] =
         hex!("23b6adf0b60c9a997f58583d80cda48c638cdc2f289edf93a70807725a0d35");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 1, 0);
     let mut actual = [0u8; 31];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 1, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -188,8 +206,9 @@ fn kat17() {
 fn kat18() {
     const EXPECTED: [u8; 1] = hex!("23");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 4, 1, 1, 1, 0);
     let mut actual = [0u8; 1];
-    yescrypt_kdf(b"", b"", flags, 4, 1, 1, 1, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -198,8 +217,9 @@ fn kat19() {
     const EXPECTED: [u8; 40] =
         hex!("e1f981733a94052fcd7acb1405df0bbde8e499b6a1331b775909b48c2f516c40dcc8301635b7237b");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 16, 8, 1, 10, 0);
     let mut actual = [0u8; 40];
-    yescrypt_kdf(b"p", b"s", flags, 16, 8, 1, 10, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -207,8 +227,9 @@ fn kat19() {
 fn kat20() {
     const EXPECTED: [u8; 40] =
         hex!("9e7a4097644284cf3b73b60450ff230cdcb6b1b19b1509eeb482f696c4f1c705c00f740216183a12");
+    let params = Params::new(Flags::WORM, 16, 8, 1, 10, 0);
     let mut actual = [0u8; 40];
-    yescrypt_kdf(b"p", b"s", Flags::WORM, 16, 8, 1, 10, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -217,8 +238,9 @@ fn kat21() {
     const EXPECTED: [u8; 40] =
         hex!("c8c7ff1122b0b291c3f2608948782cd689cc45579017aaa5ff8baa74a632ec99c3d66930fb2023bb");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 16, 8, 1, 0, 0);
     let mut actual = [0u8; 40];
-    yescrypt_kdf(b"p", b"s", flags, 16, 8, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -226,8 +248,9 @@ fn kat21() {
 fn kat22() {
     const EXPECTED: [u8; 40] =
         hex!("9dd636c2d0bb92345286efdaf8a68cfc1b4ffdc4b1adaccc7d864b9a6787b85d6ae0f5280da8889f");
+    let params = Params::new(Flags::WORM, 16, 8, 1, 0, 0);
     let mut actual = [0u8; 40];
-    yescrypt_kdf(b"p", b"s", Flags::WORM, 16, 8, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -236,8 +259,9 @@ fn kat23() {
     const EXPECTED: [u8; 32] =
         hex!("c8c7ff1122b0b291c3f2608948782cd689cc45579017aaa5ff8baa74a632ec99");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 16, 8, 1, 0, 0);
     let mut actual = [0u8; 32];
-    yescrypt_kdf(b"p", b"s", flags, 16, 8, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
 
@@ -245,7 +269,8 @@ fn kat23() {
 fn kat24() {
     const EXPECTED: [u8; 8] = hex!("c8c7ff1122b0b291");
     let flags = Flags::ROUNDS_6 | Flags::RW | Flags::SBOX_12K | Flags::GATHER_4 | Flags::SIMPLE_2;
+    let params = Params::new(flags, 16, 8, 1, 0, 0);
     let mut actual = [0u8; 8];
-    yescrypt_kdf(b"p", b"s", flags, 16, 8, 1, 0, 0, &mut actual).unwrap();
+    yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }


### PR DESCRIPTION
This already existed in the code from the automed translation, but was oddly only used in the internal-facing API, but not all the way to the backend.

This exposes it, which matches our other crates and would be helpful for implementing the `password-hash` API.