### PR TITLE
yescrypt: fixes for `clippy::cast_lossless`

### DIFF
--- a/yescrypt/src/encoding.rs
+++ b/yescrypt/src/encoding.rs
@@ -36,7 +36,7 @@ pub(crate) fn decode64<'o>(src: &str, dst: &'o mut [u8]) -> Result<&'o [u8]> {
                 _ => return Err(Error::Encoding),
             };
 
-            value |= (c as u32) << bits;
+            value |= u32::from(c) << bits;
             bits += 6;
             i += 1;
         }
@@ -81,7 +81,7 @@ pub(crate) fn decode64_uint32(src: &[u8], mut pos: usize, min: u32) -> Result<(u
     pos += 1;
 
     let mut dst = min;
-    while c as u32 > end {
+    while u32::from(c) > end {
         dst += (end + 1 - start) << bits;
         start = end + 1;
         end = start + (62 - end) / 2;
@@ -89,7 +89,7 @@ pub(crate) fn decode64_uint32(src: &[u8], mut pos: usize, min: u32) -> Result<(u
         bits += 6;
     }
 
-    dst += ((c as u32) - start) << bits;
+    dst += (u32::from(c) - start) << bits;
 
     while chars > 1 {
         chars -= 1;
@@ -105,7 +105,7 @@ pub(crate) fn decode64_uint32(src: &[u8], mut pos: usize, min: u32) -> Result<(u
         pos += 1;
 
         bits -= 6;
-        dst += (c as u32) << bits;
+        dst += u32::from(c) << bits;
     }
 
     Ok((dst, pos))
@@ -142,7 +142,7 @@ pub(crate) fn encode64<'o>(src: &[u8], out: &'o mut [u8]) -> Result<&'o str> {
         let mut value = 0u32;
         let mut bits = 0u32;
         while bits < 24 && i < src.len() {
-            value |= (src[i] as u32) << bits;
+            value |= u32::from(src[i]) << bits;
             bits += 8;
             i += 1;
         }

--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -7,7 +7,7 @@
 )]
 #![deny(unsafe_code)]
 #![warn(
-    // TODO: clippy::cast_lossless,
+    clippy::cast_lossless,
     // TODO: clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
@@ -177,8 +177,8 @@ pub fn yescrypt_kdf(passwd: &[u8], salt: &[u8], params: &Params, out: &mut [u8])
     let mut dk = [0u8; 32];
     if params.mode.is_rw()
         && params.p >= 1
-        && params.n / (params.p as u64) >= 0x100
-        && params.n / (params.p as u64) * (params.r as u64) >= 0x20000
+        && params.n / u64::from(params.p) >= 0x100
+        && params.n / u64::from(params.p) * u64::from(params.r) >= 0x20000
     {
         let mut prehash_params = *params;
         prehash_params.n >>= 6;
@@ -206,11 +206,11 @@ fn yescrypt_kdf_body(
     let p = params.p;
     let t = params.t;
 
-    if !((out.len() as u64 <= u32::MAX as u64 * 32)
-        && ((r as u64) * (p as u64) < (1 << 30) as u64)
+    if !((out.len() as u64 <= u64::from(u32::MAX) * 32)
+        && (u64::from(r) * u64::from(p) < (1 << 30) as u64)
         && !(n & (n - 1) != 0 || n <= 1 || r < 1 || p < 1)
-        && !(r as u64 > u64::MAX / 128 / (p as u64) || n > u64::MAX / 128 / (r as u64))
-        && (n <= u64::MAX / ((t as u64) + 1)))
+        && !(u64::from(r) > u64::MAX / 128 / u64::from(p) || n > u64::MAX / 128 / u64::from(r))
+        && (n <= u64::MAX / (u64::from(t) + 1)))
     {
         return Err(Error::Params);
     }

--- a/yescrypt/src/params.rs
+++ b/yescrypt/src/params.rs
@@ -81,10 +81,10 @@ impl Params {
         }
 
         if mode.is_rw()
-            && (n / (p as u64) <= 1
+            && (n / u64::from(p) <= 1
                 || r < RMIN as u32
-                || p as u64 > u64::MAX / (3 * (1 << 8) * 2 * 8)
-                || p as u64 > u64::MAX / (size_of::<PwxformCtx<'_>>() as u64))
+                || u64::from(p) > u64::MAX / (3 * (1 << 8) * 2 * 8)
+                || u64::from(p) > u64::MAX / (size_of::<PwxformCtx<'_>>() as u64))
         {
             return Err(Error::Params);
         }
@@ -137,7 +137,7 @@ impl Params {
             return Err(Error::Params);
         }
 
-        if (self.r as u64) * (self.p as u64) >= (1 << 30) {
+        if u64::from(self.r) * u64::from(self.p) >= (1 << 30) {
             return Err(Error::Params);
         }
 

--- a/yescrypt/src/pwxform.rs
+++ b/yescrypt/src/pwxform.rs
@@ -118,13 +118,13 @@ impl PwxformCtx<'_> {
                 // 5: for k = 0 to PWXsimple - 1 do
                 for k in 0..PWXSIMPLE {
                     // 6: B_{j,k} <-- (hi(B_{j,k}) * lo(B_{j,k}) + S0_{p0,k}) xor S1_{p1,k}
-                    let s0 = ((p0[k][1] as u64) << 32).wrapping_add(p0[k][0] as u64);
-                    let s1 = ((p1[k][1] as u64) << 32).wrapping_add(p1[k][0] as u64);
+                    let s0 = (u64::from(p0[k][1]) << 32).wrapping_add(u64::from(p0[k][0]));
+                    let s1 = (u64::from(p1[k][1]) << 32).wrapping_add(u64::from(p1[k][0]));
 
                     xl = xptr[j][k][0];
                     xh = xptr[j][k][1];
 
-                    let mut x = (xh as u64).wrapping_mul(xl as u64);
+                    let mut x = u64::from(xh).wrapping_mul(u64::from(xl));
                     x = x.wrapping_add(s0);
                     x ^= s1;
 

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -32,7 +32,7 @@ pub(crate) fn smix(
     let s = 32 * r;
 
     // 1: n <-- N / p
-    let mut nchunk = n / (p as u64);
+    let mut nchunk = n / u64::from(p);
 
     // 2: Nloop_all <-- fNloop(n, t, flags)
     let mut nloop_all = nchunk;
@@ -43,20 +43,20 @@ pub(crate) fn smix(
             }
             nloop_all = nloop_all.div_ceil(3); // 1/3, round up
         } else {
-            nloop_all *= t as u64 - 1;
+            nloop_all *= u64::from(t) - 1;
         }
     } else if t != 0 {
         if t == 1 {
             nloop_all += nloop_all.div_ceil(2) // 1.5, round up
         }
-        nloop_all *= t as u64;
+        nloop_all *= u64::from(t);
     }
 
     // 6: Nloop_rw <-- 0
     let mut nloop_rw = 0;
     if mode.is_rw() {
         // 4: Nloop_rw <-- Nloop_all / p
-        nloop_rw = nloop_all / (p as u64);
+        nloop_rw = nloop_all / u64::from(p);
     }
 
     // 8: n <-- n - (n mod 2)
@@ -298,7 +298,7 @@ fn smix2(
 /// Return the result of parsing B_{2r-1} as a little-endian integer.
 fn integerify(b: &[u32], r: usize) -> u64 {
     let x = &b[((2 * r) - 1) * 16..];
-    ((x[13] as u64) << 32).wrapping_add(x[0] as u64)
+    (u64::from(x[13]) << 32).wrapping_add(u64::from(x[0]))
 }
 
 /// Largest power of 2 not greater than argument.


### PR DESCRIPTION
These were all auto-applied via `cargo clippy --fix`