### PR TITLE
yescrypt: params decoder

### DIFF
--- a/yescrypt/src/params.rs
+++ b/yescrypt/src/params.rs
@@ -1,12 +1,16 @@
 //! Algorithm parameters.
 
-use crate::{Error, Flags, Result, encoding::encode64_uint32};
-use core::str;
+use crate::{
+    Error, Flags, Result,
+    encoding::{decode64_uint32, encode64_uint32},
+};
+use alloc::string::{String, ToString};
+use core::str::{self, FromStr};
 
 /// `yescrypt` algorithm parameters.
 ///
 /// These are various algorithm settings which can control e.g. the amount of resource utilization.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Flags which provide fine-grained behavior control.
     pub(crate) flags: Flags,
@@ -32,7 +36,7 @@ pub struct Params {
 
 impl Params {
     /// Maximum length of params when encoded as Base64: up to 8 params of up to 6 chars each.
-    pub const MAX_ENCODED_LEN: usize = 8 * 6;
+    pub(crate) const MAX_ENCODED_LEN: usize = 8 * 6;
 
     /// Initialize params.
     pub const fn new(flags: Flags, n: u64, r: u32, p: u32) -> Params {
@@ -80,7 +84,7 @@ impl Params {
 
     /// Encode params as (s)crypt-flavored Base64.
     #[allow(non_snake_case)]
-    pub fn encode<'o>(&self, out: &'o mut [u8]) -> Result<&'o str> {
+    pub(crate) fn encode<'o>(&self, out: &'o mut [u8]) -> Result<&'o str> {
         let flavor = if self.flags.bits() < Flags::RW.bits() {
             self.flags.bits()
         } else if (self.flags & Flags::MODE_MASK) == Flags::RW
@@ -119,6 +123,7 @@ impl Params {
         let written = encode64_uint32(&mut out[pos..], self.r, 1)?;
         pos += written;
 
+        // "have" bits signal which additional optional fields are present
         let mut have = 0;
         if self.p != 1 {
             have |= 1;
@@ -173,6 +178,96 @@ impl Default for Params {
     }
 }
 
+impl FromStr for Params {
+    type Err = Error;
+
+    #[allow(non_snake_case)]
+    fn from_str(s: &str) -> Result<Params> {
+        let bytes = s.as_bytes();
+        let mut pos = 0usize;
+
+        // flags
+        let (flavor, new_pos) = decode64_uint32(bytes, pos, 0).ok_or(Error)?;
+        pos = new_pos;
+
+        let flags = if flavor < Flags::RW.bits() {
+            Flags::from_bits(flavor)
+        } else if flavor <= Flags::RW.bits() + (Flags::RW_FLAVOR_MASK.bits() >> 2) {
+            Flags::from_bits(Flags::RW.bits() + ((flavor - Flags::RW.bits()) << 2))
+        } else {
+            return Err(Error);
+        }
+        .ok_or(Error)?;
+
+        // Nlog2
+        let (nlog2, new_pos) = decode64_uint32(bytes, pos, 1).ok_or(Error)?;
+        pos = new_pos;
+        if nlog2 > 63 {
+            return Err(Error);
+        }
+        let n = 1 << nlog2;
+
+        // r
+        let (r, new_pos) = decode64_uint32(bytes, pos, 1).ok_or(Error)?;
+        pos = new_pos;
+
+        let mut params = Self {
+            flags,
+            n,
+            r,
+            p: 1,
+            t: 0,
+            g: 0,
+            nrom: 0,
+        };
+
+        if pos < bytes.len() {
+            // "have" bits signaling which optional fields are present
+            let (have, new_pos) = decode64_uint32(bytes, pos, 1).ok_or(Error)?;
+            pos = new_pos;
+
+            // p
+            if (have & 0x01) != 0 {
+                let (p, new_pos) = decode64_uint32(bytes, pos, 2).ok_or(Error)?;
+                pos = new_pos;
+                params.p = p;
+            }
+
+            // t
+            if (have & 0x02) != 0 {
+                let (t, new_pos) = decode64_uint32(bytes, pos, 1).ok_or(Error)?;
+                pos = new_pos;
+                params.t = t;
+            }
+
+            // g
+            if (have & 0x04) != 0 {
+                let (g, new_pos) = decode64_uint32(bytes, pos, 1).ok_or(Error)?;
+                pos = new_pos;
+                params.g = g;
+            }
+
+            // NROM
+            if (have & 0x08) != 0 {
+                let (nrom_log2, _) = decode64_uint32(bytes, pos, 1).ok_or(Error)?;
+                if nrom_log2 > 63 {
+                    return Err(Error);
+                }
+                params.nrom = 1 << nrom_log2;
+            }
+        }
+
+        Ok(params)
+    }
+}
+
+impl ToString for Params {
+    fn to_string(&self) -> String {
+        let mut buf = [0u8; Self::MAX_ENCODED_LEN];
+        self.encode(&mut buf).expect("params encode failed").into()
+    }
+}
+
 #[allow(non_snake_case)]
 fn N2log2(N: u64) -> u32 {
     if N < 2 {
@@ -195,11 +290,10 @@ fn N2log2(N: u64) -> u32 {
 #[cfg(test)]
 mod tests {
     use crate::{Flags, Params};
+    use alloc::string::ToString;
 
     #[test]
-    fn params_encoder() {
-        let mut buf = [0u8; Params::MAX_ENCODED_LEN];
-
+    fn encoder() {
         let p1 = Params {
             flags: Flags::default(),
             n: 4096,
@@ -209,7 +303,7 @@ mod tests {
             g: 0,
             nrom: 0,
         };
-        assert_eq!(p1.encode(&mut buf).unwrap(), "j9T");
+        assert_eq!(p1.to_string(), "j9T");
 
         // p != 1
         let p2 = Params {
@@ -221,7 +315,7 @@ mod tests {
             g: 0,
             nrom: 0,
         };
-        assert_eq!(p2.encode(&mut buf).unwrap(), "j95.0");
+        assert_eq!(p2.to_string(), "j95.0");
 
         // t and g set
         let p3 = Params {
@@ -233,7 +327,7 @@ mod tests {
             g: 5,
             nrom: 0,
         };
-        assert_eq!(p3.encode(&mut buf).unwrap(), "j953/2");
+        assert_eq!(p3.to_string(), "j953/2");
 
         // NROM set (power of two)
         let p4 = Params {
@@ -245,6 +339,68 @@ mod tests {
             g: 0,
             nrom: 4096,
         };
-        assert_eq!(p4.encode(&mut buf).unwrap(), "jC559");
+        assert_eq!(p4.to_string(), "jC559");
+    }
+
+    #[test]
+    fn decoder() {
+        let p1: Params = "j9T".parse().unwrap();
+        assert_eq!(
+            p1,
+            Params {
+                flags: Flags::default(),
+                n: 4096,
+                r: 32,
+                p: 1,
+                t: 0,
+                g: 0,
+                nrom: 0,
+            }
+        );
+
+        // p != 1
+        let p2: Params = "j95.0".parse().unwrap();
+        assert_eq!(
+            p2,
+            Params {
+                flags: Flags::default(),
+                n: 4096,
+                r: 8,
+                p: 4,
+                t: 0,
+                g: 0,
+                nrom: 0,
+            }
+        );
+
+        // t and g set
+        let p3: Params = "j953/2".parse().unwrap();
+        assert_eq!(
+            p3,
+            Params {
+                flags: Flags::default(),
+                n: 4096,
+                r: 8,
+                p: 1,
+                t: 2,
+                g: 5,
+                nrom: 0,
+            }
+        );
+
+        // NROM set (power of two)
+        let p4: Params = "jC559".parse().unwrap();
+        assert_eq!(
+            p4,
+            Params {
+                flags: Flags::default(),
+                n: 32768,
+                r: 8,
+                p: 1,
+                t: 0,
+                g: 0,
+                nrom: 4096,
+            }
+        );
     }
 }

--- a/yescrypt/src/params.rs
+++ b/yescrypt/src/params.rs
@@ -4,8 +4,10 @@ use crate::{
     Error, Flags, Result,
     encoding::{decode64_uint32, encode64_uint32},
 };
-use alloc::string::{String, ToString};
-use core::str::{self, FromStr};
+use core::{
+    fmt::{self, Display},
+    str::{self, FromStr},
+};
 
 /// `yescrypt` algorithm parameters.
 ///
@@ -261,10 +263,10 @@ impl FromStr for Params {
     }
 }
 
-impl ToString for Params {
-    fn to_string(&self) -> String {
+impl Display for Params {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut buf = [0u8; Self::MAX_ENCODED_LEN];
-        self.encode(&mut buf).expect("params encode failed").into()
+        f.write_str(self.encode(&mut buf).expect("params encode failed"))
     }
 }
 


### PR DESCRIPTION
Add a decoder for yescrypt params strings, translated from the reference C implementation (namely the `yescrypt_r` function from `yescrypt-common.c`)