### PR TITLE
Bump `password-hash` to v0.6.0-rc.2

### DIFF
--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -35,13 +35,12 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --no-default-features
-      - run: cargo build --target ${{ matrix.target }} --no-default-features --features simple
 
   minimal-versions:
     if: false # disabled while using pre-releases
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target/
-/.readme/target/
-/benches/target/
+**/target/
 **/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2092b195c205e3d29b99ee2169fc71ea8b7dd99bd34abae4cc66e4947ec56f"
+checksum = "c4d0d625c21e8e5ca317b31568d257c4af4e93fd5a756d0301f5d517951ea6fd"
 dependencies = [
  "belt-block",
  "digest",
@@ -70,9 +70,8 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edac47499deef695d9431bf241c75ea29f4cf3dcb78d39e19b31515e4ad3b08"
+version = "0.11.0-rc.3"
+source = "git+https://github.com/RustCrypto/hashes?branch=blake2%2Frestore-blake-var#23e8c1296de00e3abfe39bf614fb1d56df90de0d"
 dependencies = [
  "digest",
 ]
@@ -88,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4f049baa079f3b50e74ad3b1fb0585db8ec51f08939671bd6fb4d65886b758"
+checksum = "8ecfb049d43f70154a8a232d709710dc7350bda1fa7d0e539a252f0938adad8e"
 dependencies = [
  "byteorder",
  "cipher",
@@ -116,9 +115,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
+checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -178,18 +177,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -225,9 +224,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
  "digest",
 ]
@@ -299,17 +298,17 @@ dependencies = [
  "getrandom",
  "password-hash",
  "pbkdf2",
- "rand_core",
  "scrypt",
 ]
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee14c44aa1c04c22c4d4532c4fa2cdd5b6d31c2514a5898530d889fc2fc2737"
+checksum = "a7d47a2d1aee5a339aa6c740d9128211a8a3d2bdf06a13e01b3f8a0b5c49b9db"
 dependencies = [
  "base64ct",
+ "getrandom",
  "rand_core",
  "subtle",
 ]
@@ -354,12 +353,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0-rc-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
 
 [[package]]
 name = "rayon"
@@ -399,9 +395,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ff3b81c8a6e381bc1673768141383f9328048a60edddcfc752a8291a138443"
+checksum = "06522a356e94a02a1f83d699a1d84dd2ba613fbb20b211153bd5a75de9ccdc92"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -423,17 +419,17 @@ name = "sha-crypt"
 version = "0.6.0-pre.1"
 dependencies = [
  "base64ct",
+ "getrandom",
  "mcf",
- "rand_core",
  "sha2",
  "subtle",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
+checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -442,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -453,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7032930cdbb2ca75cafb6b91674728bd923d9a47941ac95183337c53445399ff"
+checksum = "4b24f3259853f4857159f8dfefc4e3500b37cf91e497944b99d9434371d4db05"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ exclude = ["benches", "fuzz"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.blake2]
+git = "https://github.com/RustCrypto/hashes"
+branch = "blake2/restore-blake-var"

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -35,8 +35,9 @@ password-hash = { version = "0.6.0-rc.1", features = ["rand_core"] }
 [features]
 default = ["alloc", "password-hash", "rand"]
 alloc = ["password-hash?/alloc"]
-std = ["alloc", "password-hash?/os_rng", "base64ct/std"]
+std = ["alloc", "base64ct/std"]
 
+getrandom = ["simple", "password-hash/getrandom"]
 parallel = ["dep:rayon"]
 rand = ["password-hash?/rand_core"]
 simple = ["password-hash"]

--- a/argon2/src/blake2b_long.rs
+++ b/argon2/src/blake2b_long.rs
@@ -4,7 +4,7 @@ use crate::{Error, Result};
 
 use blake2::{
     Blake2b512, Blake2bVar,
-    digest::{self, Digest, VariableOutput},
+    digest::{self, Digest},
 };
 
 use core::convert::TryFrom;

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -39,16 +39,12 @@
 )]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use argon2::{
-//!     password_hash::{
-//!         // `OsRng` requires enabled `std` crate feature
-//!         rand_core::OsRng,
-//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
-//!     },
+//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
 //!     Argon2
 //! };
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = SaltString::try_from_rng(&mut OsRng).unwrap();
+//! let salt = SaltString::generate(); // Note: needs the `getrandom` feature of `argon2` enabled
 //!
 //! // Argon2 with default params (Argon2id v19)
 //! let argon2 = Argon2::default();
@@ -77,16 +73,12 @@
 )]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use argon2::{
-//!     password_hash::{
-//!         // `OsRng` requires enabled `std` crate feature
-//!         rand_core::OsRng,
-//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
-//!     },
+//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString },
 //!     Algorithm, Argon2, Params, Version
 //! };
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = SaltString::try_from_rng(&mut OsRng).unwrap();
+//! let salt = SaltString::generate(); // Note: needs the `getrandom` feature of `argon2` enabled
 //!
 //! // Argon2 with default params (Argon2id v19) and pepper
 //! let argon2 = Argon2::new_with_secret(

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -14,25 +14,27 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.1", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.4", default-features = false, features = ["hybrid-array"] }
-rand_core = { version = "0.9", default-features = false }
+digest = { version = "0.11.0-rc.4", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["hybrid-array"] }
+rand_core = { version = "0.10.0-rc-2", default-features = false }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.0", default-features = false, optional = true }
+password-hash = { version = "0.6.0-rc.2", default-features = false, optional = true }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = "0.11.0-rc.2"
+sha2 = "0.11.0-rc.3"
 
 [features]
 default = ["alloc", "password-hash", "rand"]
 alloc = ["password-hash/alloc"]
