### PR TITLE
sha-crypt: unify `Params` type

### DIFF
--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -2,6 +2,9 @@
 
 use core::fmt;
 
+/// Result type for the `sha-crypt` crate with its [`Error`] type.
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Error type.
 #[derive(Debug)]
 pub enum Error {

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -39,8 +39,8 @@ mod simple;
 
 pub use crate::{
     consts::{BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512},
-    errors::Error,
-    params::{ROUNDS_DEFAULT, ROUNDS_MAX, ROUNDS_MIN, Sha256Params, Sha512Params},
+    errors::{Error, Result},
+    params::Params,
 };
 
 #[cfg(feature = "simple")]
@@ -53,124 +53,17 @@ pub use {
 use alloc::vec::Vec;
 use sha2::{Digest, Sha256, Sha512};
 
-/// The SHA512 crypt function returned as byte vector
+/// The SHA-256 crypt function returned as byte vector
 ///
 /// If the provided hash is longer than defs::SALT_MAX_LEN character, it will
 /// be stripped down to defs::SALT_MAX_LEN characters.
 ///
 /// # Arguments
-/// - `password` - The password to process as a byte vector
-/// - `salt` - The salt value to use as a byte vector
-/// - `params` - The Sha512Params to use
+/// - `password`: the password to process as a byte vector
+/// - `salt`: the salt value to use as a byte vector
+/// - `params`: the parameters to use
 ///   **WARNING: Make sure to compare this value in constant time!**
-///
-/// # Returns
-/// - `Ok(())` if calculation was successful
-/// - `Err(errors::CryptError)` otherwise
-pub fn sha512_crypt(
-    password: &[u8],
-    salt: &[u8],
-    params: &Sha512Params,
-) -> [u8; BLOCK_SIZE_SHA512] {
-    let pw_len = password.len();
-
-    let salt_len = salt.len();
-    let salt = match salt_len {
-        0..=15 => &salt[0..salt_len],
-        _ => &salt[0..16],
-    };
-    let salt_len = salt.len();
-
-    let digest_a = sha512crypt_intermediate(password, salt);
-
-    // 13.
-    let mut hasher_alt = Sha512::default();
-
-    // 14.
-    for _ in 0..pw_len {
-        hasher_alt.update(password);
-    }
-
-    // 15.
-    let dp = hasher_alt.finalize();
-
-    // 16.
-    // Create byte sequence P.
-    let p_vec = produce_byte_seq(pw_len, &dp);
-
-    // 17.
-    hasher_alt = Sha512::default();
-
-    // 18.
-    // For every character in the password add the entire password.
-    for _ in 0..(16 + digest_a[0] as usize) {
-        hasher_alt.update(salt);
-    }
-
-    // 19.
-    // Finish the digest.
-    let ds = hasher_alt.finalize();
-
-    // 20.
-    // Create byte sequence S.
-    let s_vec = produce_byte_seq(salt_len, &ds);
-
-    let mut digest_c = digest_a;
-    // Repeatedly run the collected hash value through SHA512 to burn
-    // CPU cycles
-    for i in 0..params.rounds {
-        // new hasher
-        let mut hasher = Sha512::default();
-
-        // Add key or last result
-        if (i & 1) != 0 {
-            hasher.update(&p_vec);
-        } else {
-            hasher.update(digest_c);
-        }
-
-        // Add salt for numbers not divisible by 3
-        if i % 3 != 0 {
-            hasher.update(&s_vec);
-        }
-
-        // Add key for numbers not divisible by 7
-        if i % 7 != 0 {
-            hasher.update(&p_vec);
-        }
-
-        // Add key or last result
-        if (i & 1) != 0 {
-            hasher.update(digest_c);
-        } else {
-            hasher.update(&p_vec);
-        }
-
-        digest_c.clone_from_slice(&hasher.finalize());
-    }
-
-    digest_c
-}
-
-/// The SHA256 crypt function returned as byte vector
-///
-/// If the provided hash is longer than defs::SALT_MAX_LEN character, it will
-/// be stripped down to defs::SALT_MAX_LEN characters.
-///
-/// # Arguments
-/// - `password` - The password to process as a byte vector
-/// - `salt` - The salt value to use as a byte vector
-/// - `params` - The Sha256Params to use
-///   **WARNING: Make sure to compare this value in constant time!**
-///
-/// # Returns
-/// - `Ok(())` if calculation was successful
-/// - `Err(errors::CryptError)` otherwise
-pub fn sha256_crypt(
-    password: &[u8],
-    salt: &[u8],
-    params: &Sha256Params,
-) -> [u8; BLOCK_SIZE_SHA256] {
+pub fn sha256_crypt(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK_SIZE_SHA256] {
     let pw_len = password.len();
 
     let salt_len = salt.len();
@@ -251,17 +144,138 @@ pub fn sha256_crypt(
     digest_c
 }
 
-fn produce_byte_seq(len: usize, fill_from: &[u8]) -> Vec<u8> {
-    let bs = fill_from.len();
-    let mut seq: Vec<u8> = vec![0; len];
-    let mut offset: usize = 0;
-    for _ in 0..(len / bs) {
-        seq[offset..offset + bs].clone_from_slice(fill_from);
-        offset += bs;
+/// The SHA-512 crypt function returned as byte vector
+///
+/// If the provided hash is longer than defs::SALT_MAX_LEN character, it will
+/// be stripped down to defs::SALT_MAX_LEN characters.
+///
+/// # Arguments
+/// - `password`The password to process as a byte vector
+/// - `salt` - The salt value to use as a byte vector
+/// - `params` - The parameters to use
+///   **WARNING: Make sure to compare this value in constant time!**
+pub fn sha512_crypt(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK_SIZE_SHA512] {
+    let pw_len = password.len();
+
+    let salt_len = salt.len();
+    let salt = match salt_len {
+        0..=15 => &salt[0..salt_len],
+        _ => &salt[0..16],
+    };
+    let salt_len = salt.len();
+
+    let digest_a = sha512crypt_intermediate(password, salt);
+
+    // 13.
+    let mut hasher_alt = Sha512::default();
+
+    // 14.
+    for _ in 0..pw_len {
+        hasher_alt.update(password);
     }
-    let from_slice = &fill_from[..(len % bs)];
-    seq[offset..offset + (len % bs)].clone_from_slice(from_slice);
-    seq
+
+    // 15.
+    let dp = hasher_alt.finalize();
+
+    // 16.
+    // Create byte sequence P.
+    let p_vec = produce_byte_seq(pw_len, &dp);
+
+    // 17.
+    hasher_alt = Sha512::default();
+
+    // 18.
+    // For every character in the password add the entire password.
+    for _ in 0..(16 + digest_a[0] as usize) {
+        hasher_alt.update(salt);
+    }
+
+    // 19.
+    // Finish the digest.
+    let ds = hasher_alt.finalize();
+
+    // 20.
+    // Create byte sequence S.
+    let s_vec = produce_byte_seq(salt_len, &ds);
+
+    let mut digest_c = digest_a;
+    // Repeatedly run the collected hash value through SHA512 to burn
+    // CPU cycles
+    for i in 0..params.rounds {
+        // new hasher
+        let mut hasher = Sha512::default();
+
+        // Add key or last result
+        if (i & 1) != 0 {
+            hasher.update(&p_vec);
+        } else {
+            hasher.update(digest_c);
+        }
+
+        // Add salt for numbers not divisible by 3
+        if i % 3 != 0 {
+            hasher.update(&s_vec);
+        }
+
+        // Add key for numbers not divisible by 7
+        if i % 7 != 0 {
+            hasher.update(&p_vec);
+        }
+
+        // Add key or last result
+        if (i & 1) != 0 {
+            hasher.update(digest_c);
+        } else {
+            hasher.update(&p_vec);
+        }
+
+        digest_c.clone_from_slice(&hasher.finalize());
+    }
+
+    digest_c
+}
+
+fn sha256crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA256] {
+    let pw_len = password.len();
+
+    let mut hasher = Sha256::default();
+    hasher.update(password);
+    hasher.update(salt);
+
+    // 4.
+    let mut hasher_alt = Sha256::default();
+    // 5.
+    hasher_alt.update(password);
+    // 6.
+    hasher_alt.update(salt);
+    // 7.
+    hasher_alt.update(password);
+    // 8.
+    let digest_b = hasher_alt.finalize();
+
+    // 9.
+    for _ in 0..(pw_len / BLOCK_SIZE_SHA256) {
+        hasher.update(digest_b);
+    }
+    // 10.
+    hasher.update(&digest_b[..(pw_len % BLOCK_SIZE_SHA256)]);
+
+    // 11
+    let mut n = pw_len;
+    for _ in 0..pw_len {
+        if n == 0 {
+            break;
+        }
+        if (n & 1) != 0 {
+            hasher.update(digest_b);
+        } else {
+            hasher.update(password);
+        }
+        n >>= 1;
+    }
+
+    // 12.
+    hasher.finalize().as_slice().try_into().unwrap()
 }
 
 fn sha512crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA512] {
@@ -307,45 +321,15 @@ fn sha512crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA
     hasher.finalize().as_slice().try_into().unwrap()
 }
 
-fn sha256crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA256] {
-    let pw_len = password.len();
-
-    let mut hasher = Sha256::default();
-    hasher.update(password);
-    hasher.update(salt);
-
-    // 4.
-    let mut hasher_alt = Sha256::default();
-    // 5.
-    hasher_alt.update(password);
-    // 6.
-    hasher_alt.update(salt);
-    // 7.
-    hasher_alt.update(password);
-    // 8.
-    let digest_b = hasher_alt.finalize();
-
-    // 9.
-    for _ in 0..(pw_len / BLOCK_SIZE_SHA256) {
-        hasher.update(digest_b);
+fn produce_byte_seq(len: usize, fill_from: &[u8]) -> Vec<u8> {
+    let bs = fill_from.len();
+    let mut seq: Vec<u8> = vec![0; len];
+    let mut offset: usize = 0;
+    for _ in 0..(len / bs) {
+        seq[offset..offset + bs].clone_from_slice(fill_from);
+        offset += bs;
     }
-    // 10.
-    hasher.update(&digest_b[..(pw_len % BLOCK_SIZE_SHA256)]);
-
-    // 11
-    let mut n = pw_len;
-    for _ in 0..pw_len {
-        if n == 0 {
-            break;
-        }
-        if (n & 1) != 0 {
-            hasher.update(digest_b);
-        } else {
-            hasher.update(password);
-        }
-        n >>= 1;
-    }
-
-    // 12.
-    hasher.finalize().as_slice().try_into().unwrap()
+    let from_slice = &fill_from[..(len % bs)];
+    seq[offset..offset + (len % bs)].clone_from_slice(from_slice);
+    seq
 }

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -1,118 +1,79 @@
 //! Algorithm parameters.
 
-use crate::errors;
+use crate::{Error, Result};
 use core::{
     default::Default,
     fmt::{self, Display},
     str::FromStr,
 };
 
-/// Default number of rounds.
-pub const ROUNDS_DEFAULT: u32 = 5_000;
-
-/// Minimum number of rounds allowed.
-pub const ROUNDS_MIN: u32 = 1_000;
-
-/// Maximum number of rounds allowed.
-pub const ROUNDS_MAX: u32 = 999_999_999;
-
 /// Algorithm parameters.
 #[derive(Debug, Clone)]
-pub struct Sha512Params {
+pub struct Params {
+    /// Number of times to apply the digest function
     pub(crate) rounds: u32,
 }
 
-impl Default for Sha512Params {
-    fn default() -> Self {
-        Sha512Params {
-            rounds: ROUNDS_DEFAULT,
+impl Params {
+    /// Default number of rounds.
+    pub const ROUNDS_DEFAULT: u32 = 5_000;
+
+    /// Minimum number of rounds allowed.
+    pub const ROUNDS_MIN: u32 = 1_000;
+
+    /// Maximum number of rounds allowed.
+    pub const ROUNDS_MAX: u32 = 999_999_999;
+
+    /// Create new algorithm parameters.
+    pub fn new(rounds: u32) -> Result<Params> {
+        match rounds {
+            Self::ROUNDS_MIN..=Self::ROUNDS_MAX => Ok(Params { rounds }),
+            _ => Err(Error::RoundsError),
         }
     }
 }
 
-impl Display for Sha512Params {
+impl Default for Params {
+    fn default() -> Self {
+        Params {
+            rounds: Self::ROUNDS_DEFAULT,
+        }
+    }
+}
+
+impl Display for Params {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "rounds={}", self.rounds)
     }
 }
 
-impl FromStr for Sha512Params {
-    type Err = errors::Error;
+impl FromStr for Params {
+    type Err = Error;
 
-    fn from_str(_s: &str) -> Result<Self, errors::Error> {
+    fn from_str(_s: &str) -> Result<Self> {
         todo!()
-    }
-}
-
-impl Sha512Params {
-    /// Create new algorithm parameters.
-    pub fn new(rounds: u32) -> Result<Sha512Params, errors::Error> {
-        if (ROUNDS_MIN..=ROUNDS_MAX).contains(&rounds) {
-            Ok(Sha512Params { rounds })
-        } else {
-            Err(errors::Error::RoundsError)
-        }
-    }
-}
-
-/// Algorithm parameters.
-#[derive(Debug, Clone)]
-pub struct Sha256Params {
-    pub(crate) rounds: u32,
-}
-
-impl Default for Sha256Params {
-    fn default() -> Self {
-        Sha256Params {
-            rounds: ROUNDS_DEFAULT,
-        }
-    }
-}
-
-impl Display for Sha256Params {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "rounds={}", self.rounds)
-    }
-}
-
-impl FromStr for Sha256Params {
-    type Err = errors::Error;
-
-    fn from_str(_s: &str) -> Result<Self, errors::Error> {
-        todo!()
-    }
-}
-
-impl Sha256Params {
-    /// Create new algorithm parameters.
-    pub fn new(rounds: u32) -> Result<Sha256Params, errors::Error> {
-        if (ROUNDS_MIN..=ROUNDS_MAX).contains(&rounds) {
-            Ok(Sha256Params { rounds })
-        } else {
-            Err(errors::Error::RoundsError)
-        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ROUNDS_MAX, ROUNDS_MIN, Sha256Params, Sha512Params};
+    use super::Params;
 
     #[test]
     fn test_sha256_crypt_invalid_rounds() {
-        let params = Sha256Params::new(ROUNDS_MAX + 1);
+        let params = Params::new(Params::ROUNDS_MAX + 1);
         assert!(params.is_err());
 
-        let params = Sha256Params::new(ROUNDS_MIN - 1);
+        let params = Params::new(Params::ROUNDS_MIN - 1);
         assert!(params.is_err());
     }
 
     #[test]
     fn test_sha512_crypt_invalid_rounds() {
-        let params = Sha512Params::new(ROUNDS_MAX + 1);
+        let params = Params::new(Params::ROUNDS_MAX + 1);
         assert!(params.is_err());
 
-        let params = Sha512Params::new(ROUNDS_MIN - 1);
+        let params = Params::new(Params::ROUNDS_MIN - 1);
         assert!(params.is_err());
     }
 }

--- a/sha-crypt/tests/simple.rs
+++ b/sha-crypt/tests/simple.rs
@@ -3,7 +3,7 @@
 use base64ct::{Base64ShaCrypt, Encoding};
 use mcf::PasswordHash;
 use sha_crypt::{
-    SHA256_CRYPT, SHA512_CRYPT, Sha256Params, Sha512Params,
+    Params, SHA256_CRYPT, SHA512_CRYPT,
     password_hash::{CustomizedPasswordHasher, Error, PasswordVerifier},
 };
 
@@ -93,7 +93,7 @@ fn hash_sha256_crypt() {
 
     for t in TEST_VECTORS {
         if let Ok(salt) = Base64ShaCrypt::decode_vec(&t.salt) {
-            let params = Sha256Params::new(t.rounds).unwrap();
+            let params = Params::new(t.rounds).unwrap();
             let result = SHA256_CRYPT
                 .hash_password_with_params(t.input.as_bytes(), &salt, params)
                 .unwrap();
@@ -112,7 +112,7 @@ fn hash_sha512_crypt() {
 
     for t in TEST_VECTORS {
         if let Ok(salt) = Base64ShaCrypt::decode_vec(&t.salt) {
-            let params = Sha512Params::new(t.rounds).unwrap();
+            let params = Params::new(t.rounds).unwrap();
             let result = SHA512_CRYPT
                 .hash_password_with_params(t.input.as_bytes(), &salt, params)
                 .unwrap();


### PR DESCRIPTION
The previous `Sha256Params` and `Sha512Params` types were otherwise identical, so this commit unifies them into a single type