### PR TITLE
yescrypt: add `yescrypt_verify` function

### DIFF
--- a/yescrypt/src/error.rs
+++ b/yescrypt/src/error.rs
@@ -2,27 +2,39 @@
 
 use core::fmt;
 
+/// Result type for the `yescrypt` crate with its [`Error`] type.
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Error type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
+    /// Invalid password hashing algorithm.
+    #[cfg(feature = "simple")]
+    Algorithm,
+
     /// Encoding error (i.e. Base64)
     Encoding,
 
     /// Invalid params
     Params,
+
+    /// Invalid password
+    #[cfg(feature = "simple")]
+    Password,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "simple")]
+            Error::Algorithm => f.write_str("password hash must begin with `$y$`"),
             Error::Encoding => f.write_str("yescrypt encoding invalid"),
             Error::Params => f.write_str("yescrypt params invalid"),
+            #[cfg(feature = "simple")]
+            Error::Password => f.write_str("invalid password"),
         }
     }
 }
 
 impl core::error::Error for Error {}
-
-/// Result type for the `yescrypt` crate with its [`Error`] type.
-pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
Adds a function for verifying a password hash string which can parse the flavor/params from the password hash string and use it when computing a password hash to verify.

This also translates the `decode64` function from the yescrypt reference C implementation.