### PR TITLE
argon2+ballon-hash: remove `std` feature

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -35,7 +35,6 @@ hex-literal = "1"
 [features]
 default = ["alloc", "getrandom", "simple"]
 alloc = ["password-hash?/alloc"]
-std = ["alloc", "base64ct/std"]
 
 getrandom = ["simple", "phc/getrandom"]
 parallel = ["dep:rayon"]

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -134,9 +134,6 @@ compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 mod algorithm;
 mod blake2b_long;
 mod block;

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -30,10 +30,9 @@ sha2 = "0.11.0-rc.3"
 [features]
 default = ["alloc", "getrandom", "password-hash"]
 alloc = ["password-hash/alloc"]
-std = ["alloc", "getrandom"]
 
 getrandom = ["phc/getrandom"]
-parallel = ["rayon", "std"]
+parallel = ["dep:rayon"]
 password-hash = ["dep:password-hash", "dep:phc"]
 zeroize = ["dep:zeroize"]
 

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -58,9 +58,6 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 mod algorithm;
 mod balloon;
 mod error;


### PR DESCRIPTION
After #767 it is no longer used

This is technically true of `password-hash` as well, but as a post-1.0 crate we can't remove the `std` feature there