### PR TITLE
yescrypt: use `base64ct` via the `mcf` crate

### DIFF
--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -20,7 +20,7 @@ salsa20 = { version = "0.11.0-rc.1", default-features = false }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 
 # optional dependencies
-mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
+mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/yescrypt/src/encoding.rs
+++ b/yescrypt/src/encoding.rs
@@ -1,10 +1,9 @@
 //! Support for encoding (s)crypt-flavored Base64.
-// TODO(tarcieri): use `base64ct` instead?
+//!
+//! We mostly leverage the `base64ct` crate for this, however these functions are still used for
+//! encoding/decoding the parameters string.
 
 use crate::{Error, Result};
-
-#[cfg(feature = "simple")]
-use core::str;
 
 /// (s)crypt-flavored Base64 alphabet.
 static ITOA64: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -19,50 +18,6 @@ pub const ATOI64: [u8; 128] = {
     }
     tbl
 };
-
-#[cfg(feature = "simple")]
-pub(crate) fn decode64<'o>(src: &str, dst: &'o mut [u8]) -> Result<&'o [u8]> {
-    let src = src.as_bytes();
-    let mut pos = 0usize;
-    let mut i = 0usize;
-
-    while i < src.len() {
-        let mut value = 0u32;
-        let mut bits = 0u32;
-
-        while bits < 24 && i < src.len() {
-            let c = match ATOI64.get(src[i] as usize) {
-                Some(&c) if c <= 63 => c,
-                _ => return Err(Error::Encoding),
-            };
-
-            value |= u32::from(c) << bits;
-            bits += 6;
-            i += 1;
-        }
-
-        // must have at least one full byte
-        if bits < 12 {
-            return Err(Error::Encoding);
-        }
-
-        while pos < dst.len() {
-            dst[pos] = (value & 0xFF) as u8;
-            pos += 1;
-            value >>= 8;
-            bits -= 8;
-            if bits < 8 {
-                if value != 0 {
-                    // 2 or 4
-                    return Err(Error::Encoding);
-                }
-                break;
-            }
-        }
-    }
-
-    Ok(&dst[..pos])
-}
 
 pub(crate) fn decode64_uint32(src: &[u8], mut pos: usize, min: u32) -> Result<(u32, usize)> {
     let mut start = 0u32;
@@ -111,48 +66,6 @@ pub(crate) fn decode64_uint32(src: &[u8], mut pos: usize, min: u32) -> Result<(u
     Ok((dst, pos))
 }
 
-#[cfg(feature = "simple")]
-pub(crate) fn encode64<'o>(src: &[u8], out: &'o mut [u8]) -> Result<&'o str> {
-    fn encode64_uint32_fixed(dst: &mut [u8], mut src: u32, srcbits: u32) -> Result<usize> {
-        let mut bits: u32 = 0;
-        let mut pos = 0;
-
-        while bits < srcbits {
-            if dst.len() <= pos {
-                return Err(Error::Encoding);
-            }
-
-            dst[pos] = ITOA64[(src & 0x3f) as usize];
-            pos += 1;
-            src >>= 6;
-            bits += 6;
-        }
-
-        if src != 0 || dst.len() < pos {
-            return Err(Error::Encoding);
-        }
-
-        Ok(pos)
-    }
-
-    let mut pos = 0;
-    let mut i = 0;
-
-    while i < src.len() {
-        let mut value = 0u32;
-        let mut bits = 0u32;
-        while bits < 24 && i < src.len() {
-            value |= u32::from(src[i]) << bits;
-            bits += 8;
-            i += 1;
-        }
-        let dnext = encode64_uint32_fixed(&mut out[pos..], value, bits)?;
-        pos += dnext;
-    }
-
-    str::from_utf8(&out[..pos]).map_err(|_| Error::Encoding)
-}
-
 pub(crate) fn encode64_uint32(dst: &mut [u8], mut src: u32, min: u32) -> Result<usize> {
     let mut start = 0u32;
     let mut end = 47u32;
@@ -196,37 +109,4 @@ pub(crate) fn encode64_uint32(dst: &mut [u8], mut src: u32, min: u32) -> Result<
     }
 
     Ok(pos)
-}
-
-#[cfg(feature = "simple")]
-#[cfg(test)]
-mod tests {
-    use super::{decode64, encode64};
-    use hex_literal::hex;
-
-    const TEST_VECTORS: &[(&[u8], &str)] = &[
-        (b"", ""),
-        (&hex!("00"), ".."),
-        (&hex!("0102"), "/6."),
-        (&hex!("010203040506"), "/6k.2IU/"),
-        (&hex!("02030405060708090A0BAABBFF00"), "0A./3Mk/6YU09cuiz1."),
-    ];
-
-    #[test]
-    fn decode() {
-        for &(bin, base64) in TEST_VECTORS {
-            let mut buf = [0u8; 64];
-            let decoded = decode64(base64, &mut buf).unwrap();
-            assert_eq!(decoded, bin);
-        }
-    }
-
-    #[test]
-    fn encode() {
-        for &(bin, base64) in TEST_VECTORS {
-            let mut buf = [0u8; 64];
-            let encoded = encode64(bin, &mut buf).unwrap();
-            assert_eq!(encoded, base64);
-        }
-    }
 }


### PR DESCRIPTION
Leverages the `Base64ShaCrypt` encoding from the `base64ct` crate in place of the translated implementation from the reference implementation