### PR TITLE
yescrypt: remove preallocation

### DIFF
--- a/yescrypt/src/flags.rs
+++ b/yescrypt/src/flags.rs
@@ -25,20 +25,11 @@ bitflags::bitflags! {
         /// SBox 12k
         const SBOX_12K = 0x080;
 
-        /// Use shared preallocated memory
-        const SHARED_PREALLOCATED = 0x10000;
-
         /// Mode mask value
         const MODE_MASK = 0x3;
 
         /// Read/write flavor mask value
         const RW_FLAVOR_MASK = 0x3fc;
-
-        /// Initialize shared memory
-        const INIT_SHARED = 0x01000000;
-
-        /// Allocate only
-        const ALLOC_ONLY = 0x08000000;
 
         /// Prehash
         const PREHASH = 0x10000000;

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -20,7 +20,7 @@ const SBYTES: u64 = crate::pwxform::SBYTES as u64;
 /// greater than 1.
 pub(crate) fn smix(
     b: &mut [u32],
-    r: usize,
+    r: u32,
     n: u64,
     p: u32,
     t: u32,
@@ -29,6 +29,7 @@ pub(crate) fn smix(
     xy: &mut [u32],
     passwd: &mut [u8],
 ) {
+    let r = r as usize;
     let s = 32 * r;
 
     // 1: n <-- N / p
@@ -54,9 +55,7 @@ pub(crate) fn smix(
 
     // 6: Nloop_rw <-- 0
     let mut nloop_rw = 0;
-    if flags.contains(Flags::INIT_SHARED) {
-        nloop_rw = nloop_all;
-    } else if flags.contains(Flags::RW) {
+    if flags.contains(Flags::RW) {
         // 4: Nloop_rw <-- Nloop_all / p
         nloop_rw = nloop_all / (p as u64);
     }


### PR DESCRIPTION
Removes the `SHARED_PREALLOCATED`, `INIT_SHARED`, and `ALLOC_ONLY` flags and the functionality associated with them.

It's unclear if it was correctly implemented or useful, and not tested. This simplifies the implementation until such functionality can be added back properly and well-tested.