### PR TITLE
Add `PasswordVerifier<str>` impls

### DIFF
--- a/pbkdf2/src/phc.rs
+++ b/pbkdf2/src/phc.rs
@@ -39,7 +39,7 @@ impl CustomizedPasswordHasher<PasswordHash> for Pbkdf2 {
             return Err(Error::Version);
         }
 
-        let salt = Salt::new(salt).map_err(|_| Error::SaltInvalid)?;
+        let salt = Salt::new(salt)?;
 
         let mut buffer = [0u8; Output::MAX_LENGTH];
         let out = buffer
@@ -54,7 +54,7 @@ impl CustomizedPasswordHasher<PasswordHash> for Pbkdf2 {
         };
 
         f(password, &salt, params.rounds, out);
-        let output = Output::new(out).map_err(|_| Error::OutputSize)?;
+        let output = Output::new(out)?;
 
         Ok(PasswordHash {
             algorithm: *algorithm.ident(),

--- a/scrypt/src/phc.rs
+++ b/scrypt/src/phc.rs
@@ -39,13 +39,13 @@ impl CustomizedPasswordHasher<PasswordHash> for Scrypt {
             return Err(Error::Version);
         }
 
-        let salt = Salt::new(salt).map_err(|_| Error::SaltInvalid)?;
+        let salt = Salt::new(salt)?;
         let len = params.len.unwrap_or(Params::RECOMMENDED_LEN);
 
         let mut buffer = [0u8; Output::MAX_LENGTH];
         let out = buffer.get_mut(..len).ok_or(Error::OutputSize)?;
         scrypt(password, &salt, &params, out).map_err(|_| Error::OutputSize)?;
-        let output = Output::new(out).map_err(|_| Error::OutputSize)?;
+        let output = Output::new(out)?;
 
         Ok(PasswordHash {
             algorithm: ALG_ID,

--- a/sha-crypt/src/mcf.rs
+++ b/sha-crypt/src/mcf.rs
@@ -144,6 +144,17 @@ where
     }
 }
 
+impl<D> PasswordVerifier<str> for ShaCrypt<D>
+where
+    Self: ShaCryptCore,
+{
+    fn verify_password(&self, password: &[u8], hash: &str) -> password_hash::Result<()> {
+        // TODO(tarcieri): better mapping from `mcf::Error` and `password_hash::Error`?
+        let hash = PasswordHashRef::new(hash).map_err(|_| Error::EncodingInvalid)?;
+        self.verify_password(password, hash)
+    }
+}
+
 impl ShaCryptCore for ShaCrypt<Sha256> {
     const MCF_ID: &'static str = "5";
     type Output = [u8; BLOCK_SIZE_SHA256];

--- a/yescrypt/src/mcf.rs
+++ b/yescrypt/src/mcf.rs
@@ -127,3 +127,11 @@ impl PasswordVerifier<PasswordHashRef> for Yescrypt {
         Ok(())
     }
 }
+
+impl PasswordVerifier<str> for Yescrypt {
+    fn verify_password(&self, password: &[u8], hash: &str) -> Result<()> {
+        // TODO(tarcieri): better mapping from `mcf::Error` and `password_hash::Error`?
+        let hash = PasswordHashRef::new(hash).map_err(|_| Error::EncodingInvalid)?;
+        self.verify_password(password, hash)
+    }
+}


### PR DESCRIPTION
For algorithms where there is only one canonical encoding (PHC or MCF), adds `PasswordVerifier<str>` impls which mean the user doesn't have to first parse the hash.

It would be good if there were a better conversion from `mcf::Error` to `password_hash::Error`, perhaps the latter could pull in the `mcf` crate optionally like it does with `phc` and have an error conversion impl.