### PR TITLE
Use `mcf` and `password-hash` crate releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,8 +270,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "mcf"
-version = "0.6.0-pre"
-source = "git+https://github.com/RustCrypto/formats#6863922a04b2fce8668a1459295febe0d35bfcad"
+version = "0.6.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fe7b16e9a78dd25fb4a09d26f04fe0f8bd5a8a7574c27cbec331f9cf802e79"
 dependencies = [
  "base64ct",
 ]
@@ -305,8 +306,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.4"
-source = "git+https://github.com/RustCrypto/traits#c45480e68908f7f1b37624cd89be10b35ef63a59"
+version = "0.6.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87dec027112bafe3cc8a4dd8072c688dbd62dec3cd4e76897f2ce809a7008aee"
 dependencies = [
  "getrandom",
  "phc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,3 @@ opt-level = 2
 argon2 = { path = "./argon2" }
 pbkdf2 = { path = "./pbkdf2" }
 scrypt = { path = "./scrypt" }
-
-mcf = { git = "https://github.com/RustCrypto/formats" }
-password-hash = { git = "https://github.com/RustCrypto/traits" }

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -22,7 +22,7 @@ blake2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional dependencies
 rayon = { version = "1.7", optional = true }
-password-hash = { version = "0.6.0-rc.4", optional = true, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.5", optional = true, features = ["phc"] }
 phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.11.0-rc.4", default-features = false }
 crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.5", optional = true, default-features = false, features = ["phc"] }
 phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 getrandom = { version = "0.3", default-features = false }
-password-hash = { version = "0.6.0-rc.4", features = ["alloc", "phc"] }
+password-hash = { version = "0.6.0-rc.5", features = ["alloc", "phc"] }
 phc = { version = "0.6.0-rc.0", features = ["getrandom"] }
 
 # optional dependencies

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
 hmac = { version = "0.13.0-rc.3", default-features = false, optional = true }
-password-hash = { version = "0.6.0-rc.4", default-features = false, optional = true, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.5", default-features = false, optional = true, features = ["phc"] }
 phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -20,7 +20,7 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
-password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.5", optional = true, default-features = false, features = ["phc"] }
 phc = { version = "0.6.0-rc.0", optional = true, features = ["rand_core"] }
 
 [features]

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -22,7 +22,7 @@ base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 getrandom = { version = "0.3", optional = true, default-features = false }
-mcf = { version = "=0.6.0-pre", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "base64"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -21,8 +21,8 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-mcf = { version = "=0.6.0-pre", optional = true, default-features = false, features = ["alloc", "base64"] }
-password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false }
+mcf = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "base64"] }
+password-hash = { version = "0.6.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Switches from git to `mcf` v0.6.0-rc.0 and `password-hash` v0.6.0-rc.5