### PR TITLE
sha-crypt: switch from `rand` to `rand_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,15 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,26 +357,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
 
 [[package]]
 name = "rand_core"
@@ -457,7 +428,7 @@ name = "sha-crypt"
 version = "0.6.0-pre.1"
 dependencies = [
  "base64ct",
- "rand",
+ "rand_core",
  "sha2",
  "subtle",
 ]
@@ -615,26 +586,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -18,15 +18,15 @@ rust-version = "1.85"
 
 [dependencies]
 sha2 = { version = "0.11.0-rc.2", default-features = false }
+base64ct = { version = "1.7.1", default-features = false }
 
 # optional dependencies
-rand = { version = "0.9", optional = true }
+rand_core = { version = "0.9", optional = true, default-features = false, features = ["os_rng"] }
 subtle = { version = "2", optional = true, default-features = false }
-base64ct = "1.7.1"
 
 [features]
 default = ["simple"]
-simple = ["rand", "subtle"]
+simple = ["base64ct/alloc", "dep:rand_core", "dep:subtle"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/src/defs.rs
+++ b/sha-crypt/src/defs.rs
@@ -14,10 +14,6 @@ pub const PW_SIZE_SHA512: usize = 86;
 #[cfg(feature = "simple")]
 pub const SALT_MAX_LEN: usize = 16;
 
-/// Encoding table.
-#[cfg(feature = "simple")]
-pub static TAB: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
 /// Inverse encoding map for SHA512.
 #[rustfmt::skip]
 pub const MAP_SHA512: [u8; 64] = [


### PR DESCRIPTION
Replaces the use of `Distribution` by first filling a buffer with random bytes, then encoding it as Base64.

It seems the Base64 encoding is directly consumed by the algorithm, or otherwise it would probably make sense to convert all usages of `salt` to be raw bytes. That warrants further investigation.