### PR TITLE
Switch from `std::error::Error` to `core::error::Error`

### DIFF
--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -32,12 +32,9 @@
 //! password-based authentication. Do not use this API to derive cryptographic
 //! keys: see the "key derivation" usage example below.
 //!
-#![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
-#![cfg_attr(
-    not(all(feature = "password-hash", feature = "std")),
-    doc = "```ignore"
-)]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+#![cfg_attr(all(feature = "alloc", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "alloc", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use argon2::{
 //!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, phc::Salt},
 //!     Argon2
@@ -66,12 +63,9 @@
 //!
 //! [pepper]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#peppering
 //!
-#![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
-#![cfg_attr(
-    not(all(feature = "password-hash", feature = "std")),
-    doc = "```ignore"
-)]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+#![cfg_attr(all(feature = "alloc", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "alloc", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use argon2::{
 //!     password_hash::{
 //!         phc::{PasswordHash, Salt},
@@ -118,12 +112,9 @@
 //! This API is useful for transforming a password into cryptographic keys for
 //! e.g. password-based encryption.
 //!
-#![cfg_attr(all(feature = "password-hash", feature = "std"), doc = "```")]
-#![cfg_attr(
-    not(all(feature = "password-hash", feature = "std")),
-    doc = "```ignore"
-)]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+#![cfg_attr(feature = "alloc", doc = "```")]
+#![cfg_attr(not(feature = "alloc"), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use argon2::Argon2;
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!

--- a/balloon-hash/src/error.rs
+++ b/balloon-hash/src/error.rs
@@ -57,5 +57,4 @@ impl From<Error> for password_hash::Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use balloon_hash::{
 //!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, phc::Salt},
 //!     Balloon

--- a/bcrypt-pbkdf/src/errors.rs
+++ b/bcrypt-pbkdf/src/errors.rs
@@ -24,5 +24,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/password-auth/src/errors.rs
+++ b/password-auth/src/errors.rs
@@ -30,6 +30,12 @@ impl fmt::Display for ParseError {
     }
 }
 
+impl core::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
 /// Password verification errors.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VerifyError {
@@ -55,8 +61,11 @@ impl From<ParseError> for VerifyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {}
-
-#[cfg(feature = "std")]
-impl std::error::Error for VerifyError {}
+impl core::error::Error for VerifyError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Parse(err) => Some(err),
+            _ => None,
+        }
+    }
+}

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -25,6 +25,9 @@ phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 
 [features]
 default = ["simple", "rayon"]
+alloc = ["password-hash?/alloc"]
+
+getrandom = ["simple", "phc/getrandom"]
 rayon = ["dep:rayon"]
 simple = ["dep:password-hash", "dep:phc"]
 

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -12,20 +12,18 @@
 //!
 //! # Usage (simple with default params)
 //!
-//! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(all(feature = "simple", feature = "std"))]
-//! # {
+#![cfg_attr(all(feature = "alloc", feature = "getrandom"), doc = "```")]
+#![cfg_attr(not(all(feature = "alloc", feature = "getrandom")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use scrypt::{
 //!     password_hash::{
-//!         rand_core::OsRng,
-//!         PasswordHash, PasswordHasher, PasswordVerifier, SaltString
+//!         PasswordHasher, PasswordVerifier, phc::{PasswordHash, Salt}
 //!     },
 //!     Scrypt
 //! };
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = SaltString::generate(&mut OsRng);
+//! let salt = Salt::generate();
 //!
 //! // Hash password to PHC string ($scrypt$...)
 //! let password_hash = Scrypt.hash_password(password, &salt)?.to_string();
@@ -33,7 +31,6 @@
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;
 //! assert!(Scrypt.verify_password(password, &parsed_hash).is_ok());
-//! # }
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
The latter was being used in some places, but not consistently.

Notably this gets rid of the `std` dependency on various test examples.