+std = ["alloc", "getrandom"]
+
+getrandom = ["password-hash/getrandom"]
 parallel = ["rayon", "std"]
 rand = ["password-hash/rand_core"]
-std = ["alloc", "password-hash/os_rng", "rand_core/std"]
 zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -28,21 +28,17 @@
 //!
 //! The following example demonstrates the high-level password hashing API:
 //!
-//! ```
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(all(feature = "password-hash", feature = "std"))]
-//! # {
 //! use balloon_hash::{
-//!     password_hash::{
-//!         rand_core::OsRng,
-//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
-//!     },
+//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
 //!     Balloon
 //! };
 //! use sha2::Sha256;
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = SaltString::try_from_rng(&mut OsRng)?;
+//! let salt = SaltString::generate(); // Note: needs the `getrandom` feature of `balloon-hash` enabled
 //!
 //! // Balloon with default params
 //! let balloon = Balloon::<Sha256>::default();
@@ -53,7 +49,6 @@
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;
 //! assert!(balloon.verify_password(password, &parsed_hash).is_ok());
-//! # }
 //! # Ok(())
 //! # }
 //! ```

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -14,9 +14,11 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-blowfish = { version = "0.10.0-rc.1", features = ["bcrypt"] }
+blowfish = { version = "0.10.0-rc.2", features = ["bcrypt"] }
 pbkdf2 = { version = "0.13.0-rc.1", default-features = false, path = "../pbkdf2" }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
