### PR TITLE
Leverage `password-hash/getrandom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,8 +306,9 @@ dependencies = [
 [[package]]
 name = "password-hash"
 version = "0.6.0-rc.4"
-source = "git+https://github.com/RustCrypto/traits#c1a92e9ac52f9201e1a3503b2ecd63007027b157"
+source = "git+https://github.com/RustCrypto/traits#c45480e68908f7f1b37624cd89be10b35ef63a59"
 dependencies = [
+ "getrandom",
  "phc",
 ]
 

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -36,7 +36,7 @@ hex-literal = "1"
 default = ["alloc", "getrandom", "simple"]
 alloc = ["password-hash?/alloc"]
 
-getrandom = ["simple", "phc/getrandom"]
+getrandom = ["simple", "password-hash/getrandom"]
 parallel = ["dep:rayon"]
 simple = ["password-hash", "phc"]
 zeroize = ["dep:zeroize"]

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -366,7 +366,7 @@ fn hashtest(
     assert_eq!(out, expected_raw_hash);
 
     // Test hash encoding
-    let phc_hash = ctx.hash_password(pwd, salt).unwrap().to_string();
+    let phc_hash = ctx.hash_password_with_salt(pwd, salt).unwrap().to_string();
     assert_eq!(phc_hash, expected_phc_hash);
 
     let hash = PasswordHash::new(alternative_phc_hash).unwrap();

--- a/argon2/tests/phc_strings.rs
+++ b/argon2/tests/phc_strings.rs
@@ -211,7 +211,10 @@ fn check_hash_encoding_parameters_order() {
 
     let password = b"password";
     let salt = [0u8; 8];
-    let password_hash = ctx.hash_password(password, &salt).unwrap().to_string();
+    let password_hash = ctx
+        .hash_password_with_salt(password, &salt)
+        .unwrap()
+        .to_string();
 
     // The parameters shall appear in the m,t,p,keyid,data order
     assert_eq!(

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.11.0-rc.3"
 default = ["alloc", "getrandom", "password-hash"]
 alloc = ["password-hash/alloc"]
 
-getrandom = ["phc/getrandom"]
+getrandom = ["password-hash/getrandom"]
 parallel = ["dep:rayon"]
 password-hash = ["dep:password-hash", "dep:phc"]
 zeroize = ["dep:zeroize"]

--- a/balloon-hash/tests/balloon.rs
+++ b/balloon-hash/tests/balloon.rs
@@ -92,7 +92,7 @@ fn hash_simple_retains_configured_params() {
     let params = Params::new(s_cost, t_cost, p_cost).unwrap();
     let hasher = Balloon::<Sha256>::new(Algorithm::default(), params, None);
     let hash = hasher
-        .hash_password(EXAMPLE_PASSWORD, EXAMPLE_SALT)
+        .hash_password_with_salt(EXAMPLE_PASSWORD, EXAMPLE_SALT)
         .unwrap();
 
     assert_eq!(hash.version.unwrap(), 1);

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -61,13 +61,13 @@ fn generate_phc_hash(password: &[u8], salt: &[u8]) -> password_hash::Result<Pass
     // Algorithms below are in order of preference
     //
     #[cfg(feature = "argon2")]
-    return Argon2::default().hash_password(password, salt);
+    return Argon2::default().hash_password_with_salt(password, salt);
 
     #[cfg(feature = "scrypt")]
-    return Scrypt.hash_password(password, salt);
+    return Scrypt.hash_password_with_salt(password, salt);
 
     #[cfg(feature = "pbkdf2")]
-    return Pbkdf2.hash_password(password, salt);
+    return Pbkdf2.hash_password_with_salt(password, salt);
 }
 
 /// Verify the provided password against the provided password hash.

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -33,7 +33,7 @@ belt-hash = "0.2.0-rc.3"
 
 [features]
 default = ["hmac"]
-getrandom = ["simple", "phc/getrandom"]
+getrandom = ["simple", "password-hash/getrandom"]
 simple = ["hmac", "dep:password-hash", "dep:phc", "sha2"]
 
 [package.metadata.docs.rs]

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -58,16 +58,17 @@
 #![cfg_attr(feature = "simple", doc = "```")]
 #![cfg_attr(not(feature = "simple"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: example requires `getrandom` feature is enabled
