### PR TITLE
Cut new prereleases

### DIFF
--- a/.readme/Cargo.toml
+++ b/.readme/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "readme"
 description = "rustdoc tests for toplevel README.md"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 publish = false
 
 [dependencies]
-password-hash = "0.6.0-rc.0"
+password-hash = "0.6.0-rc.3"
 argon2 = { path = "../argon2" }
 pbkdf2 = { path = "../pbkdf2", features = ["simple"] }
 scrypt = { path = "../scrypt" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "base64ct",
  "blake2",
@@ -23,7 +23,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "balloon-hash"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -293,7 +293,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "password-auth"
-version = "1.1.0-pre.1"
+version = "1.1.0-pre.2"
 dependencies = [
  "argon2",
  "getrandom",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 dependencies = [
  "belt-hash",
  "digest",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "readme"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "argon2",
  "password-hash",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.3"
+version = "0.12.0-rc.4"
 dependencies = [
  "password-hash",
  "pbkdf2",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "1.1.0-pre.1"
+version = "1.1.0-pre.2"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 including support for Argon2, PBKDF2, and scrypt password hashing algorithms

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.3"
+version = "0.12.0-rc.4"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `argon2` v0.6.0-rc.3
- `balloon-hash` v0.5.0-rc.1
- `password-auth` v1.1.0-pre.2
- `pbkdf2` v0.13.0-rc.3
- `scrypt` v0.12.0-rc.4