### PR TITLE
sha-crypt: dynamic `Algorithm` support

### DIFF
--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -2,8 +2,9 @@
 name = "sha-crypt"
 version = "0.6.0-rc.1"
 description = """
-Pure Rust implementation of the SHA-crypt password hash based on SHA-512
-as implemented by the POSIX crypt C library
+Pure Rust implementation of the SHA-crypt password hashing algorithm based on SHA-256/SHA-512
+as implemented by the POSIX crypt C library, including support for generating and verifying password
+hash strings in the Modular Crypt Format
 """
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha-crypt/README.md
+++ b/sha-crypt/README.md
@@ -2,16 +2,16 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
-Pure Rust implementation of the [SHA-crypt password hash based on SHA-512][1],
+Pure Rust implementation of the [SHA-crypt password hash based on SHA-256/SHA-512][1],
 a legacy password hashing scheme supported by the [POSIX crypt C library][2].
 
-Password hashes using this algorithm start with `$6$` when encoded using the
-[PHC string format][3].
+Password hashes using this algorithm start with `$5$` or `$6$` when encoded
+using the [Modular Crypt Format][3].
 
 ## License
 
@@ -34,15 +34,15 @@ dual licensed as above, without any additional terms or conditions.
 [crate-link]: https://crates.io/crates/sha-crypt
 [docs-image]: https://docs.rs/sha-crypt/badge.svg
 [docs-link]: https://docs.rs/sha-crypt/
