### PR TITLE
Updates for `password-hash` API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,8 +305,7 @@ dependencies = [
 [[package]]
 name = "password-hash"
 version = "0.6.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d47a2d1aee5a339aa6c740d9128211a8a3d2bdf06a13e01b3f8a0b5c49b9db"
+source = "git+https://github.com/RustCrypto/traits#85ce438cffe141361b36492d28e9784070c9df2d"
 dependencies = [
  "base64ct",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ exclude = ["benches", "fuzz"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.password-hash]
+git = "https://github.com/RustCrypto/traits"

--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(feature = "password-hash")]
-use password_hash::Ident;
+use password_hash::phc::Ident;
 
 /// Argon2d algorithm identifier
 #[cfg(feature = "password-hash")]
@@ -94,8 +94,8 @@ impl Display for Algorithm {
 impl FromStr for Algorithm {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Algorithm> {
-        match s {
+    fn from_str(name: &str) -> Result<Algorithm> {
+        match name {
             "argon2d" => Ok(Algorithm::Argon2d),
             "argon2i" => Ok(Algorithm::Argon2i),
             "argon2id" => Ok(Algorithm::Argon2id),
@@ -112,15 +112,10 @@ impl From<Algorithm> for Ident<'static> {
 }
 
 #[cfg(feature = "password-hash")]
-impl<'a> TryFrom<Ident<'a>> for Algorithm {
+impl TryFrom<&str> for Algorithm {
     type Error = password_hash::Error;
 
-    fn try_from(ident: Ident<'a>) -> password_hash::Result<Algorithm> {
-        match ident {
-            ARGON2D_IDENT => Ok(Algorithm::Argon2d),
-            ARGON2I_IDENT => Ok(Algorithm::Argon2i),
-            ARGON2ID_IDENT => Ok(Algorithm::Argon2id),
-            _ => Err(password_hash::Error::Algorithm),
-        }
+    fn try_from(name: &str) -> password_hash::Result<Algorithm> {
+        name.parse().map_err(|_| password_hash::Error::Algorithm)
     }
 }

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -5,7 +5,7 @@ use base64ct::{Base64Unpadded as B64, Encoding};
 use core::str::FromStr;
 
 #[cfg(feature = "password-hash")]
-use password_hash::{ParamsString, PasswordHash};
+use password_hash::{PasswordHash, phc::ParamsString};
 
 /// Argon2 password hash parameters.
 ///

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -14,7 +14,7 @@ use argon2::{
     PasswordVerifier, Version,
 };
 use hex_literal::hex;
-use password_hash::SaltString;
+use password_hash::phc::SaltString;
 
 /// Params used by the KATs.
 fn example_params() -> Params {
@@ -368,7 +368,10 @@ fn hashtest(
 
     // Test hash encoding
     let salt_string = SaltString::encode_b64(salt).unwrap();
-    let phc_hash = ctx.hash_password(pwd, &salt_string).unwrap().to_string();
+    let phc_hash = ctx
+        .hash_password(pwd, salt_string.as_ref())
+        .unwrap()
+        .to_string();
     assert_eq!(phc_hash, expected_phc_hash);
 
     let hash = PasswordHash::new(alternative_phc_hash).unwrap();

--- a/argon2/tests/phc_strings.rs
+++ b/argon2/tests/phc_strings.rs
@@ -9,8 +9,8 @@ use argon2::{
     PasswordVerifier, Version,
 };
 use password_hash::{
-    SaltString,
     errors::{Error, InvalidValue},
+    phc::SaltString,
 };
 
 /// Valid password
@@ -217,7 +217,7 @@ fn check_hash_encoding_parameters_order() {
     let password = b"password";
     let salt_string = SaltString::encode_b64(&salt).unwrap();
     let password_hash = ctx
-        .hash_password(password, &salt_string)
+        .hash_password(password, salt_string.as_ref())
         .unwrap()
         .to_string();
 

--- a/balloon-hash/src/algorithm.rs
+++ b/balloon-hash/src/algorithm.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(feature = "password-hash")]
-use password_hash::Ident;
+use password_hash::phc::Ident;
 
 /// Balloon primitive type: variants of the algorithm.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Default)]
@@ -87,11 +87,11 @@ impl From<Algorithm> for Ident<'static> {
 }
 
 #[cfg(feature = "password-hash")]
-impl<'a> TryFrom<Ident<'a>> for Algorithm {
+impl<'a> TryFrom<&'a str> for Algorithm {
     type Error = password_hash::Error;
 
-    fn try_from(ident: Ident<'a>) -> password_hash::Result<Algorithm> {
-        match ident {
+    fn try_from(name: &'a str) -> password_hash::Result<Algorithm> {
+        match name.try_into()? {
             Self::BALLOON_IDENT => Ok(Algorithm::Balloon),
             Self::BALLOON_M_IDENT => Ok(Algorithm::BalloonM),
             _ => Err(password_hash::Error::Algorithm),

--- a/balloon-hash/src/params.rs
+++ b/balloon-hash/src/params.rs
@@ -4,7 +4,10 @@ use crate::{Error, Result};
 use core::num::NonZeroU32;
 
 #[cfg(feature = "password-hash")]
-use password_hash::{ParamsString, PasswordHash, errors::InvalidValue};
+use password_hash::{
+    errors::InvalidValue,
+    phc::{ParamsString, PasswordHash},
+};
 
 /// Balloon password hash parameters.
 ///

--- a/balloon-hash/tests/balloon.rs
+++ b/balloon-hash/tests/balloon.rs
@@ -75,7 +75,7 @@ fn test_vectors() {
 #[cfg(all(feature = "password-hash", feature = "alloc"))]
 #[test]
 fn hash_simple_retains_configured_params() {
-    use balloon_hash::{PasswordHasher, Salt};
+    use balloon_hash::PasswordHasher;
     use sha2::Sha256;
 
     /// Example password only: don't use this as a real password!!!
@@ -91,8 +91,9 @@ fn hash_simple_retains_configured_params() {
 
     let params = Params::new(s_cost, t_cost, p_cost).unwrap();
     let hasher = Balloon::<Sha256>::new(Algorithm::default(), params, None);
-    let salt = Salt::from_b64(EXAMPLE_SALT).unwrap();
-    let hash = hasher.hash_password(EXAMPLE_PASSWORD, salt).unwrap();
+    let hash = hasher
+        .hash_password(EXAMPLE_PASSWORD, EXAMPLE_SALT)
+        .unwrap();
 
     assert_eq!(hash.version.unwrap(), 1);
 

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -26,7 +26,10 @@ mod errors;
 pub use crate::errors::{ParseError, VerifyError};
 
 use alloc::string::{String, ToString};
-use password_hash::{ParamsString, PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use password_hash::{
+    PasswordHasher, PasswordVerifier,
+    phc::{ParamsString, PasswordHash, SaltString},
+};
 
 #[cfg(not(any(feature = "argon2", feature = "pbkdf2", feature = "scrypt")))]
 compile_error!(
@@ -46,7 +49,7 @@ use scrypt::Scrypt;
 /// crate features (typically Argon2 unless explicitly disabled).
 pub fn generate_hash(password: impl AsRef<[u8]>) -> String {
     let salt = SaltString::generate();
-    generate_phc_hash(password.as_ref(), &salt)
+    generate_phc_hash(password.as_ref(), salt.as_ref())
         .map(|hash| hash.to_string())
         .expect("password hashing error")
 }
@@ -55,7 +58,7 @@ pub fn generate_hash(password: impl AsRef<[u8]>) -> String {
 #[allow(unreachable_code)]
 fn generate_phc_hash<'a>(
     password: &[u8],
-    salt: &'a SaltString,
+    salt: &'a str,
 ) -> password_hash::Result<PasswordHash<'a>> {
     //
     // Algorithms below are in order of preference

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -59,7 +59,7 @@
 #![cfg_attr(not(feature = "simple"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use pbkdf2::{
-//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, phc::SaltString},
 //!     Pbkdf2
 //! };
 //!
@@ -67,7 +67,7 @@
 //! let salt = SaltString::generate();
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
-//! let password_hash = Pbkdf2.hash_password(password, &salt)?.to_string();
+//! let password_hash = Pbkdf2.hash_password(password, salt.as_ref())?.to_string();
 //!
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;

--- a/pbkdf2/tests/simple.rs
+++ b/pbkdf2/tests/simple.rs
@@ -5,10 +5,7 @@
 #![cfg(feature = "simple")]
 
 use hex_literal::hex;
-use pbkdf2::{
-    Algorithm, Params, Pbkdf2,
-    password_hash::{PasswordHasher, Salt},
-};
+use pbkdf2::{Algorithm, Params, Pbkdf2, password_hash::CustomizedPasswordHasher};
 
 const PASSWORD: &str = "password";
 const SALT_B64: &str = "c2FsdA"; // "salt"
@@ -21,7 +18,7 @@ fn hash_with_default_algorithm() {
     //   S = "salt" (4 octets)
     //   c = 4096
     //   dkLen = 32
-    let salt = Salt::from_b64(SALT_B64).unwrap();
+    let salt = SALT_B64;
 
     let params = Params {
         rounds: 4096,


### PR DESCRIPTION
Includes updates for the following:
- Extract `phc` submodule (RustCrypto/traits#2103)
- Extract `CustomizedPasswordHasher` trait (RustCrypto/traits#2105)