### PR TITLE
yescrypt: use `subtle` for password hash comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+ "subtle",
 ]
 
 [[package]]

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -18,6 +18,7 @@ hmac = { version = "0.13.0-rc.3", default-features = false }
 pbkdf2 = { version = "0.13.0-rc.1", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
+subtle = { version = "2", default-features = false }
 
 # optional dependencies
 mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }

--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -160,8 +160,7 @@ pub fn yescrypt_verify(passwd: &[u8], hash: &str) -> Result<()> {
     let mut actual = vec![0u8; expected.len()];
     yescrypt_kdf(passwd, &salt, &params, &mut actual)?;
 
-    // TODO(tarcieri): constant-time comparison?
-    if expected != actual {
+    if subtle::ConstantTimeEq::ct_ne(actual.as_slice(), &expected).into() {
         return Err(Error::Password);
     }
 


### PR DESCRIPTION
For rationale, see:

https://docs.rs/password-hash/0.6.0-rc.2/password_hash/struct.Output.html#constant-time-comparisons