### PR TITLE
Updates for `password-hash` trait `Params` bound changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 [[package]]
 name = "password-hash"
 version = "0.6.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits#85ce438cffe141361b36492d28e9784070c9df2d"
+source = "git+https://github.com/RustCrypto/traits#ac8d6ed0cf25a467ce4f00a235d425ca68b4466a"
 dependencies = [
  "base64ct",
  "getrandom",


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2106

The afforementioned upstream PR changed the bounds from ones which work on PHC types like `phc::PasswordHash` and `phc::ParamsString` to core traits like `Display` and `FromStr`.

This updates the `Params` types in `argon2`, `balloon-hash`, `pbkdf2`, and `scrypt` to impl the traits needed to meet the new bounds. Notably this PR is mostly additive and continues to support all the old traits, while adding support for new ones (thunking through `phc::ParamsString`)