+[build-image]: https://github.com/RustCrypto/password-hashes/actions/workflows/sha-crypt.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/password-hashes/actions/workflows/sha-crypt.yml 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
-[build-image]: https://github.com/RustCrypto/password-hashes/workflows/sha-crypt/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/password-hashes/actions?query=workflow%3Asha-crypt
 
 [//]: # (general links)
 
 [1]: https://www.akkadia.org/drepper/SHA-crypt.txt
 [2]: https://en.wikipedia.org/wiki/Crypt_(C)
-[3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
+[3]: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html

--- a/sha-crypt/src/algorithm.rs
+++ b/sha-crypt/src/algorithm.rs
@@ -1,0 +1,81 @@
+use core::{fmt, str::FromStr};
+use password_hash::Error;
+
+/// SHA-crypt algorithm variants: SHA-256 or SHA-512.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Algorithm {
+    /// SHA-256-crypt: SHA-crypt instantiated with SHA-256.
+    Sha256Crypt,
+
+    /// SHA-512-crypt: SHA-crypt instantiated with SHA-512.
+    Sha512Crypt,
+}
+
+impl Default for Algorithm {
+    /// Recommended default algorithm: SHA-512.
+    fn default() -> Self {
+        Self::RECOMMENDED
+    }
+}
+
+impl Algorithm {
+    /// SHA-256-crypt Modular Crypt Format algorithm identifier
+    pub const SHA256_CRYPT_IDENT: &str = "5";
+
+    /// SHA-512-crypt Modular Crypt Format algorithm identifier
+    pub const SHA512_CRYPT_IDENT: &str = "6";
+
+    /// Recommended default algorithm: SHA-512.
+    const RECOMMENDED: Self = Self::Sha512Crypt;
+
+    /// Parse an [`Algorithm`] from the provided string.
+    pub fn new(id: impl AsRef<str>) -> password_hash::Result<Self> {
+        id.as_ref().parse()
+    }
+
+    /// Get the Modular Crypt Format algorithm identifier for this algorithm.
+    pub const fn ident(&self) -> &'static str {
+        match self {
+            Algorithm::Sha256Crypt => Self::SHA256_CRYPT_IDENT,
+            Algorithm::Sha512Crypt => Self::SHA512_CRYPT_IDENT,
+        }
+    }
+
+    /// Get the identifier string for this PBKDF2 [`Algorithm`].
+    pub fn as_str(&self) -> &'static str {
+        self.ident()
+    }
+}
+
+impl AsRef<str> for Algorithm {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Algorithm {
+    type Err = Error;
+
+    fn from_str(s: &str) -> password_hash::Result<Algorithm> {
+        s.try_into()
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Algorithm {
+    type Error = Error;
+
+    fn try_from(name: &'a str) -> password_hash::Result<Algorithm> {
+        match name {
+            Self::SHA256_CRYPT_IDENT => Ok(Algorithm::Sha256Crypt),
+            Self::SHA512_CRYPT_IDENT => Ok(Algorithm::Sha512Crypt),
+            _ => Err(Error::Algorithm),
+        }
+    }
+}

--- a/sha-crypt/src/mcf.rs
+++ b/sha-crypt/src/mcf.rs
@@ -2,47 +2,24 @@
 
 pub use mcf::{PasswordHash, PasswordHashRef};
 
-use crate::{BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512, Params, sha256_crypt, sha512_crypt};
+use crate::{BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512, Params, algorithm::Algorithm};
 use base64ct::{Base64ShaCrypt, Encoding};
-use core::{marker::PhantomData, str::FromStr};
+use core::str::FromStr;
 use mcf::Base64;
 use password_hash::{
     CustomizedPasswordHasher, Error, PasswordHasher, PasswordVerifier, Result, Version,
 };
-use sha2::{Sha256, Sha512};
+use subtle::ConstantTimeEq;
 
-/// SHA-crypt uses digest-specific parameters.
-pub trait ShaCryptCore {
-    /// Modular Crypt Format ID.
-    const MCF_ID: &'static str;
-
-    /// Output data
-    type Output: AsRef<[u8]>;
-
-    /// Core function
-    fn sha_crypt_core(password: &[u8], salt: &[u8], params: &Params) -> Self::Output;
+/// SHA-crypt type for use with the [`PasswordHasher`] and [`PasswordVerifier`] traits, which can
+/// produce and verify password hashes in [`Modular Crypt Format`][`mcf`].
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct ShaCrypt {
+    /// Default algorithm to use when generating password hashes.
+    algorithm: Algorithm,
 }
 
-/// sha-crypt type for use with [`PasswordHasher`].
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct ShaCrypt<D> {
-    phantom: PhantomData<D>,
-}
-
-/// SHA-crypt initialized using SHA-256
-pub const SHA256_CRYPT: ShaCrypt<Sha256> = ShaCrypt {
-    phantom: PhantomData,
-};
-
-/// SHA-crypt initialized using SHA-512
-pub const SHA512_CRYPT: ShaCrypt<Sha512> = ShaCrypt {
-    phantom: PhantomData,
-};
-
-impl<D> CustomizedPasswordHasher<PasswordHash> for ShaCrypt<D>
-where
-    Self: ShaCryptCore,
-{
+impl CustomizedPasswordHasher<PasswordHash> for ShaCrypt {
     type Params = Params;
 
     fn hash_password_customized(
@@ -53,9 +30,10 @@ where
         version: Option<Version>,
         params: Params,
     ) -> Result<PasswordHash> {
-        if alg_id.is_some() && alg_id != Some(Self::MCF_ID) {
-            return Err(Error::Algorithm);
-        }
+        let alg = alg_id
+            .map(|id| id.parse::<Algorithm>())
+            .transpose()?
+            .unwrap_or(self.algorithm);
 
         if version.is_some() {
             return Err(Error::Version);
@@ -63,9 +41,7 @@ where
 
         // We compute the function over the Base64-encoded salt
         let salt = Base64ShaCrypt::encode_string(salt);
-        let out = Self::sha_crypt_core(password, salt.as_bytes(), &params);
-
-        let mut mcf_hash = PasswordHash::from_id(Self::MCF_ID).expect("should have valid ID");
+        let mut mcf_hash = PasswordHash::from_id(alg.ident()).expect("should have valid ID");
 
         mcf_hash
             .push_displayable(&params)
@@ -75,39 +51,36 @@ where
             .push_str(&salt)
             .map_err(|_| Error::EncodingInvalid)?;
 
-        mcf_hash.push_base64(out.as_ref(), Base64::Crypt);
+        match alg {
+            Algorithm::Sha256Crypt => {
+                let out = sha256_crypt_core(password, salt.as_bytes(), &params);
+                mcf_hash.push_base64(&out, Base64::Crypt);
+            }
+            Algorithm::Sha512Crypt => {
+                let out = sha512_crypt_core(password, salt.as_bytes(), &params);
+                mcf_hash.push_base64(&out, Base64::Crypt);
+            }
+        }
 
         Ok(mcf_hash)
     }
 }
 
-impl<D> PasswordHasher<PasswordHash> for ShaCrypt<D>
-where
-    Self: ShaCryptCore,
-{
+impl PasswordHasher<PasswordHash> for ShaCrypt {
     fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
         self.hash_password_customized(password, salt, None, None, Params::default())
     }
 }
 
-impl<D> PasswordVerifier<PasswordHash> for ShaCrypt<D>
-where
-    Self: ShaCryptCore,
-{
+impl PasswordVerifier<PasswordHash> for ShaCrypt {
     fn verify_password(&self, password: &[u8], hash: &PasswordHash) -> Result<()> {
         self.verify_password(password, hash.as_password_hash_ref())
     }
 }
 
-impl<D> PasswordVerifier<PasswordHashRef> for ShaCrypt<D>
-where
-    Self: ShaCryptCore,
-{
+impl PasswordVerifier<PasswordHashRef> for ShaCrypt {
     fn verify_password(&self, password: &[u8], hash: &PasswordHashRef) -> Result<()> {
-        if hash.id() != Self::MCF_ID {
-            return Err(Error::Algorithm);
-        }
-
+        let alg = hash.id().parse::<Algorithm>()?;
         let mut fields = hash.fields();
         let mut next = fields.next().ok_or(Error::EncodingInvalid)?;
 
@@ -134,9 +107,16 @@ where
             return Err(Error::EncodingInvalid);
         }
 
-        let actual = Self::sha_crypt_core(password, salt, &params);
+        let is_valid = match alg {
+            Algorithm::Sha256Crypt => sha256_crypt_core(password, salt, &params)
+                .as_ref()
+                .ct_eq(&expected),
+            Algorithm::Sha512Crypt => sha512_crypt_core(password, salt, &params)
+                .as_ref()
+                .ct_eq(&expected),
+        };
 
-        if subtle::ConstantTimeEq::ct_ne(actual.as_ref(), &expected).into() {
+        if (!is_valid).into() {
             return Err(Error::PasswordInvalid);
         }
 
@@ -144,10 +124,7 @@ where
     }
 }
 
-impl<D> PasswordVerifier<str> for ShaCrypt<D>
-where
-    Self: ShaCryptCore,
-{
+impl PasswordVerifier<str> for ShaCrypt {
     fn verify_password(&self, password: &[u8], hash: &str) -> password_hash::Result<()> {
         // TODO(tarcieri): better mapping from `mcf::Error` and `password_hash::Error`?
         let hash = PasswordHashRef::new(hash).map_err(|_| Error::EncodingInvalid)?;
@@ -155,45 +132,41 @@ where
     }
 }
 
-impl ShaCryptCore for ShaCrypt<Sha256> {
-    const MCF_ID: &'static str = "5";
-    type Output = [u8; BLOCK_SIZE_SHA256];
-
-    /// Core function
-    fn sha_crypt_core(password: &[u8], salt: &[u8], params: &Params) -> Self::Output {
-        let output = sha256_crypt(password, salt, params);
-        let transposition_table = [
-            20, 10, 0, 11, 1, 21, 2, 22, 12, 23, 13, 3, 14, 4, 24, 5, 25, 15, 26, 16, 6, 17, 7, 27,
-            8, 28, 18, 29, 19, 9, 30, 31,
-        ];
-
-        let mut transposed = [0u8; BLOCK_SIZE_SHA256];
-        for (i, &ti) in transposition_table.iter().enumerate() {
-            transposed[i] = output[ti as usize];
-        }
-
-        transposed
+impl From<Algorithm> for ShaCrypt {
+    fn from(algorithm: Algorithm) -> Self {
+        Self { algorithm }
     }
 }
 
-impl ShaCryptCore for ShaCrypt<Sha512> {
-    const MCF_ID: &'static str = "6";
-    type Output = [u8; BLOCK_SIZE_SHA512];
+/// SHA-256-crypt core function: uses an algorithm-specific transposition table.
+fn sha256_crypt_core(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK_SIZE_SHA256] {
+    let output = super::sha256_crypt(password, salt, params);
+    let transposition_table = [
+        20, 10, 0, 11, 1, 21, 2, 22, 12, 23, 13, 3, 14, 4, 24, 5, 25, 15, 26, 16, 6, 17, 7, 27, 8,
+        28, 18, 29, 19, 9, 30, 31,
+    ];
 
-    /// Core function
-    fn sha_crypt_core(password: &[u8], salt: &[u8], params: &Params) -> Self::Output {
-        let output = sha512_crypt(password, salt, params);
-        let transposition_table = [
-            42, 21, 0, 1, 43, 22, 23, 2, 44, 45, 24, 3, 4, 46, 25, 26, 5, 47, 48, 27, 6, 7, 49, 28,
-            29, 8, 50, 51, 30, 9, 10, 52, 31, 32, 11, 53, 54, 33, 12, 13, 55, 34, 35, 14, 56, 57,
-            36, 15, 16, 58, 37, 38, 17, 59, 60, 39, 18, 19, 61, 40, 41, 20, 62, 63,
-        ];
-
-        let mut transposed = [0u8; BLOCK_SIZE_SHA512];
-        for (i, &ti) in transposition_table.iter().enumerate() {
-            transposed[i] = output[ti as usize];
-        }
-
-        transposed
+    let mut transposed = [0u8; BLOCK_SIZE_SHA256];
+    for (i, &ti) in transposition_table.iter().enumerate() {
+        transposed[i] = output[ti as usize];
     }
+
+    transposed
+}
+
+/// SHA-512-crypt core function: uses an algorithm-specific transposition table.
+fn sha512_crypt_core(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK_SIZE_SHA512] {
+    let output = super::sha512_crypt(password, salt, params);
+    let transposition_table = [
+        42, 21, 0, 1, 43, 22, 23, 2, 44, 45, 24, 3, 4, 46, 25, 26, 5, 47, 48, 27, 6, 7, 49, 28, 29,
+        8, 50, 51, 30, 9, 10, 52, 31, 32, 11, 53, 54, 33, 12, 13, 55, 34, 35, 14, 56, 57, 36, 15,
+        16, 58, 37, 38, 17, 59, 60, 39, 18, 19, 61, 40, 41, 20, 62, 63,
+    ];
+
+    let mut transposed = [0u8; BLOCK_SIZE_SHA512];
+    for (i, &ti) in transposition_table.iter().enumerate() {
+        transposed[i] = output[ti as usize];
+    }
+
+    transposed
 }

--- a/yescrypt/README.md
+++ b/yescrypt/README.md
@@ -54,12 +54,12 @@ dual licensed as above, without any additional terms or conditions.
 [crate-link]: https://crates.io/crates/yescrypt
 [docs-image]: https://docs.rs/yescrypt/badge.svg
 [docs-link]: https://docs.rs/yescrypt/
+[build-image]: https://github.com/RustCrypto/password-hashes/actions/workflows/yescrypt.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/password-hashes/actions/workflows/yescrypt.yml 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
-[build-image]: https://github.com/RustCrypto/password-hashes/actions/workflows/yescrypt.yml/badge.svg
-[build-link]: https://github.com/RustCrypto/password-hashes/actions/workflows/yescrypt.yml 
 
 [//]: # (links)
 


### PR DESCRIPTION
Removes the `D` generic parameter on `ShaCrypt` and replaces it internally with a new `Algorithm` enum, similar to other crates like `argon2` and `pbkdf2`, where `ShaCrypt` can now store a default algorithm.

The verifier impl now dynamically dispatches on the MCF algorithm ID, and can verify both SHA-256-crypt and SHA-512-crypt hashes.