### PR TITLE
yescrypt: enable `clippy::cast_possible_truncation`

### DIFF
--- a/yescrypt/src/encoding.rs
+++ b/yescrypt/src/encoding.rs
@@ -12,9 +12,9 @@ static ITOA64: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
 /// Reverse lookup table for (s)crypt-flavored Base64 alphabet.
 pub const ATOI64: [u8; 128] = {
     let mut tbl = [0xFFu8; 128]; // use 0xFF as a placeholder for invalid chars
-    let mut i = 0;
+    let mut i = 0u8;
     while i < 64 {
-        tbl[ITOA64[i] as usize] = i as u8;
+        tbl[ITOA64[i as usize] as usize] = i;
         i += 1;
     }
     tbl
@@ -47,7 +47,7 @@ pub(crate) fn decode64<'o>(src: &str, dst: &'o mut [u8]) -> Result<&'o [u8]> {
         }
 
         while pos < dst.len() {
-            dst[pos] = value as u8;
+            dst[pos] = (value & 0xFF) as u8;
             pos += 1;
             value >>= 8;
             bits -= 8;

--- a/yescrypt/src/params.rs
+++ b/yescrypt/src/params.rs
@@ -82,7 +82,7 @@ impl Params {
 
         if mode.is_rw()
             && (n / u64::from(p) <= 1
-                || r < RMIN as u32
+                || r < RMIN
                 || u64::from(p) > u64::MAX / (3 * (1 << 8) * 2 * 8)
                 || u64::from(p) > u64::MAX / (size_of::<PwxformCtx<'_>>() as u64))
         {

--- a/yescrypt/src/smix.rs
+++ b/yescrypt/src/smix.rs
@@ -69,7 +69,6 @@ pub(crate) fn smix(
     // 10: Nloop_rw <-- Nloop_rw + (Nloop_rw mod 2)
     nloop_rw += 1;
     nloop_rw &= !1; // round up to even
-    let mut vchunk = 0;
 
     // S_n = [S_i for i in 0..p]
     let mut sn = if mode.is_rw() {
@@ -79,6 +78,8 @@ pub(crate) fn smix(
     };
     let mut ctxs = Vec::with_capacity(sn.len());
     let mut sn = sn.iter_mut();
+
+    let mut vchunk = 0;
 
     // 11: for i = 0 to p - 1 do
     // 12: u <-- in
@@ -95,7 +96,7 @@ pub(crate) fn smix(
         };
 
         let bs = &mut b[(i * s)..];
-        let vp = &mut v[vchunk as usize * s..];
+        let vp = &mut v[(usize::try_from(vchunk)? * s)..];
 
         // 17: if YESCRYPT_RW flag is set
         let mut ctx_i = if mode.is_rw() {
@@ -216,7 +217,7 @@ fn smix1(
     // 2: for i = 0 to N - 1 do
     for i in 0..n {
         // 3: V_i <-- X
-        v[i as usize * s..][..s].copy_from_slice(x);
+        v[(usize::try_from(i)? * s)..][..s].copy_from_slice(x);
         if mode.is_rw() && i > 1 {
             let n = prev_power_of_two(i);
             let j = usize::try_from((integerify(x, r) & (n - 1)) + (i - n))?;


### PR DESCRIPTION
Fixes offenses, either by masking to show that truncation is expected, using `TryFrom` and `?` to convert to `Error::Internal` if the conversion fails, or starting with a narrower type and widening instead of trying to go the other direction.