### PR TITLE
yescrypt: make buffer arg to `smix` a slice

### DIFF
--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -237,7 +237,7 @@ unsafe fn yescrypt_kdf_body(
         let mut pwxform_ctx = PwxformCtx::new(p as usize, s);
 
         smix::smix(
-            b.as_mut_ptr(),
+            &mut b,
             r as usize,
             n,
             p,
@@ -255,7 +255,7 @@ unsafe fn yescrypt_kdf_body(
         for i in 0..p {
             // 3: B_i <-- MF(B_i, N)
             smix::smix(
-                b[(32 * (r as usize) * (i as usize))..].as_mut_ptr(),
+                &mut b[(32 * (r as usize) * (i as usize))..],
                 r as usize,
                 n,
                 1,

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -15,7 +15,7 @@ use core::ffi::c_void;
 /// length; the temporary storage XY must be 256r bytes in length.  The value N must be a power of 2
 /// greater than 1.
 pub(crate) unsafe fn smix(
-    b: *mut u32,
+    b: &mut [u32],
     r: usize,
     n: u64,
     p: u32,
@@ -83,7 +83,7 @@ pub(crate) unsafe fn smix(
         } else {
             n - vchunk
         };
-        let bp = b.add(i * s);
+        let bp = b.as_mut_ptr().add(i * s);
         let vp = v.add(vchunk as usize * s);
 
         // 17: if YESCRYPT_RW flag is set
@@ -157,7 +157,7 @@ pub(crate) unsafe fn smix(
 
         // 31: SMix2_r(B_i, N, Nloop_all - Nloop_rw, V, flags excluding YESCRYPT_RW)
         smix2(
-            b.add(i * s),
+            b.as_mut_ptr().add(i * s),
             r,
             n,
             nloop_all - nloop_rw,


### PR DESCRIPTION
Replaces the pointer, but still converts to a pointer later in the function. An incremental improvement.