### PR TITLE
Use `phc` crate prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,8 +307,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits#8b33a0834d1222b290bf5af28802f166ae18c58c"
+version = "0.6.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4087c2ea1e1d8a217af92740e5d49eb3ee0e6d8f0df513b375140d6f6265ee"
 dependencies = [
  "phc",
 ]
@@ -330,8 +331,9 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/formats#1e7caeb8e57b89d5cff1fba6ab500928fb3eccf7"
+version = "0.6.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f960577aaac5c259bc0866d685ba315c0ed30793c602d7287f54980913863"
 dependencies = [
  "base64ct",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,3 @@ exclude = ["benches", "fuzz"]
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-password-hash = { git = "https://github.com/RustCrypto/traits" }
-phc = { git = "https://github.com/RustCrypto/formats" }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -22,8 +22,8 @@ blake2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional dependencies
 rayon = { version = "1.7", optional = true }
-password-hash = { version = "0.6.0-rc.3", optional = true, features = ["phc"] }
-phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
+password-hash = { version = "0.6.0-rc.4", optional = true, features = ["phc"] }
+phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -19,8 +19,8 @@ crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = [
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["phc"] }
-phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
+password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["phc"] }
+phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.85"
 
 [dependencies]
 getrandom = { version = "0.3", default-features = false }
-password-hash = { version = "0.6.0-rc.3", features = ["alloc", "phc"] }
-phc = { version = "0.3.0-pre", features = ["getrandom"] }
+password-hash = { version = "0.6.0-rc.4", features = ["alloc", "phc"] }
+phc = { version = "0.6.0-rc.0", features = ["getrandom"] }
 
 # optional dependencies
 argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -18,8 +18,8 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
 hmac = { version = "0.13.0-rc.3", default-features = false, optional = true }
-password-hash = { version = "0.6.0-rc.3", default-features = false, optional = true, features = ["phc"] }
-phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
+password-hash = { version = "0.6.0-rc.4", default-features = false, optional = true, features = ["phc"] }
+phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -20,8 +20,8 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["phc"] }
-phc = { version = "0.3.0-pre", optional = true, features = ["rand_core"] }
+password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["phc"] }
+phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 
 [features]
 default = ["simple", "rayon"]


### PR DESCRIPTION
Switches from git for sourcing `password-hash` and `phc` to the following crate prereleases:

- `password-hash` v0.6.0-rc.4
- `phc` v0.6.0-rc.0