### PR TITLE
yescrypt: extract `util` module; bring MSRV down to 1.86

### DIFF
--- a/.github/workflows/yescrypt.yml
+++ b/.github/workflows/yescrypt.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.88.0 # MSRV
+            rust: 1.86.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -39,7 +39,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.88.0 # MSRV
+            rust: 1.86.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - target: powerpc-unknown-linux-gnu
-            rust: 1.88.0 # MSRV
+            rust: 1.86.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.86"
 
 [dependencies]
 bitflags = "2"

--- a/yescrypt/src/pwxform.rs
+++ b/yescrypt/src/pwxform.rs
@@ -1,6 +1,9 @@
 //! pwxform: parallel wide transformation
 
-use crate::{salsa20, xor};
+use crate::{
+    salsa20,
+    util::{slice_as_chunks_mut, xor},
+};
 
 // These are tunable, but they must meet certain constraints.
 const PWXSIMPLE: usize = 2;
@@ -30,7 +33,8 @@ impl<'a> PwxformCtx<'a> {
     /// The input `B` must be 128r bytes in length.
     pub(crate) fn blockmix_pwxform(&mut self, b: &mut [u32], r: usize) {
         // Convert 128-byte blocks to PWXbytes blocks
-        let (b, _b) = b.as_chunks_mut::<PWXWORDS>();
+        // TODO(tarcieri): use upstream `[T]::as_chunks_mut` when MSRV is 1.88
+        let (b, _b) = slice_as_chunks_mut::<_, PWXWORDS>(b);
         assert_eq!(b.len(), 2 * r);
         assert!(_b.is_empty());
 

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -3,9 +3,10 @@
 use alloc::vec::Vec;
 
 use crate::{
-    Flags, cast_slice, hmac_sha256,
+    Flags,
     pwxform::{PwxformCtx, SWORDS},
-    salsa20, xor,
+    salsa20,
+    util::{cast_slice, hmac_sha256, slice_as_chunks_mut, xor},
 };
 
 const SBYTES: u64 = crate::pwxform::SBYTES as u64;
@@ -115,13 +116,16 @@ pub(crate) fn smix(
             let (s1, s0) = s10.split_at_mut((1 << 8) * 4);
 
             // 19: S2_i <-- S_{i,0...2^Swidth-1}
-            let (s2, _) = s2.as_chunks_mut::<2>();
+            // TODO(tarcieri): use upstream `[T]::as_chunks_mut` when MSRV is 1.88
+            let (s2, _) = slice_as_chunks_mut::<_, 2>(s2);
 
             // 20: S1_i <-- S_{i,2^Swidth...2*2^Swidth-1}
-            let (s1, _) = s1.as_chunks_mut::<2>();
+            // TODO(tarcieri): use upstream `[T]::as_chunks_mut` when MSRV is 1.88
+            let (s1, _) = slice_as_chunks_mut::<_, 2>(s1);
 
             // 21: S0_i <-- S_{i,2*2^Swidth...3*2^Swidth-1}
-            let (s0, _) = s0.as_chunks_mut::<2>();
+            // TODO(tarcieri): use upstream `[T]::as_chunks_mut` when MSRV is 1.88
+            let (s0, _) = slice_as_chunks_mut::<_, 2>(s0);
 
             // 22: w_i <-- 0
             let w = 0;

--- a/yescrypt/src/util.rs
+++ b/yescrypt/src/util.rs
@@ -1,0 +1,72 @@
+//! Utility functions.
+
+use core::{ops::BitXorAssign, slice};
+use sha2::Sha256;
+
+pub(crate) fn xor<T>(dst: &mut [T], src: &[T])
+where
+    T: BitXorAssign + Copy,
+{
+    assert_eq!(dst.len(), src.len());
+    for (dst, src) in core::iter::zip(dst, src) {
+        *dst ^= *src
+    }
+}
+
+pub(crate) fn cast_slice(input: &[u32]) -> &[u8] {
+    let new_len = input
+        .len()
+        .checked_mul(size_of::<u32>() / size_of::<u8>())
+        .unwrap();
+
+    // SAFETY: `new_len` accounts for the size difference between the two types
+    unsafe { slice::from_raw_parts(input.as_ptr().cast(), new_len) }
+}
+
+pub(crate) fn cast_slice_mut(input: &mut [u32]) -> &mut [u8] {
+    let new_len = input
+        .len()
+        .checked_mul(size_of::<u32>() / size_of::<u8>())
+        .unwrap();
+
+    // SAFETY: `new_len` accounts for the size difference between the two types
+    unsafe { slice::from_raw_parts_mut(input.as_mut_ptr().cast(), new_len) }
+}
+
+pub(crate) fn hmac_sha256(key: &[u8], in_0: &[u8]) -> [u8; 32] {
+    use hmac::{KeyInit, Mac};
+
+    let mut hmac = hmac::Hmac::<Sha256>::new_from_slice(key)
+        .expect("key length should always be valid with hmac");
+    hmac.update(in_0);
+    hmac.finalize().into_bytes().into()
+}
+
+// TODO(tarcieri): use upstream `[T]::as_chunks_mut` when MSRV is 1.88
+#[inline]
+#[must_use]
+pub(crate) fn slice_as_chunks_mut<T, const N: usize>(slice: &mut [T]) -> (&mut [[T; N]], &mut [T]) {
+    assert!(N != 0, "chunk size must be non-zero");
+    let len_rounded_down = slice.len() / N * N;
+    // SAFETY: The rounded-down value is always the same or smaller than the
+    // original length, and thus must be in-bounds of the slice.
+    let (multiple_of_n, remainder) = unsafe { slice.split_at_mut_unchecked(len_rounded_down) };
+    // SAFETY: We already panicked for zero, and ensured by construction
+    // that the length of the subslice is a multiple of N.
+    let array_slice = unsafe { slice_as_chunks_unchecked_mut(multiple_of_n) };
+    (array_slice, remainder)
+}
+
+#[inline]
+#[must_use]
+unsafe fn slice_as_chunks_unchecked_mut<T, const N: usize>(slice: &mut [T]) -> &mut [[T; N]] {
+    assert!(
+        N != 0 && slice.len() % N == 0,
+        "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks"
+    );
+
+    let new_len = slice.len() / N;
+    // SAFETY: We cast a slice of `new_len * N` elements into
+    // a slice of `new_len` many `N` elements chunks.
+    unsafe { slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), new_len) }
+}


### PR DESCRIPTION
Ideally we could ship a crate with MSRV 1.85 so we have a release that works on stable Debian.

This vendors the code for `[T]::as_chunks_mut` and in the process extracts a `util` module to contain the various shared free functions.

There's still a usage of `get_disjoint_mut` which keeps the MSRV at 1.86 which is a bit less trivial to just vendor like this, which is not addressed for now, but ideally we'd have a temporary replacement for that as well.

cc @conradludgate 