### PR TITLE
Use the `phc` crate

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -37,8 +37,8 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --no-default-features
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features password-hash
-      - run: cargo build --target ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --features zeroize
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features simple
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features zeroize
 
   minimal-versions:
     if: false # disabled while using pre-releases

--- a/.github/workflows/balloon-hash.yml
+++ b/.github/workflows/balloon-hash.yml
@@ -36,7 +36,6 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features password-hash
-      - run: cargo build --target ${{ matrix.target }} --release
 
   minimal-versions:
     if: false # disabled while using pre-releases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "cpufeatures",
  "hex-literal",
  "password-hash",
+ "phc",
  "rayon",
  "zeroize",
 ]
@@ -29,6 +30,7 @@ dependencies = [
  "digest",
  "hex-literal",
  "password-hash",
+ "phc",
  "rand_core",
  "rayon",
  "sha2",
@@ -299,19 +301,16 @@ dependencies = [
  "getrandom",
  "password-hash",
  "pbkdf2",
+ "phc",
  "scrypt",
 ]
 
 [[package]]
 name = "password-hash"
 version = "0.6.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ceb29fb5976f752babcc02842a530515b714919233f0912845c742dffb6246"
+source = "git+https://github.com/RustCrypto/traits#8b33a0834d1222b290bf5af28802f166ae18c58c"
 dependencies = [
- "base64ct",
- "getrandom",
- "rand_core",
- "subtle",
+ "phc",
 ]
 
 [[package]]
@@ -323,9 +322,21 @@ dependencies = [
  "hex-literal",
  "hmac",
  "password-hash",
+ "phc",
  "sha1",
  "sha2",
  "streebog",
+]
+
+[[package]]
+name = "phc"
+version = "0.3.0-pre"
+source = "git+https://github.com/RustCrypto/formats#1e7caeb8e57b89d5cff1fba6ab500928fb3eccf7"
+dependencies = [
+ "base64ct",
+ "getrandom",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -410,6 +421,7 @@ version = "0.12.0-rc.4"
 dependencies = [
  "password-hash",
  "pbkdf2",
+ "phc",
  "rayon",
  "salsa20",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ exclude = ["benches", "fuzz"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+password-hash = { git = "https://github.com/RustCrypto/traits" }
+phc = { git = "https://github.com/RustCrypto/formats" }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following code example shows how to verify a password when stored using one
 of many possible password hashing algorithms implemented in this repository.
 
 ```rust
+# fn main() -> Result<(), Box<dyn core::error::Error>> {
 use password_hash::{phc, PasswordVerifier};
 
 use argon2::Argon2;
@@ -35,12 +36,20 @@ use scrypt::Scrypt;
 let hash_string = "$argon2i$v=19$m=65536,t=1,p=1$c29tZXNhbHQAAAAAAAAAAA$+r0d29hqEB0yasKr55ZgICsQGSkl0v0kgwhd+U3wyRo";
 let input_password = "password";
 
-let password_hash = phc::PasswordHash::new(&hash_string).expect("invalid password hash");
+let password_hash = phc::PasswordHash::new(&hash_string)?;
 
 // Trait objects for algorithms to support
 let algs: &[&dyn PasswordVerifier<phc::PasswordHash>] = &[&Argon2::default(), &Pbkdf2, &Scrypt];
 
-password_hash.verify_password(algs, input_password).expect("invalid password");
+for alg in algs {
+    if alg.verify_password(input_password.as_ref(), &password_hash).is_ok() {
+        return Ok(());
+    }
+}
+
+// If we get here, the password is invalid
+# Err(Box::new(password_hash::Error::PasswordInvalid))
+# }
 ```
 
 ## Minimum Supported Rust Version (MSRV) Policy

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -22,7 +22,8 @@ blake2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional dependencies
 rayon = { version = "1.7", optional = true }
-password-hash = { version = "0.6.0-rc.3", optional = true }
+password-hash = { version = "0.6.0-rc.3", optional = true, features = ["phc"] }
+phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
@@ -30,17 +31,15 @@ cpufeatures = "0.2.17"
 
 [dev-dependencies]
 hex-literal = "1"
-password-hash = { version = "0.6.0-rc.3", features = ["rand_core"] }
 
 [features]
-default = ["alloc", "password-hash", "rand"]
+default = ["alloc", "getrandom", "simple"]
 alloc = ["password-hash?/alloc"]
 std = ["alloc", "base64ct/std"]
 
-getrandom = ["simple", "password-hash/getrandom"]
+getrandom = ["simple", "phc/getrandom"]
 parallel = ["dep:rayon"]
-rand = ["password-hash?/rand_core"]
-simple = ["password-hash"]
+simple = ["password-hash", "phc"]
 zeroize = ["dep:zeroize"]
 
 [lints.rust.unexpected_cfgs]

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -583,7 +583,7 @@ fn reference_argon2i_v0x10_mismatching_hash() {
     .unwrap();
     assert_eq!(
         Argon2::default().verify_password(b"password", &hash),
-        Err(password_hash::errors::Error::Password)
+        Err(password_hash::Error::PasswordInvalid)
     );
 }
 
@@ -716,7 +716,7 @@ fn reference_argon2i_v0x13_mismatching_hash() {
     .unwrap();
     assert_eq!(
         Argon2::default().verify_password(b"password", &hash),
-        Err(password_hash::errors::Error::Password)
+        Err(password_hash::Error::PasswordInvalid)
     );
 }
 

--- a/argon2/tests/phc_strings.rs
+++ b/argon2/tests/phc_strings.rs
@@ -8,7 +8,7 @@ use argon2::{
     Algorithm, Argon2, AssociatedData, KeyId, ParamsBuilder, PasswordHash, PasswordHasher,
     PasswordVerifier, Version,
 };
-use password_hash::errors::{Error, InvalidValue};
+use password_hash::Error;
 
 /// Valid password
 pub const VALID_PASSWORD: &[u8] = b"password";
@@ -90,61 +90,60 @@ testcase_bad_encoding!(
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_m_not_a_number,
-    Error::ParamValueInvalid(InvalidValue::InvalidChar('d')),
+    Error::ParamInvalid { name: "m" },
     "$argon2i$m=dummy,t=2,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_m_too_small,
-    Error::ParamValueInvalid(InvalidValue::TooShort),
+    Error::ParamInvalid { name: "m" },
     "$argon2i$m=0,t=2,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_m_too_big,
-    Error::ParamValueInvalid(InvalidValue::InvalidFormat),
+    Error::ParamInvalid { name: "m" },
     "$argon2i$m=4294967296,t=2,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 
 testcase_bad_encoding!(
     argon2i_invalid_encoding_t_not_a_number,
-    Error::ParamValueInvalid(InvalidValue::InvalidChar('d')),
+    Error::ParamInvalid { name: "t" },
     "$argon2i$m=65536,t=dummy,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_t_too_small,
-    Error::ParamValueInvalid(InvalidValue::TooShort),
+    Error::ParamInvalid { name: "t" },
     "$argon2i$m=65536,t=0,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_t_too_big,
-    Error::ParamValueInvalid(InvalidValue::InvalidFormat),
+    Error::ParamInvalid { name: "t" },
     "$argon2i$m=65536,t=4294967296,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 
 testcase_bad_encoding!(
     argon2i_invalid_encoding_p_not_a_number,
-    Error::ParamValueInvalid(InvalidValue::InvalidChar('d')),
+    Error::ParamInvalid { name: "p" },
     "$argon2i$m=65536,t=2,p=dummy$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_p_too_small,
-    Error::ParamValueInvalid(InvalidValue::TooShort),
+    Error::ParamInvalid { name: "p" },
     "$argon2i$m=65536,t=2,p=0$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
-// TODO: Wrong error is returned, this should be changed in the `password-hash` crate
 ignored_testcase_bad_encoding!(
     argon2i_invalid_encoding_p_too_big,
-    Error::ParamValueInvalid(InvalidValue::InvalidFormat),
+    Error::ParamInvalid { name: "p" },
     "$argon2i$m=65536,t=2,p=256$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 
 testcase_bad_encoding!(
     argon2i_invalid_encoding_keyid_not_b64,
-    Error::B64Encoding(base64ct::Error::InvalidEncoding),
+    Error::ParamInvalid { name: "keyid" },
     "$argon2i$m=65536,t=2,p=1,keyid=dummy$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 testcase_bad_encoding!(
     argon2i_invalid_encoding_data_not_b64,
-    Error::B64Encoding(base64ct::Error::InvalidEncoding),
+    Error::ParamInvalid { name: "data" },
     "$argon2i$m=65536,t=2,p=1,data=dummy$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"
 );
 
@@ -179,19 +178,19 @@ fn check_decoding_supports_default_parameters() {
 // TODO: Wrong error is returned, this should be changed in the `password-hash` crate
 ignored_testcase_bad_encoding!(
     argon2i_invalid_encoding_missing_m,
-    Error::ParamValueInvalid(InvalidValue::InvalidFormat),
+    Error::ParamsInvalid,
     "$argon2d$v=16$t=2,p=3$8PDw8PDw8PA$Xv5daH0zPuKO3c9tMBG/WOIUsDrPqq815/xyQTukNxY"
 );
 // TODO: Wrong error is returned, this should be changed in the `password-hash` crate
 ignored_testcase_bad_encoding!(
     argon2i_invalid_encoding_missing_t,
-    Error::ParamValueInvalid(InvalidValue::InvalidFormat),
+    Error::ParamsInvalid,
     "$argon2d$v=16$m=32,p=3$8PDw8PDw8PA$Xv5daH0zPuKO3c9tMBG/WOIUsDrPqq815/xyQTukNxY"
 );
 // TODO: Wrong error is returned, this should be changed in the `password-hash` crate
 ignored_testcase_bad_encoding!(
     argon2i_invalid_encoding_missing_p,
-    Error::ParamValueInvalid(InvalidValue::InvalidFormat),
+    Error::ParamsInvalid,
     "$argon2d$v=16$m=32,t=2$8PDw8PDw8PA$Xv5daH0zPuKO3c9tMBG/WOIUsDrPqq815/xyQTukNxY"
 );
 

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -20,6 +20,7 @@ rand_core = { version = "0.10.0-rc-2", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["phc"] }
+phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
 
@@ -28,13 +29,13 @@ hex-literal = "1"
 sha2 = "0.11.0-rc.3"
 
 [features]
-default = ["alloc", "password-hash", "rand"]
+default = ["alloc", "getrandom", "password-hash"]
 alloc = ["password-hash/alloc"]
 std = ["alloc", "getrandom"]
 
-getrandom = ["password-hash/getrandom"]
+getrandom = ["phc/getrandom"]
 parallel = ["rayon", "std"]
-rand = ["password-hash/rand_core"]
+password-hash = ["dep:password-hash", "dep:phc"]
 zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]

--- a/balloon-hash/src/algorithm.rs
+++ b/balloon-hash/src/algorithm.rs
@@ -91,9 +91,9 @@ impl<'a> TryFrom<&'a str> for Algorithm {
     type Error = password_hash::Error;
 
     fn try_from(name: &'a str) -> password_hash::Result<Algorithm> {
-        match name.try_into()? {
-            Self::BALLOON_IDENT => Ok(Algorithm::Balloon),
-            Self::BALLOON_M_IDENT => Ok(Algorithm::BalloonM),
+        match name.try_into() {
+            Ok(Self::BALLOON_IDENT) => Ok(Algorithm::Balloon),
+            Ok(Self::BALLOON_M_IDENT) => Ok(Algorithm::BalloonM),
             _ => Err(password_hash::Error::Algorithm),
         }
     }

--- a/balloon-hash/src/error.rs
+++ b/balloon-hash/src/error.rs
@@ -2,9 +2,6 @@
 
 use core::fmt;
 
-#[cfg(feature = "password-hash")]
-use password_hash::errors::InvalidValue;
-
 /// Result with balloon's [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -51,14 +48,11 @@ impl From<Error> for password_hash::Error {
     fn from(err: Error) -> password_hash::Error {
         match err {
             Error::AlgorithmInvalid => password_hash::Error::Algorithm,
-            Error::MemoryTooLittle => InvalidValue::TooShort.param_error(),
-            Error::ThreadsTooFew => InvalidValue::TooShort.param_error(),
-            Error::ThreadsTooMany => InvalidValue::TooLong.param_error(),
-            Error::TimeTooSmall => InvalidValue::TooShort.param_error(),
-            Error::OutputSize { actual, expected } => password_hash::Error::OutputSize {
-                provided: actual.cmp(&expected),
-                expected,
-            },
+            Error::MemoryTooLittle
+            | Error::ThreadsTooFew
+            | Error::ThreadsTooMany
+            | Error::TimeTooSmall => password_hash::Error::ParamsInvalid,
+            Error::OutputSize { .. } => password_hash::Error::OutputSize,
         }
     }
 }

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -249,8 +249,9 @@ where
     Array<u8, D::OutputSize>: ArrayDecoding,
 {
     fn hash_password(&self, password: &[u8], salt: &[u8]) -> password_hash::Result<PasswordHash> {
-        let salt = Salt::new(salt)?;
-        let output = Output::new(&self.hash(password, &salt)?)?;
+        let salt = Salt::new(salt).map_err(|_| password_hash::Error::SaltInvalid)?;
+        let hash = self.hash(password, &salt)?;
+        let output = Output::new(&hash).map_err(|_| password_hash::Error::OutputSize)?;
 
         Ok(PasswordHash {
             algorithm: self.algorithm.ident(),

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -18,7 +18,8 @@ rust-version = "1.85"
 
 [dependencies]
 getrandom = { version = "0.3", default-features = false }
-password-hash = { version = "0.6.0-rc.3", features = ["alloc", "getrandom"] }
+password-hash = { version = "0.6.0-rc.3", features = ["alloc", "phc"] }
+phc = { version = "0.3.0-pre", features = ["getrandom"] }
 
 # optional dependencies
 argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }

--- a/password-auth/src/errors.rs
+++ b/password-auth/src/errors.rs
@@ -4,15 +4,14 @@ use alloc::string::ToString;
 use core::fmt;
 
 /// Password hash parse errors.
-// This type has no public constructor and deliberately keeps
-// `password_hash::Error` out of the public API so it can evolve
-// independently (e.g. get to 1.0 faster)
+// This type has no public constructor and deliberately keeps `phc::Error` out of the public API
+// so we can upgrade the `phc` version without it being a breaking change
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct ParseError(password_hash::Error);
+pub struct ParseError(phc::Error);
 
 impl ParseError {
     /// Create a new parse error.
-    pub(crate) fn new(err: password_hash::Error) -> Self {
+    pub(crate) fn new(err: phc::Error) -> Self {
         Self(err)
     }
 }

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -89,8 +89,13 @@ pub fn verify_password(password: impl AsRef<[u8]>, hash: &str) -> Result<(), Ver
         &Scrypt,
     ];
 
-    hash.verify_password(algs, password)
-        .map_err(|_| VerifyError::PasswordInvalid)
+    for &alg in algs {
+        if alg.verify_password(password.as_ref(), &hash).is_ok() {
+            return Ok(());
+        }
+    }
+
+    Err(VerifyError::PasswordInvalid)
 }
 
 /// Determine if the given password hash is using the recommended algorithm and

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -17,8 +17,9 @@ rust-version = "1.85"
 digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.3", default-features = false, optional = true, features = ["phc", "rand_core"] }
 hmac = { version = "0.13.0-rc.3", default-features = false, optional = true }
+password-hash = { version = "0.6.0-rc.3", default-features = false, optional = true, features = ["phc"] }
+phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 
@@ -32,8 +33,8 @@ belt-hash = "0.2.0-rc.3"
 
 [features]
 default = ["hmac"]
-getrandom = ["simple", "password-hash/getrandom"]
-simple = ["getrandom", "hmac", "password-hash", "sha2"]
+getrandom = ["simple", "phc/getrandom"]
+simple = ["hmac", "dep:password-hash", "dep:phc", "sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -20,15 +20,13 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.3", default-features = false, features = ["phc", "rand_core"], optional = true }
-
-[dev-dependencies]
-password-hash = { version = "0.6.0-rc.3", features = ["rand_core"] }
+password-hash = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["phc"] }
+phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
 
 [features]
 default = ["simple", "rayon"]
 rayon = ["dep:rayon"]
-simple = ["dep:password-hash"]
+simple = ["dep:password-hash", "dep:phc"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2116

The `phc` crate was recently extracted from the `password-hash` crate, implementing the Password Hashing Competition (PHC) string format for storing password hashes.

This also factored apart the error types so there are separate ones for `phc::Error` and `password_hash::Error`, which is the primary source of changes in this PR.