### PR TITLE
sha-crypt: customized `Params` for `ShaCrypt`

### DIFF
--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -71,7 +71,7 @@ pub const BLOCK_SIZE_SHA512: usize = 64;
 /// - `params`: the parameters to use
 ///
 ///   **WARNING: Make sure to compare this value in constant time!**
-pub fn sha256_crypt(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK_SIZE_SHA256] {
+pub fn sha256_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_SIZE_SHA256] {
     let pw_len = password.len();
 
     let salt_len = salt.len();
@@ -160,7 +160,7 @@ pub fn sha256_crypt(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK
 /// - `params` - The parameters to use
 ///
 ///   **WARNING: Make sure to compare this value in constant time!**
-pub fn sha512_crypt(password: &[u8], salt: &[u8], params: &Params) -> [u8; BLOCK_SIZE_SHA512] {
+pub fn sha512_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_SIZE_SHA512] {
     let pw_len = password.len();
 
     let salt_len = salt.len();

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -7,10 +7,11 @@ use core::{
     str::FromStr,
 };
 
+/// Name of the parameter when serialized in an MCF string.
 const ROUNDS_PARAM: &str = "rounds=";
 
 /// Algorithm parameters.
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Number of times to apply the digest function
     pub(crate) rounds: u32,


### PR DESCRIPTION
Adds the ability to customize the default params used by `ShaCrypt`, the Modular Crypt Format password hasher.