### PR TITLE
pbkdf2: customizable `Params` for `Pbkdf2` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ let input_password = "password";
 let password_hash = phc::PasswordHash::new(&hash_string)?;
 
 // Trait objects for algorithms to support
-let algs: &[&dyn PasswordVerifier<phc::PasswordHash>] = &[&Argon2::default(), &Pbkdf2, &Scrypt::default()];
+let algs: &[&dyn PasswordVerifier<phc::PasswordHash>] = &[
+    &Argon2::default(),
+    &Pbkdf2::default(),
+    &Scrypt::default()
+];
 
 for alg in algs {
     if alg.verify_password(input_password.as_ref(), &password_hash).is_ok() {

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -67,7 +67,7 @@ fn generate_phc_hash(password: &[u8]) -> password_hash::Result<PasswordHash> {
     return Scrypt::default().hash_password(password);
 
     #[cfg(feature = "pbkdf2")]
-    return Pbkdf2.hash_password(password);
+    return Pbkdf2::default().hash_password(password);
 }
 
 /// Verify the provided password against the provided password hash.
@@ -84,7 +84,7 @@ pub fn verify_password(password: impl AsRef<[u8]>, hash: &str) -> Result<(), Ver
         #[cfg(feature = "argon2")]
         &Argon2::default(),
         #[cfg(feature = "pbkdf2")]
-        &Pbkdf2,
+        &Pbkdf2::default(),
         #[cfg(feature = "scrypt")]
         &Scrypt::default(),
     ];

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -69,14 +69,15 @@
 //!     Pbkdf2
 //! };
 //!
+//! let pbkdf2 = Pbkdf2::new(); // Uses `Params::RECOMMENDED`
 //! let password = b"hunter42"; // Bad password; don't actually use!
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
-//! let password_hash = Pbkdf2.hash_password(password)?.to_string();
+//! let password_hash = pbkdf2.hash_password(password)?.to_string();
 //!
 //! // Verify password against PHC string
 //! let parsed_hash = PasswordHash::new(&password_hash)?;
-//! assert!(Pbkdf2.verify_password(password, &parsed_hash).is_ok());
+//! assert!(pbkdf2.verify_password(password, &parsed_hash).is_ok());
 //! # Ok(())
 //! # }
 //! ```

--- a/pbkdf2/tests/phc.rs
+++ b/pbkdf2/tests/phc.rs
@@ -28,7 +28,7 @@ fn hash_with_default_algorithm() {
         output_length: 40,
     };
 
-    let hash = Pbkdf2
+    let hash = Pbkdf2::new()
         .hash_password_customized(PASSWORD, SALT, None, None, params)
         .unwrap();
 


### PR DESCRIPTION
Following the general pattern of `Argon2` and `Scrypt`, allows the `Params` used with the `Pbkdf2` type to be customized.

See also: #797