### PR TITLE
yescrypt: use `Vec` for `PwxformCtx` storage

### DIFF
--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -232,13 +232,7 @@ unsafe fn yescrypt_kdf_body(
             return Err(Error);
         }
 
-        let pwxform_ctx = match PwxformCtx::alloc(p, s) {
-            Ok(ctx) => ctx,
-            Err(e) => {
-                free(s as *mut c_void);
-                return Err(e);
-            }
-        };
+        let mut pwxform_ctx = PwxformCtx::new(p as usize, s);
 
         smix::smix(
             b.as_mut_ptr(),
@@ -249,11 +243,10 @@ unsafe fn yescrypt_kdf_body(
             flags,
             v.as_mut_ptr(),
             xy.as_mut_ptr(),
-            pwxform_ctx,
+            pwxform_ctx.as_mut_slice(),
             sha256.as_mut_ptr() as *mut u8,
         );
 
-        free(pwxform_ctx as *mut c_void);
         free(s as *mut c_void);
     } else {
         for i in 0..p {
@@ -266,7 +259,7 @@ unsafe fn yescrypt_kdf_body(
                 flags,
                 v.as_mut_ptr(),
                 xy.as_mut_ptr(),
-                ptr::null_mut(),
+                &mut [],
                 ptr::null_mut(),
             );
         }

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -23,10 +23,12 @@ pub(crate) unsafe fn smix(
     flags: Flags,
     v: *mut u32,
     xy: *mut u32,
-    ctx: *mut PwxformCtx,
+    ctx: &mut [PwxformCtx],
     passwd: *mut u8,
 ) {
-    let s: usize = 32 * r;
+    // TODO(tarcieri): switch from pointers to Rust references
+    let ctx = ctx.as_mut_ptr();
+    let s = 32 * r;
 
     // 1: n <-- N / p
     let mut nchunk = n / (p as u64);
@@ -84,7 +86,7 @@ pub(crate) unsafe fn smix(
         };
         let bp = b.add(i.wrapping_mul(s));
         let vp = v.add((vchunk as usize).wrapping_mul(s));
-        let mut ctx_i: *mut PwxformCtx = ptr::null_mut();
+        let mut ctx_i = ptr::null_mut();
 
         // 17: if YESCRYPT_RW flag is set
         if flags.contains(Flags::RW) {
@@ -158,8 +160,8 @@ pub(crate) unsafe fn smix(
 
 /// Compute first loop of `B = SMix_r(B, N)`.
 ///
-/// The input B must be 128r bytes in length; the temporary storage V must be 128rN bytes in length;
-/// the temporary storage XY must be 256r bytes in length.
+/// The input B must be 128r bytes in length; the temporary storage `V` must be 128rN bytes in
+/// length; the temporary storage `XY` must be 256r bytes in length.
 unsafe fn smix1(
     b: *mut u32,
     r: usize,


### PR DESCRIPTION
Removes an instance of `malloc`, replacing it with `Vec`.

Also replaces the immediate first occurance of passing it as a pointer (to `smix`) with a mutable slice, though it's immediately converted to a pointer after that. More work to be done!