+//!
 //! use pbkdf2::{
-//!     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, phc::Salt},
+//!     password_hash::{PasswordHasher, PasswordVerifier, phc::PasswordHash},
 //!     Pbkdf2
 //! };
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = Salt::generate();
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
-//! let password_hash = Pbkdf2.hash_password(password, &salt)?.to_string();
+//! let password_hash = Pbkdf2.hash_password(password)?.to_string();
 //!
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -65,7 +65,7 @@ impl CustomizedPasswordHasher<PasswordHash> for Pbkdf2 {
 }
 
 impl PasswordHasher<PasswordHash> for Pbkdf2 {
-    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
+    fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
         self.hash_password_customized(password, salt, None, None, Params::default())
     }
 }

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -27,7 +27,7 @@ phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 default = ["simple", "rayon"]
 alloc = ["password-hash?/alloc"]
 
-getrandom = ["simple", "phc/getrandom"]
+getrandom = ["simple", "password-hash/getrandom"]
 rayon = ["dep:rayon"]
 simple = ["dep:password-hash", "dep:phc"]
 

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(all(feature = "alloc", feature = "getrandom"), doc = "```")]
 #![cfg_attr(not(all(feature = "alloc", feature = "getrandom")), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: example requires `getrandom` feature is enabled
+//!
 //! use scrypt::{
 //!     password_hash::{
 //!         PasswordHasher, PasswordVerifier, phc::{PasswordHash, Salt}
@@ -23,10 +25,9 @@
 //! };
 //!
 //! let password = b"hunter42"; // Bad password; don't actually use!
-//! let salt = Salt::generate();
 //!
 //! // Hash password to PHC string ($scrypt$...)
-//! let password_hash = Scrypt.hash_password(password, &salt)?.to_string();
+//! let password_hash = Scrypt.hash_password(password)?.to_string();
 //!
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -58,7 +58,7 @@ impl CustomizedPasswordHasher<PasswordHash> for Scrypt {
 }
 
 impl PasswordHasher<PasswordHash> for Scrypt {
-    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
+    fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
         self.hash_password_customized(password, salt, None, None, Params::default())
     }
 }

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -28,7 +28,8 @@ password-hash = { version = "0.6.0-rc.4", optional = true, default-features = fa
 hex-literal = "1"
 
 [features]
-default = ["simple"]
+default = ["getrandom"]
+getrandom = ["simple", "password-hash/getrandom"]
 simple = ["dep:mcf", "dep:password-hash"]
 
 [package.metadata.docs.rs]

--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -25,15 +25,15 @@
 
 //! # Usage
 //! ## Password Hashing
-//! NOTE: the `simple` crate feature must be enabled (on-by-default)
-#![cfg_attr(feature = "simple", doc = "```")]
-#![cfg_attr(not(feature = "simple"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> yescrypt::password_hash::Result<()> {
+//! // NOTE: example requires `getrandom` feature is enabled
+//!
 //! use yescrypt::{Yescrypt, PasswordHasher, PasswordVerifier};
 //!
 //! let password = b"pleaseletmein"; // don't actually use this as a password!
-//! let salt = b"WZaPV7LSUEKMo34."; // unique per password, ideally 16-bytes and random
-//! let password_hash = Yescrypt.hash_password(password, salt)?;
+//! let password_hash = Yescrypt.hash_password(password)?;
 //! assert!(password_hash.as_str().starts_with("$y$"));
 //!
 //! // verify password is correct for the given hash

--- a/yescrypt/src/simple.rs
+++ b/yescrypt/src/simple.rs
@@ -69,7 +69,7 @@ impl CustomizedPasswordHasher<PasswordHash> for Yescrypt {
 }
 
 impl PasswordHasher<PasswordHash> for Yescrypt {
-    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
+    fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
         self.hash_password_customized(password, salt, None, None, Params::default())
     }
 }


### PR DESCRIPTION
Companion PR to RustCrypto/traits#2123

The aforementioned traits PR renames `PasswordHash::hash_password` to `hash_password_with_salt`, so this PR updates the method name change accordingly.

When the `getrandom` feature is enabled, it provides a new `PasswordHash::hash_password` which *just* accepts a password as an argument, relying on `getrandom` to internally generate a salt.

This updates all the code examples to use the new API so users don't have to deal with randomly generating a salt.