### PR TITLE
Cut new prereleases of `mcf`-dependent crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.7"
+version = "0.12.0-rc.8"
 dependencies = [
  "cfg-if",
  "mcf",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 dependencies = [
  "base64ct",
  "mcf",
@@ -575,7 +575,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yescrypt"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "hex-literal",
  "hmac",

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.7"
+version = "0.12.0-rc.8"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 description = """
 Pure Rust implementation of the SHA-crypt password hash based on SHA-512
 as implemented by the POSIX crypt C library

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yescrypt"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 description = "Pure Rust implementation of the yescrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `scrypt` v0.12.0-rc.8
- `sha-crypt` v0.6.0-rc.1
- `yescrypt` v0.1.0-rc.2