### PR TITLE
yescrypt: refactor `Flags` to remove `bitflags` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,12 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
-
-[[package]]
 name = "blake2"
 version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,7 +593,6 @@ checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 name = "yescrypt"
 version = "0.1.0-pre.1"
 dependencies = [
- "bitflags",
  "hex-literal",
  "hmac",
  "mcf",

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-bitflags = "2"
 hmac = { version = "0.13.0-rc.1", default-features = false }
 pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.1", default-features = false }

--- a/yescrypt/src/flags.rs
+++ b/yescrypt/src/flags.rs
@@ -1,38 +1,121 @@
 //! Algorithm flags.
 
-bitflags::bitflags! {
-    /// Flags for controlling the operation of `yescrypt`.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct Flags: u32 {
-        /// Write once read many
-        const WORM = 0x001;
+use crate::{Error, Result};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign};
 
-        /// Read/write
-        const RW = 0x002;
+/// Mode mask value
+const MODE_MASK: u32 = 0x3;
 
-        /// 3 rounds
-        const ROUNDS_3 = 0b000;
+/// Read/write flavor mask value
+const RW_FLAVOR_MASK: u32 = 0x3fc;
 
-        /// 6 rounds
-        const ROUNDS_6 = 0x004;
+/// Flags for selecting the "flavor" of `yescrypt`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Flags(pub(crate) u32);
 
-        /// Gather 4
-        const GATHER_4 = 0x010;
+impl Flags {
+    /// Empty flags (represents `scrypt` classic)
+    pub const EMPTY: Self = Self(0);
 
-        /// Simple 2
-        const SIMPLE_2 = 0x020;
+    /// Write once read many
+    pub const WORM: Self = Self(0x001);
 
-        /// SBox 12k
-        const SBOX_12K = 0x080;
+    /// Read/write
+    pub const RW: Self = Self(0x002);
 
-        /// Mode mask value
-        const MODE_MASK = 0x3;
+    /// 6 rounds
+    pub const ROUNDS_6: Self = Self(0x004);
 
-        /// Read/write flavor mask value
-        const RW_FLAVOR_MASK = 0x3fc;
+    /// Gather 4
+    pub const GATHER_4: Self = Self(0x010);
 
-        /// Prehash
-        const PREHASH = 0x10000000;
+    /// Simple 2
+    pub const SIMPLE_2: Self = Self(0x020);
+
+    /// SBox 12k
+    pub const SBOX_12K: Self = Self(0x080);
+
+    /// Prehash
+    pub(crate) const PREHASH: Self = Self(0x10000000);
+
+    /// All possible flags.
+    // Notably this only includes flags in the public API
+    const ALL_FLAGS: Self = Self(
+        Self::WORM.0
+            | Self::RW.0
+            | Self::ROUNDS_6.0
+            | Self::GATHER_4.0
+            | Self::SIMPLE_2.0
+            | Self::SBOX_12K.0,
+    );
+
+    /// Get the raw bits used to encode the flags.
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Create flags from raw bits.
+    pub const fn from_bits(bits: u32) -> Result<Self> {
+        // Check for any bits outside the allowed range.
+        if bits & !Self::ALL_FLAGS.0 != 0 {
+            return Err(Error::Params);
+        }
+
+        Ok(Self(bits))
+    }
+
+    /// Are any flags set?
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Is the prehash bit set?
+    pub(crate) fn has_prehash(self) -> bool {
+        self.0 & Flags::PREHASH.0 != 0
+    }
+
+    /// Is the read-write bit set?
+    pub(crate) fn has_rw(self) -> bool {
+        self.0 & Flags::RW.0 != 0
+    }
+
+    /// Clear the given flag bits.
+    pub(crate) fn clear(self, other: Self) -> Self {
+        Self(self.0 & !other.0)
+    }
+
+    /// Get the mode based on the mode mask.
+    pub(crate) fn mode(self) -> Result<Mode> {
+        match Flags(self.0 & MODE_MASK) {
+            Flags(0) => Ok(Mode::Classic),
+            Self::WORM => Ok(Mode::Worm),
+            Self::RW => Ok(Mode::Rw {
+                flavor_bits: self.0 & RW_FLAVOR_MASK,
+            }),
+            _ => Err(Error::Params),
+        }
+    }
+
+    /// Compute a `u32` representing the "flavor" of yescrypt to be encoded into the params string.
+    pub(crate) fn flavor(self) -> Result<u32> {
+        if self.0 < Flags::RW.0 {
+            Ok(self.0)
+        } else if (self.0 & MODE_MASK) == Flags::RW.0 && self.0 <= (Flags::RW.0 | RW_FLAVOR_MASK) {
+            Ok(Flags::RW.0 + (self.0 >> 2))
+        } else {
+            Err(Error::Params)
+        }
+    }
+
+    /// Decode flags from a "flavor" represented by a `u32` as encoded in a params string.
+    pub(crate) fn from_flavor(flavor: u32) -> Result<Self> {
+        if flavor < Flags::RW.0 {
+            Self::from_bits(flavor)
+        } else if flavor <= Flags::RW.0 + (RW_FLAVOR_MASK >> 2) {
+            Self::from_bits(Flags::RW.0 + ((flavor - Flags::RW.0) << 2))
+        } else {
+            Err(Error::Params)
+        }
     }
 }
 
@@ -40,5 +123,67 @@ impl Default for Flags {
     fn default() -> Self {
         // Adapted from upstream reference C's `YESCRYPT_RW_DEFAULTS`
         Flags::RW | Flags::ROUNDS_6 | Flags::GATHER_4 | Flags::SIMPLE_2 | Flags::SBOX_12K
+    }
+}
+
+impl BitAnd for Flags {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitAndAssign for Flags {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl BitOr for Flags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for Flags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// yescrypt modes
+pub(crate) enum Mode {
+    /// classic scrypt
+    Classic,
+
+    /// write once, read many
+    Worm,
+
+    /// read-write
+    Rw {
+        /// flavor of yescrypt, e.g. `ROUNDS_6`, `GATHER_4`, `SIMPLE_2`, `SBOX_12K`
+        flavor_bits: u32,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Flags;
+
+    #[test]
+    fn flavor() {
+        assert_eq!(Flags::EMPTY.flavor().unwrap(), 0);
+        assert_eq!(Flags::WORM.flavor().unwrap(), 1);
+        assert_eq!(Flags::default().flavor().unwrap(), 0b101111);
+    }
+
+    #[test]
+    fn from_flavor() {
+        assert_eq!(Flags::from_flavor(0).unwrap(), Flags::EMPTY);
+        assert_eq!(Flags::from_flavor(1).unwrap(), Flags::WORM);
+        assert_eq!(Flags::from_flavor(0b101111).unwrap(), Flags::default());
     }
 }

--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -169,7 +169,7 @@ pub fn yescrypt_kdf(passwd: &[u8], salt: &[u8], params: &Params, out: &mut [u8])
     // Perform conditional pre-hashing
     let mut passwd = passwd;
     let mut dk = [0u8; 32];
-    if params.flags.contains(Flags::RW)
+    if params.flags.has_rw()
         && params.p >= 1
         && params.n / (params.p as u64) >= 0x100
         && params.n / (params.p as u64) * (params.r as u64) >= 0x20000
@@ -216,7 +216,7 @@ fn yescrypt_kdf_body(passwd: &[u8], salt: &[u8], params: &Params, out: &mut [u8]
     let mut sha256 = [0u8; 32];
     if !flags.is_empty() {
         sha256 = util::hmac_sha256(
-            if flags.contains(Flags::PREHASH) {
+            if flags.has_prehash() {
                 &b"yescrypt-prehash"[..]
             } else {
                 &b"yescrypt"[..]
@@ -234,7 +234,7 @@ fn yescrypt_kdf_body(passwd: &[u8], salt: &[u8], params: &Params, out: &mut [u8]
         passwd = &sha256;
     }
 
-    if flags.contains(Flags::RW) {
+    if flags.has_rw() {
         smix::smix(&mut b, r, n, p, t, flags, &mut v, &mut xy, &mut sha256);
         passwd = &sha256;
     } else {
@@ -268,7 +268,7 @@ fn yescrypt_kdf_body(passwd: &[u8], salt: &[u8], params: &Params, out: &mut [u8]
     // SCRAM (RFC 5802), so that an extension of SCRAM (with the steps so
     // far in place of SCRAM's use of PBKDF2 and with SHA-256 in place of
     // SCRAM's use of SHA-1) would be usable with yescrypt hashes.
-    if !flags.is_empty() && !flags.contains(Flags::PREHASH) {
+    if !flags.is_empty() && !flags.has_prehash() {
         let dkp = if !flags.is_empty() && out.len() < 32 {
             &mut dk
         } else {

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -37,7 +37,7 @@ pub(crate) fn smix(
 
     // 2: Nloop_all <-- fNloop(n, t, flags)
     let mut nloop_all = nchunk;
-    if flags.contains(Flags::RW) {
+    if flags.has_rw() {
         if t <= 1 {
             if t != 0 {
                 nloop_all *= 2; // 2/3
@@ -55,7 +55,7 @@ pub(crate) fn smix(
 
     // 6: Nloop_rw <-- 0
     let mut nloop_rw = 0;
-    if flags.contains(Flags::RW) {
+    if flags.has_rw() {
         // 4: Nloop_rw <-- Nloop_all / p
         nloop_rw = nloop_all / (p as u64);
     }
@@ -73,7 +73,7 @@ pub(crate) fn smix(
     let mut vchunk = 0;
 
     // S_n = [S_i for i in 0..p]
-    let mut sn = if flags.contains(Flags::RW) {
+    let mut sn = if flags.has_rw() {
         alloc::vec![[0u32; SWORDS]; p as usize]
     } else {
         Vec::new()
@@ -99,7 +99,7 @@ pub(crate) fn smix(
         let vp = &mut v[vchunk as usize * s..];
 
         // 17: if YESCRYPT_RW flag is set
-        let mut ctx_i = if flags.contains(Flags::RW) {
+        let mut ctx_i = if flags.has_rw() {
             let si = sn.next().unwrap();
 
             // 18: SMix1_1(B_i, Sbytes / 128, S_i, no flags)
@@ -107,7 +107,7 @@ pub(crate) fn smix(
                 bs,
                 1,
                 SBYTES / 128,
-                Flags::empty(),
+                Flags::EMPTY,
                 &mut si[..],
                 xy,
                 &mut None,
@@ -165,7 +165,7 @@ pub(crate) fn smix(
     // 30: for i = 0 to p - 1 do
     #[allow(clippy::needless_range_loop)]
     for i in 0..p as usize {
-        let mut ctx_i = if flags.contains(Flags::RW) {
+        let mut ctx_i = if flags.has_rw() {
             Some(&mut ctxs[i])
         } else {
             None
@@ -177,7 +177,7 @@ pub(crate) fn smix(
             r,
             n,
             nloop_all - nloop_rw,
-            flags & !Flags::RW,
+            flags.clear(Flags::RW),
             v,
             xy,
             &mut ctx_i,
@@ -212,7 +212,7 @@ fn smix1(
     for i in 0..n {
         // 3: V_i <-- X
         v[i as usize * s..][..s].copy_from_slice(x);
-        if flags.contains(Flags::RW) && i > 1 {
+        if flags.has_rw() && i > 1 {
             let n = prev_power_of_two(i);
             let j = usize::try_from((integerify(x, r) & (n - 1)) + (i - n)).unwrap();
             xor(x, &v[j * s..][..s]);
@@ -267,7 +267,7 @@ fn smix2(
         xor(x, &v[j * s..][..s]);
 
         // V_j <-- X
-        if flags.contains(Flags::RW) {
+        if flags.has_rw() {
             v[j as usize * s..][..s].copy_from_slice(x);
         }
 

--- a/yescrypt/tests/kats.rs
+++ b/yescrypt/tests/kats.rs
@@ -10,7 +10,7 @@ fn kat0() {
         "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442"
         "fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906"
     );
-    let params = Params::new(Flags::empty(), 16, 1, 1).unwrap();
+    let params = Params::new(Flags::EMPTY, 16, 1, 1).unwrap();
     let mut actual = [0u8; 64];
     yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
@@ -19,7 +19,7 @@ fn kat0() {
 #[test]
 fn kat1() {
     const EXPECTED: [u8; 8] = hex!("77d6576238657b20");
-    let params = Params::new(Flags::empty(), 16, 1, 1).unwrap();
+    let params = Params::new(Flags::EMPTY, 16, 1, 1).unwrap();
     let mut actual = [0u8; 8];
     yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());
@@ -31,7 +31,7 @@ fn kat2() {
         "efad0c23314cb572bc3cfb1543da42f8a8b073004c866b64ab5055a4f09fa5f5"
         "71142ebfe7e05a3b92c432f31dea95ad5f9c854b6456462f4bd0f732b7cdc549"
     );
-    let params = Params::new(Flags::empty(), 4, 1, 1).unwrap();
+    let params = Params::new(Flags::EMPTY, 4, 1, 1).unwrap();
     let mut actual = [0u8; 64];
     yescrypt_kdf(b"", b"", &params, &mut actual).unwrap();
     assert_eq!(EXPECTED.as_slice(), actual.as_slice());


### PR DESCRIPTION
Pares the `Flags` type down to the minimum that is actually needed.

Moves flags-related functionality into the `Flags` type (notably computing the "flavor" `u32`) and adds some smoke tests.