### PR TITLE
yescrypt: fix miscomputed outputs

### DIFF
--- a/yescrypt/tests/kats.rs
+++ b/yescrypt/tests/kats.rs
@@ -263,3 +263,21 @@ fn kat24() {
     yescrypt_kdf(b"p", b"s", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
 }
+
+/// Regression test for RustCrypto/password-hashes#680
+#[test]
+fn regression680() {
+    let params = Params::new(Flags::default(), 4096, 32, 1);
+    let salt: &[u8] = &[
+        198, 183, 30, 133, 125, 115, 128, 76, 161, 57, 49, 10, 94, 249, 166, 29,
+    ];
+    let mut output = [0u8; 32];
+    yescrypt_kdf(b"password", salt, &params, &mut output).unwrap();
+    assert_eq!(
+        output,
+        [
+            197, 98, 241, 33, 68, 79, 182, 214, 153, 96, 65, 173, 79, 243, 43, 4, 53, 180, 211,
+            128, 155, 167, 159, 129, 73, 143, 205, 236, 163, 185, 102, 186
+        ]
+    );
+}

--- a/yescrypt/tests/simple.rs
+++ b/yescrypt/tests/simple.rs
@@ -40,14 +40,6 @@ fn yescrypt_reference_test() {
     for (i, &expected_hash) in EXAMPLE_HASHES.iter().enumerate() {
         let i = i as u32;
 
-        // TODO(tarcieri): debug what's wrong with test case #1 (RustCrypto/password-hashes#680)
-        // flags: Flags(RW | ROUNDS_6 | GATHER_4 | SIMPLE_2 | SBOX_12K),
-        // n: 32768, r: 7, p: 1, t: 0, g: 0, nrom: 0
-        // We compute: `$y$jC4$LdJMENpBABJJ3hIHjB1B$uASRlRN7zZJm0O6PsGMZuTwZiO46DFweFRGnIxEjnl4`
-        if i == 1 {
-            continue;
-        }
-
         // Test case logic adapted from the yescrypt C reference implementation (tests.c)
         let mut N_log2 = if i < 14 { 16 - i } else { 2 };
         let r = if i < 8 { 8 - i } else { 1 + (i & 1) };


### PR DESCRIPTION
There were a few regressions introduced in the recent translation which were not caught by the KATs or review.

The first was in 763d6f6 (mea culpa), which rewrote `wrapping_*` arithmetic using standard infix operators which apply checked arithmetic in debug. Notably in this commit a `wrapped_mul` was incorrectly translated to a `/`.

The next is this logic gated a prehashing step, support for which was removed in subsequent commits but not caught in part because the KATs don't cover values of `N` that large (ironically, including the recommended value). Such support has now been added back.

With that, we now pass both the `simple` password hash vector which was failing before, and also the regression noted in #616 which has been captured as a regression test.

Fixes #680.