### PR TITLE
Cut new releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "base64ct",
  "blake2",
@@ -23,7 +23,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "balloon-hash"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -292,7 +292,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "password-auth"
-version = "1.1.0-pre.3"
+version = "1.1.0-rc.0"
 dependencies = [
  "argon2",
  "getrandom",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 dependencies = [
  "belt-hash",
  "digest",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.5"
+version = "0.12.0-rc.6"
 dependencies = [
  "password-hash",
  "pbkdf2",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.6.0-pre.1"
+version = "0.6.0-rc.0"
 dependencies = [
  "base64ct",
  "mcf",
@@ -558,7 +558,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yescrypt"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "hex-literal",
  "hmac",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "1.1.0-pre.3"
+version = "1.1.0-rc.0"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 including support for Argon2, PBKDF2, and scrypt password hashing algorithms
@@ -21,9 +21,9 @@ getrandom = { version = "0.3", default-features = false }
 password-hash = { version = "0.6.0-rc.6", features = ["alloc", "getrandom", "phc"] }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.4", optional = true, default-features = false, features = ["alloc", "password-hash"] }
-pbkdf2 = { version = "0.13.0-rc.4", optional = true, default-features = false, features = ["password-hash"] }
-scrypt = { version = "0.12.0-rc.5", optional = true, default-features = false, features = ["password-hash"] }
+argon2 = { version = "0.6.0-rc.5", optional = true, default-features = false, features = ["alloc", "password-hash"] }
+pbkdf2 = { version = "0.13.0-rc.5", optional = true, default-features = false, features = ["password-hash"] }
+scrypt = { version = "0.12.0-rc.6", optional = true, default-features = false, features = ["password-hash"] }
 
 [features]
 default = ["argon2", "std"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.5"
+version = "0.12.0-rc.6"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-pbkdf2 = { version = "0.13.0-rc.4", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.5", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.6.0-pre.1"
+version = "0.6.0-rc.0"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library
@@ -22,7 +22,7 @@ base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 mcf = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc", "base64"] }
-password-hash = { version = "0.6.0-rc.4", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.6", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yescrypt"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 description = "Pure Rust implementation of the yescrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 hmac = { version = "0.13.0-rc.3", default-features = false }
-pbkdf2 = { version = "0.13.0-rc.4", default-features = false, features = ["hmac"] }
+pbkdf2 = { version = "0.13.0-rc.5", default-features = false, features = ["hmac"] }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
Releases the following crates:
- argon2 v0.6.0-rc.5
- balloon-hash v0.5.0-rc.3
- password-auth v1.1.0-rc.0
- pbkdf2 v0.13.0-rc.5
- scrypt v0.12.0-rc.6
- sha-crypt v0.6.0-rc.0
- yescrypt v0.1.0-rc.1