### PR TITLE
yescrypt: error enum

### DIFF
--- a/yescrypt/src/error.rs
+++ b/yescrypt/src/error.rs
@@ -3,16 +3,26 @@
 use core::fmt;
 
 /// Error type.
-#[derive(Debug)]
-pub struct Error;
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Encoding error (i.e. Base64)
+    Encoding,
+
+    /// Invalid params
+    Params,
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "yescrypt error")
+        match self {
+            Error::Encoding => f.write_str("yescrypt encoding invalid"),
+            Error::Params => f.write_str("yescrypt params invalid"),
+        }
     }
 }
 
 impl core::error::Error for Error {}
 
-/// Result type for the `yescrypt` crate.
+/// Result type for the `yescrypt` crate with its [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
Adds an initial error enum with variants for `Encoding` and `Params`.

This is an initial conversion to an enum, and ideally we'd have more fine-grained variants than this which can report more precisely which parameters were incorrect.