### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "base64ct",
  "blake2",
@@ -24,14 +24,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "balloon-hash"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "crypto-bigint",
  "digest",
  "hex-literal",
  "password-hash",
  "phc",
- "rand_core",
  "rayon",
  "sha2",
  "zeroize",
@@ -295,7 +294,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "password-auth"
-version = "1.1.0-pre.2"
+version = "1.1.0-pre.3"
 dependencies = [
  "argon2",
  "getrandom",
@@ -316,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.3"
+version = "0.13.0-rc.4"
 dependencies = [
  "belt-hash",
  "digest",
@@ -419,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.4"
+version = "0.12.0-rc.5"
 dependencies = [
  "password-hash",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ exclude = ["benches", "fuzz"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+argon2 = { path = "./argon2" }
+pbkdf2 = { path = "./pbkdf2" }
+scrypt = { path = "./scrypt" }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,6 @@ rust-version = "1.85"
 [dependencies]
 digest = { version = "0.11.0-rc.4", default-features = false }
 crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["hybrid-array"] }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
 
 # optional dependencies
 password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["phc"] }

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 blowfish = { version = "0.10.0-rc.2", features = ["bcrypt"] }
-pbkdf2 = { version = "0.13.0-rc.2", default-features = false, path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.4", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional features

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "1.1.0-pre.2"
+version = "1.1.0-pre.3"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 including support for Argon2, PBKDF2, and scrypt password hashing algorithms
@@ -22,9 +22,9 @@ password-hash = { version = "0.6.0-rc.4", features = ["alloc", "phc"] }
 phc = { version = "0.6.0-rc.0", features = ["getrandom"] }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "simple"], path = "../argon2" }
-pbkdf2 = { version = "0.13.0-rc.0", optional = true, default-features = false, features = ["simple"], path = "../pbkdf2" }
-scrypt = { version = "0.12.0-rc.0", optional = true, default-features = false, features = ["simple"], path = "../scrypt" }
+argon2 = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["alloc", "simple"] }
+pbkdf2 = { version = "0.13.0-rc.4", optional = true, default-features = false, features = ["simple"] }
+scrypt = { version = "0.12.0-rc.5", optional = true, default-features = false, features = ["simple"] }
 
 [features]
 default = ["argon2", "std"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-rc.3"
+version = "0.13.0-rc.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.4"
+version = "0.12.0-rc.5"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-pbkdf2 = { version = "0.13.0-rc.2", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.4", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 hmac = { version = "0.13.0-rc.3", default-features = false }
-pbkdf2 = { version = "0.13.0-rc.2", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.4", default-features = false, features = ["hmac"] }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
These use the recently extracted `phc` crate (#761)

Releases the following:
- `argon2` v0.6.0-rc.4
- `balloon-hash` v0.5.0-rc.2
- `password-auth` v1.1.0-pre.3
- `pbkdf2` v0.13.0-rc.4
- `scrypt` v0.12.0-rc.5