+
+# optional features
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -17,14 +17,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-password-hash = { version = "0.6.0-rc.0", features = ["alloc", "rand_core"] }
-rand_core = { version = "0.9", features = ["os_rng"] }
+getrandom = { version = "0.3", default-features = false }
+password-hash = { version = "0.6.0-rc.2", features = ["alloc", "getrandom"] }
 
 # optional dependencies
 argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
 pbkdf2 = { version = "0.13.0-rc.0", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
 scrypt = { version = "0.12.0-rc.0", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
-getrandom = { version = "0.3", optional = true, default-features = false }
 
 [features]
 default = ["argon2", "std"]

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -27,7 +27,6 @@ pub use crate::errors::{ParseError, VerifyError};
 
 use alloc::string::{String, ToString};
 use password_hash::{ParamsString, PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
-use rand_core::OsRng;
 
 #[cfg(not(any(feature = "argon2", feature = "pbkdf2", feature = "scrypt")))]
 compile_error!(
@@ -46,7 +45,7 @@ use scrypt::Scrypt;
 /// Uses the best available password hashing algorithm given the enabled
 /// crate features (typically Argon2 unless explicitly disabled).
 pub fn generate_hash(password: impl AsRef<[u8]>) -> String {
-    let salt = SaltString::try_from_rng(&mut OsRng).expect("Rng error");
+    let salt = SaltString::generate();
     generate_phc_hash(password.as_ref(), &salt)
         .map(|hash| hash.to_string())
         .expect("password hashing error")

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -14,26 +14,27 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.1", features = ["mac"] }
+digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.0", default-features = false, optional = true, features = ["rand_core"] }
-hmac = { version = "0.13.0-rc.1", default-features = false, optional = true }
-sha1 = { version = "0.11.0-rc.2", default-features = false, optional = true }
-sha2 = { version = "0.11.0-rc.2", default-features = false, optional = true }
+password-hash = { version = "0.6.0-rc.2", default-features = false, optional = true, features = ["rand_core"] }
+hmac = { version = "0.13.0-rc.3", default-features = false, optional = true }
+sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
+sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 
 [dev-dependencies]
-hmac = "0.13.0-rc.1"
+hmac = "0.13.0-rc.3"
 hex-literal = "1"
-sha1 = "0.11.0-rc.2"
-sha2 = "0.11.0-rc.2"
-streebog = "0.11.0-rc.2"
-belt-hash = "0.2.0-rc.1"
+sha1 = "0.11.0-rc.3"
+sha2 = "0.11.0-rc.3"
+streebog = "0.11.0-rc.3"
+belt-hash = "0.2.0-rc.3"
 
 [features]
 default = ["hmac"]
-std = ["password-hash/os_rng"]
-simple = ["hmac", "password-hash", "sha2"]
+std = []
+getrandom = ["simple", "password-hash/getrandom"]
+simple = ["getrandom", "hmac", "password-hash", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -55,20 +55,16 @@
 //!
 //! The following example demonstrates the high-level password hashing API:
 //!
-//! ```
+#![cfg_attr(feature = "simple", doc = "```")]
+#![cfg_attr(not(feature = "simple"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! # #[cfg(feature = "simple")]
-//! # {
 //! use pbkdf2::{
-//!     password_hash::{
-//!         rand_core::OsRng,
-//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
-//!     },
+//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
 //!     Pbkdf2
 //! };
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = SaltString::try_from_rng(&mut OsRng).unwrap();
+//! let salt = SaltString::generate();
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
 //! let password_hash = Pbkdf2.hash_password(password, &salt)?.to_string();
@@ -76,7 +72,6 @@
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;
 //! assert!(Pbkdf2.verify_password(password, &parsed_hash).is_ok());
-//! # }
 //! # Ok(())
 //! # }
 //! ```

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -15,15 +15,15 @@ rust-version = "1.85"
 
 [dependencies]
 pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
-salsa20 = { version = "0.11.0-rc.1", default-features = false }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
+salsa20 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.1", default-features = false, features = ["rand_core"], optional = true }
+password-hash = { version = "0.6.0-rc.2", default-features = false, features = ["rand_core"], optional = true }
 
 [dev-dependencies]
-password-hash = { version = "0.6.0-rc.1", features = ["rand_core"] }
+password-hash = { version = "0.6.0-rc.2", features = ["rand_core"] }
 
 [features]
 default = ["simple", "rayon"]

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-sha2 = { version = "0.11.0-rc.2", default-features = false }
-base64ct = { version = "1.7.1", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
+base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
+getrandom = { version = "0.3", optional = true, default-features = false }
 mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }
-rand_core = { version = "0.9", optional = true, default-features = false, features = ["os_rng"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]
 default = ["simple"]
-simple = ["dep:mcf", "dep:rand_core", "dep:subtle"]
+simple = ["dep:getrandom", "dep:mcf", "dep:subtle"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/src/simple.rs
+++ b/sha-crypt/src/simple.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use alloc::string::{String, ToString};
 use base64ct::{Base64ShaCrypt, Encoding};
-use rand_core::{OsRng, RngCore, TryRngCore};
 
 const SHA256_MCF_ID: &str = "5";
 const SHA512_MCF_ID: &str = "6";
@@ -227,7 +226,7 @@ pub fn sha256_check(password: &str, hashed_value: &str) -> Result<(), CheckError
 fn random_salt() -> String {
     // Create buffer containing raw bytes to encode as Base64
     let mut buf = [0u8; (SALT_MAX_LEN * 3).div_ceil(4)];
-    OsRng.unwrap_err().fill_bytes(&mut buf);
+    getrandom::fill(&mut buf).expect("RNG failure");
     Base64ShaCrypt::encode_string(&buf)
 }
 

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = { version = "0.13.0-rc.1", default-features = false }
+hmac = { version = "0.13.0-rc.3", default-features = false }
 pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
-salsa20 = { version = "0.11.0-rc.1", default-features = false }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
+salsa20 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional dependencies
 mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }


### PR DESCRIPTION
This upgrades `rand_core` to v0.10 prereleases and depends directly on `getrandom` for access to the system RNG.

It additionally bumps other crates like `digest` and `blake2` which use the new `crypto-common` with an upgraded `rand_core`.

This required restoring some functionality in `blake2` which was used by `argon2`: https://github.com/RustCrypto/hashes/pull/754

This is currently referenced as a git branch until we decide if this is a permanent solution for `argon2` or not, so as to unblock the upgrade.