### PR TITLE
Parallelize scrypt with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ version = "0.12.0-rc.2"
 dependencies = [
  "password-hash",
  "pbkdf2",
+ "rayon",
  "salsa20",
  "sha2",
 ]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.85"
 pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.1", default-features = false }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
+rayon = { version = "1.11", optional = true }
 
 # optional dependencies
 password-hash = { version = "0.6.0-rc.1", default-features = false, features = ["rand_core"], optional = true }
@@ -25,8 +26,9 @@ password-hash = { version = "0.6.0-rc.1", default-features = false, features = [
 password-hash = { version = "0.6.0-rc.1", features = ["rand_core"] }
 
 [features]
-default = ["simple"]
+default = ["simple", "rayon"]
 simple = ["password-hash"]
+rayon = ["dep:rayon"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/benches/lib.rs
+++ b/scrypt/benches/lib.rs
@@ -6,11 +6,23 @@ extern crate test;
 use test::Bencher;
 
 #[bench]
-pub fn scrypt_15_8_1(bh: &mut Bencher) {
+pub fn scrypt_17_8_1(bh: &mut Bencher) {
     let password = b"my secure password";
     let salt = b"salty salt";
     let mut buf = [0u8; 32];
     let params = scrypt::Params::recommended();
+    bh.iter(|| {
+        scrypt::scrypt(password, salt, &params, &mut buf).unwrap();
+        test::black_box(&buf);
+    });
+}
+
+#[bench]
+pub fn scrypt_17_2_4(bh: &mut Bencher) {
+    let password = b"my secure password";
+    let salt = b"salty salt";
+    let mut buf = [0u8; 32];
+    let params = scrypt::Params::new(17, 2, 4).unwrap();
     bh.iter(|| {
         scrypt::scrypt(password, salt, &params, &mut buf).unwrap();
         test::black_box(&buf);


### PR DESCRIPTION
Implements https://github.com/RustCrypto/password-hashes/issues/79

If `p>1`, then the different RoMix blocks are calculated in parallel, using Rayon.

# Benchmarks
## without `rayon` feature
```
test scrypt_17_2_4 ... bench: 270,342,994.10 ns/iter (+/- 37,060,120.60)
test scrypt_17_8_1 ... bench: 294,787,189.50 ns/iter (+/- 21,095,956.53)
```
## with `rayon` feature
```
test scrypt_17_2_4 ... bench: 116,287,221.00 ns/iter (+/- 12,892,179.24)
test scrypt_17_8_1 ... bench: 290,716,320.30 ns/iter (+/- 13,595,822.07)
```