### PR TITLE
yescrypt: restore MSRV 1.85

### DIFF
--- a/.github/workflows/yescrypt.yml
+++ b/.github/workflows/yescrypt.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.86.0 # MSRV
+            rust: 1.85.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -39,7 +39,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.86.0 # MSRV
+            rust: 1.85.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - target: powerpc-unknown-linux-gnu
-            rust: 1.86.0 # MSRV
+            rust: 1.85.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["crypto", "hashing", "password", "phf"]
 categories = ["authentication", "cryptography", "no-std"]
 readme = "README.md"
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.85"
 
 [dependencies]
 bitflags = "2"

--- a/yescrypt/README.md
+++ b/yescrypt/README.md
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/yescrypt/badge.svg
 [docs-link]: https://docs.rs/yescrypt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.86+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/password-hashes/actions/workflows/yescrypt.yml/badge.svg

--- a/yescrypt/src/pwxform.rs
+++ b/yescrypt/src/pwxform.rs
@@ -68,7 +68,9 @@ impl PwxformCtx<'_> {
 
         // 12: for i = i + 1 to 2r - 1 do
         for i in (i + 1)..(2 * r) {
-            let [bim1, bi] = b.get_disjoint_mut([i - 1, i]).unwrap();
+            // TODO(tarcieri): use `get_disjoint_mut` when MSRV is 1.86
+            let (bim1, bi) = b[(i - 1)..i].split_at_mut(1);
+            let (bim1, bi) = (&bim1[0], &mut bi[0]);
 
             /* 13: B_i <-- H(B_i xor B_{i-1}) */
             xor(bi, bim1);


### PR DESCRIPTION
This is a nice MSRV to release on because we get both the 2024 edition and Debian stable support.

Includes TODOs to use `get_disjoint_mut` when MSRV is 1.86