### PR TITLE
sha-crypt: remove `std` feature; add `core::error::Error` impls

### DIFF
--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -26,8 +26,7 @@ base64ct = "1.7.1"
 
 [features]
 default = ["simple"]
-simple = ["rand", "std", "subtle"]
-std = []
+simple = ["rand", "subtle"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/src/b64.rs
+++ b/sha-crypt/src/b64.rs
@@ -84,8 +84,6 @@ mod tests {
         let e = super::encode_sha256(&original);
         let d = super::decode_sha256(&e).unwrap();
 
-        std::println!("o {:?}", &original);
-        std::println!("d {:?}", &d);
         for i in 0..d.len() {
             assert_eq!(&original[i], &d[i]);
         }

--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -1,12 +1,10 @@
 //! Error types.
 
 use alloc::string;
+use core::fmt;
 
 #[cfg(feature = "simple")]
 use alloc::string::String;
-
-#[cfg(feature = "std")]
-use std::io;
 
 /// Error type.
 #[derive(Debug)]
@@ -17,24 +15,32 @@ pub enum CryptError {
     /// RNG failed.
     RandomError,
 
-    /// I/O error.
-    #[cfg(feature = "std")]
-    IoError(io::Error),
-
     /// UTF-8 error.
     StringError(string::FromUtf8Error),
-}
-
-#[cfg(feature = "std")]
-impl From<io::Error> for CryptError {
-    fn from(e: io::Error) -> Self {
-        CryptError::IoError(e)
-    }
 }
 
 impl From<string::FromUtf8Error> for CryptError {
     fn from(e: string::FromUtf8Error) -> Self {
         CryptError::StringError(e)
+    }
+}
+
+impl core::error::Error for CryptError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            CryptError::StringError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CryptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CryptError::RoundsError => write!(f, "rounds error"),
+            CryptError::RandomError => write!(f, "random error"),
+            CryptError::StringError(_) => write!(f, "string error"),
+        }
     }
 }
 
@@ -55,5 +61,15 @@ pub struct DecodeError;
 impl From<DecodeError> for CheckError {
     fn from(_: DecodeError) -> CheckError {
         CheckError::InvalidFormat("invalid B64".into())
+    }
+}
+
+#[cfg(feature = "simple")]
+impl core::error::Error for DecodeError {}
+
+#[cfg(feature = "simple")]
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "decode error")
     }
 }

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -40,9 +40,6 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 mod b64;
 mod defs;
 mod errors;


### PR DESCRIPTION
The `std` feature was previously unused, while `core::error::Error` allows the error trait to be impl'd without a `std` dependency