### PR TITLE
sha-crypt: use `mcf` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ name = "sha-crypt"
 version = "0.6.0-pre.1"
 dependencies = [
  "base64ct",
+ "mcf",
  "rand_core",
  "sha2",
  "subtle",

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -21,12 +21,13 @@ sha2 = { version = "0.11.0-rc.2", default-features = false }
 base64ct = { version = "1.7.1", default-features = false }
 
 # optional dependencies
+mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }
 rand_core = { version = "0.9", optional = true, default-features = false, features = ["os_rng"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]
 default = ["simple"]
-simple = ["base64ct/alloc", "dep:rand_core", "dep:subtle"]
+simple = ["base64ct/alloc", "dep:mcf", "dep:rand_core", "dep:subtle"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/tests/lib.rs
+++ b/sha-crypt/tests/lib.rs
@@ -162,8 +162,10 @@ fn test_sha512_simple_check_roundtrip() {
     let params = Sha512Params::new(5_000).expect("Rounds error");
 
     let hash = sha512_simple(pw, &params);
+    dbg!(&hash);
 
     let c_r = sha512_check(pw, &hash);
+    dbg!(&c_r);
     assert!(c_r.is_ok());
 }
 


### PR DESCRIPTION
Begins an initial integration of using the `mcf` crate for the purposes of constructing strings in Modular Crypt Format.