### PR TITLE
yescrypt: impl `password-hash` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,8 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "mcf"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7b81dccc6352af3f2bf99887f60cad09b991829ec92f0271ce8c3c68c0dfb6"
+version = "0.6.0-pre"
+source = "git+https://github.com/RustCrypto/formats#6863922a04b2fce8668a1459295febe0d35bfcad"
 dependencies = [
  "base64ct",
 ]
@@ -307,8 +306,7 @@ dependencies = [
 [[package]]
 name = "password-hash"
 version = "0.6.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4087c2ea1e1d8a217af92740e5d49eb3ee0e6d8f0df513b375140d6f6265ee"
+source = "git+https://github.com/RustCrypto/traits#c1a92e9ac52f9201e1a3503b2ecd63007027b157"
 dependencies = [
  "phc",
 ]
@@ -566,6 +564,7 @@ dependencies = [
  "hex-literal",
  "hmac",
  "mcf",
+ "password-hash",
  "pbkdf2",
  "salsa20",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ opt-level = 2
 argon2 = { path = "./argon2" }
 pbkdf2 = { path = "./pbkdf2" }
 scrypt = { path = "./scrypt" }
+
+mcf = { git = "https://github.com/RustCrypto/formats" }
+password-hash = { git = "https://github.com/RustCrypto/traits" }

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -22,7 +22,7 @@ base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 getrandom = { version = "0.3", optional = true, default-features = false }
-mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "=0.6.0-pre", optional = true, default-features = false, features = ["alloc", "base64"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -21,14 +21,15 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-mcf = { version = "0.2", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "=0.6.0-pre", optional = true, default-features = false, features = ["alloc", "base64"] }
+password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
 
 [features]
 default = ["simple"]
-simple = ["dep:mcf"]
+simple = ["dep:mcf", "dep:password-hash"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/yescrypt/src/error.rs
+++ b/yescrypt/src/error.rs
@@ -9,10 +9,6 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
-    /// Invalid password hashing algorithm.
-    #[cfg(feature = "simple")]
-    Algorithm,
-
     /// Encoding error (i.e. Base64)
     Encoding,
 
@@ -21,22 +17,14 @@ pub enum Error {
 
     /// Invalid params
     Params,
-
-    /// Invalid password
-    #[cfg(feature = "simple")]
-    Password,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            #[cfg(feature = "simple")]
-            Error::Algorithm => write!(f, "password hash must begin with `$y$`"),
             Error::Encoding => write!(f, "yescrypt encoding invalid"),
             Error::Internal => write!(f, "internal error"),
             Error::Params => write!(f, "yescrypt params invalid"),
-            #[cfg(feature = "simple")]
-            Error::Password => write!(f, "invalid password"),
         }
     }
 }
@@ -46,5 +34,16 @@ impl core::error::Error for Error {}
 impl From<TryFromIntError> for Error {
     fn from(_: TryFromIntError) -> Self {
         Error::Internal
+    }
+}
+
+#[cfg(feature = "simple")]
+impl From<Error> for password_hash::Error {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::Encoding => password_hash::Error::EncodingInvalid,
+            Error::Internal => password_hash::Error::Internal,
+            Error::Params => password_hash::Error::ParamsInvalid,
+        }
     }
 }

--- a/yescrypt/src/simple.rs
+++ b/yescrypt/src/simple.rs
@@ -1,0 +1,121 @@
+//! Implementation of the `password-hash` crate API.
+
+use crate::{Params, yescrypt_kdf};
+use alloc::vec;
+use mcf::{Base64, PasswordHash, PasswordHashRef};
+use password_hash::{
+    CustomizedPasswordHasher, Error, PasswordHasher, PasswordVerifier, Result, Version,
+};
+
+/// Identifier for yescrypt when encoding to the Modular Crypt Format, i.e. `$y$`
+#[cfg(feature = "simple")]
+const YESCRYPT_MCF_ID: &str = "y";
+
+/// Base64 variant used by yescrypt.
+const YESCRYPT_BASE64: Base64 = Base64::ShaCrypt;
+
+/// yescrypt type for use with [`PasswordHasher`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Yescrypt;
+
+impl CustomizedPasswordHasher<PasswordHash> for Yescrypt {
+    type Params = Params;
+
+    fn hash_password_customized(
+        &self,
+        password: &[u8],
+        salt: &[u8],
+        alg_id: Option<&str>,
+        version: Option<Version>,
+        params: Params,
+    ) -> Result<PasswordHash> {
+        // TODO(tarcieri): tunable hash output size?
+        const HASH_SIZE: usize = 32;
+
+        match alg_id {
+            Some(YESCRYPT_MCF_ID) | None => (),
+            _ => return Err(Error::Algorithm),
+        }
+
+        if version.is_some() {
+            return Err(Error::Version);
+        }
+
+        let mut out = [0u8; HASH_SIZE];
+        yescrypt_kdf(password, salt, &params, &mut out)?;
+
+        // Begin building the Modular Crypt Format hash.
+        let mut mcf_hash = PasswordHash::from_id(YESCRYPT_MCF_ID).expect("should be valid");
+
+        // Add params string to the hash
+        mcf_hash
+            .push_displayable(params)
+            .map_err(|_| Error::EncodingInvalid)?;
+
+        // Add salt
+        mcf_hash.push_base64(salt, YESCRYPT_BASE64);
+
+        // Add yescrypt password hashing function output
+        mcf_hash.push_base64(&out, YESCRYPT_BASE64);
+
+        Ok(mcf_hash)
+    }
+}
+
+impl PasswordHasher<PasswordHash> for Yescrypt {
+    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
+        self.hash_password_customized(password, salt, None, None, Params::default())
+    }
+}
+
+impl PasswordVerifier<PasswordHash> for Yescrypt {
+    fn verify_password(&self, password: &[u8], hash: &PasswordHash) -> Result<()> {
+        self.verify_password(password, hash.as_password_hash_ref())
+    }
+}
+
+impl PasswordVerifier<PasswordHashRef> for Yescrypt {
+    fn verify_password(&self, password: &[u8], hash: &PasswordHashRef) -> Result<()> {
+        // verify id matches `$y`
+        if hash.id() != YESCRYPT_MCF_ID {
+            return Err(Error::Algorithm);
+        }
+
+        let mut fields = hash.fields();
+
+        // decode params
+        let params: Params = fields
+            .next()
+            .ok_or(Error::EncodingInvalid)?
+            .as_str()
+            .parse()?;
+
+        // decode salt
+        let salt = fields
+            .next()
+            .ok_or(Error::EncodingInvalid)?
+            .decode_base64(YESCRYPT_BASE64)
+            .map_err(|_| Error::EncodingInvalid)?;
+
+        // decode expected password hash
+        let expected = fields
+            .next()
+            .ok_or(Error::EncodingInvalid)?
+            .decode_base64(YESCRYPT_BASE64)
+            .map_err(|_| Error::EncodingInvalid)?;
+
+        // should be the last field
+        if fields.next().is_some() {
+            return Err(Error::EncodingInvalid);
+        }
+
+        let mut actual = vec![0u8; expected.len()];
+        yescrypt_kdf(password, &salt, &params, &mut actual)?;
+
+        if subtle::ConstantTimeEq::ct_ne(actual.as_slice(), &expected).into() {
+            return Err(Error::PasswordInvalid);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Now that the password hash traits have been decoupled from the PHC format, this impls them for `yescrypt`, replacing the previous `simple` API with one based on the traits.

In the process this also bumps `mcf` to the latest prerelease which included some useful changes to make this work.