### PR TITLE
argon2: check `p_cost < Params::MIN_P_COST` before `m_cost < p_cost * 8`

### DIFF
--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -114,16 +114,6 @@ impl Params {
             return Err(Error::MemoryTooLittle);
         }
 
-        // Note: we don't need to check `MAX_M_COST`, since it's `u32::MAX`
-
-        if m_cost < p_cost * 8 {
-            return Err(Error::MemoryTooLittle);
-        }
-
-        if t_cost < Params::MIN_T_COST {
-            return Err(Error::TimeTooSmall);
-        }
-
         // Note: we don't need to check `MAX_T_COST`, since it's `u32::MAX`
 
         if p_cost < Params::MIN_P_COST {
@@ -132,6 +122,16 @@ impl Params {
 
         if p_cost > Params::MAX_P_COST {
             return Err(Error::ThreadsTooMany);
+        }
+
+        // Note: we don't need to check `MAX_M_COST`, since it's `u32::MAX`
+
+        if m_cost < p_cost * 8 {
+            return Err(Error::MemoryTooLittle);
+        }
+
+        if t_cost < Params::MIN_T_COST {
+            return Err(Error::TimeTooSmall);
         }
 
         if let Some(len) = output_len {


### PR DESCRIPTION
`p_cost * 8` overflows for `p_cost` values  larger than `u32::MAX / 8`, which can trigger panic with enabled overflow checks.

The bug was reported by nb0999 via e-mail.