### PR TITLE
sha-crypt: simplify Base64 encoding

### DIFF
--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 sha2 = { version = "0.11.0-rc.2", default-features = false }
-base64ct = { version = "1.7.1", default-features = false }
+base64ct = { version = "1.7.1", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }
@@ -27,7 +27,7 @@ subtle = { version = "2", optional = true, default-features = false }
 
 [features]
 default = ["simple"]
-simple = ["base64ct/alloc", "dep:mcf", "dep:rand_core", "dep:subtle"]
+simple = ["dep:mcf", "dep:rand_core", "dep:subtle"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/src/b64.rs
+++ b/sha-crypt/src/b64.rs
@@ -1,34 +1,13 @@
 //! Base64 encoding support
 
-use crate::consts::{
-    BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512, MAP_SHA256, MAP_SHA512, PW_SIZE_SHA256, PW_SIZE_SHA512,
+#![cfg(feature = "simple")]
+
+use crate::{
+    consts::{BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512, MAP_SHA256, MAP_SHA512, PW_SIZE_SHA256},
+    errors::DecodeError,
 };
 use base64ct::{Base64ShaCrypt, Encoding};
 
-#[cfg(feature = "simple")]
-use crate::errors::DecodeError;
-
-pub fn encode_sha512(source: &[u8]) -> [u8; PW_SIZE_SHA512] {
-    let mut transposed = [0u8; BLOCK_SIZE_SHA512];
-    for (i, &ti) in MAP_SHA512.iter().enumerate() {
-        transposed[i] = source[ti as usize];
-    }
-    let mut buf = [0u8; PW_SIZE_SHA512];
-    Base64ShaCrypt::encode(&transposed, &mut buf).unwrap();
-    buf
-}
-
-pub fn encode_sha256(source: &[u8]) -> [u8; PW_SIZE_SHA256] {
-    let mut transposed = [0u8; BLOCK_SIZE_SHA256];
-    for (i, &ti) in MAP_SHA256.iter().enumerate() {
-        transposed[i] = source[ti as usize];
-    }
-    let mut buf = [0u8; PW_SIZE_SHA256];
-    Base64ShaCrypt::encode(&transposed, &mut buf).unwrap();
-    buf
-}
-
-#[cfg(feature = "simple")]
 pub fn decode_sha512(source: &[u8]) -> Result<[u8; BLOCK_SIZE_SHA512], DecodeError> {
     const BUF_SIZE: usize = 86;
     let mut buf = [0u8; BUF_SIZE];
@@ -40,7 +19,6 @@ pub fn decode_sha512(source: &[u8]) -> Result<[u8; BLOCK_SIZE_SHA512], DecodeErr
     Ok(transposed)
 }
 
-#[cfg(feature = "simple")]
 pub fn decode_sha256(source: &[u8]) -> Result<[u8; BLOCK_SIZE_SHA256], DecodeError> {
     let mut buf = [0u8; PW_SIZE_SHA256];
     Base64ShaCrypt::decode(source, &mut buf).unwrap();
@@ -50,42 +28,4 @@ pub fn decode_sha256(source: &[u8]) -> Result<[u8; BLOCK_SIZE_SHA256], DecodeErr
         transposed[ti as usize] = buf[i];
     }
     Ok(transposed)
-}
-
-mod tests {
-    #[cfg(feature = "simple")]
-    #[test]
-    fn test_encode_decode_sha512() {
-        let original: [u8; 64] = [
-            0x0b, 0x5b, 0xdf, 0x7d, 0x92, 0xe2, 0xfc, 0xbd, 0xab, 0x57, 0xcb, 0xf3, 0xe0, 0x03,
-            0x16, 0x62, 0xd3, 0x6e, 0xa0, 0x57, 0x44, 0x8c, 0xca, 0x35, 0xec, 0x80, 0x75, 0x2a,
-            0x37, 0xd4, 0xe6, 0xfa, 0xf7, 0xd7, 0x78, 0xf4, 0x8e, 0x0b, 0x3e, 0xab, 0x23, 0x05,
-            0x15, 0xdd, 0x79, 0x14, 0x45, 0xac, 0x66, 0x60, 0x25, 0x94, 0x97, 0x5e, 0x0f, 0x7f,
-            0x5f, 0xaf, 0x1a, 0xe5, 0x08, 0xe7, 0x7d, 0xd4,
-        ];
-
-        let e = super::encode_sha512(&original);
-        let d = super::decode_sha512(&e).unwrap();
-
-        for i in 0..d.len() {
-            assert_eq!(&original[i], &d[i]);
-        }
-    }
-
-    #[cfg(feature = "simple")]
-    #[test]
-    fn test_encode_decode_sha256() {
-        let original: [u8; 32] = [
-            0x0b, 0x5b, 0xdf, 0x7d, 0x92, 0xe2, 0xfc, 0xbd, 0xab, 0x57, 0xcb, 0xf3, 0xe0, 0x03,
-            0x16, 0x62, 0xd3, 0x6e, 0xa0, 0x57, 0x44, 0x8c, 0xca, 0x35, 0xec, 0x80, 0x75, 0x2a,
-            0x5f, 0xaf, 0x1a, 0xe5,
-        ];
-
-        let e = super::encode_sha256(&original);
-        let d = super::decode_sha256(&e).unwrap();
-
-        for i in 0..d.len() {
-            assert_eq!(&original[i], &d[i]);
-        }
-    }
 }

--- a/sha-crypt/src/consts.rs
+++ b/sha-crypt/src/consts.rs
@@ -5,10 +5,8 @@ pub const BLOCK_SIZE_SHA256: usize = 32;
 pub const BLOCK_SIZE_SHA512: usize = 64;
 
 /// PWD part length of the password string of SHA256
+#[cfg(feature = "simple")]
 pub const PW_SIZE_SHA256: usize = 43;
-
-/// PWD part length of the password string of SHA512
-pub const PW_SIZE_SHA512: usize = 86;
 
 /// Maximum length of a salt
 #[cfg(feature = "simple")]


### PR DESCRIPTION
Composes the "simple" MCF API in terms of the existing Base64 APIs, and factors the Base64 encoding functions into those Base64 APIs.