### PR TITLE
scrypt: rename `rayon` feature to `parallel`

### DIFF
--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -31,7 +31,7 @@ getrandom = ["password-hash", "password-hash/getrandom"]
 mcf = ["alloc", "password-hash", "dep:mcf", "dep:subtle"]
 phc = ["password-hash/phc"]
 rand_core = ["password-hash/rand_core"]
-rayon = ["dep:rayon"]
+parallel = ["dep:rayon"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -107,16 +107,16 @@ pub fn scrypt(
     let mut b = vec![0u8; pr128];
     pbkdf2_hmac::<Sha256>(password, salt, 1, &mut b);
 
-    #[cfg(not(feature = "rayon"))]
+    #[cfg(not(feature = "parallel"))]
     romix_sequential(nr128, r128, n, &mut b);
-    #[cfg(feature = "rayon")]
+    #[cfg(feature = "parallel")]
     romix_parallel(nr128, r128, n, &mut b);
 
     pbkdf2_hmac::<Sha256>(password, &b, 1, output);
     Ok(())
 }
 
-#[cfg(not(feature = "rayon"))]
+#[cfg(not(feature = "parallel"))]
 fn romix_sequential(nr128: usize, r128: usize, n: usize, b: &mut [u8]) {
     let mut v = vec![0u8; nr128];
     let mut t = vec![0u8; r128];
@@ -126,7 +126,7 @@ fn romix_sequential(nr128: usize, r128: usize, n: usize, b: &mut [u8]) {
     });
 }
 
-#[cfg(feature = "rayon")]
+#[cfg(feature = "parallel")]
 fn romix_parallel(nr128: usize, r128: usize, n: usize, b: &mut [u8]) {
     use rayon::{iter::ParallelIterator as _, slice::ParallelSliceMut as _};
 


### PR DESCRIPTION
`rayon` is an implementation detail of parallel password hash computation, not the actual feature.

`parallel` matches the existing `argon2` crate feature.