### PR TITLE
yescrypt: configurable `Params` for `Yescrypt` hasher

### DIFF
--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -32,12 +32,13 @@
 //!
 //! use yescrypt::{Yescrypt, PasswordHasher, PasswordVerifier};
 //!
+//! let yescrypt = Yescrypt::default();
 //! let password = b"pleaseletmein"; // don't actually use this as a password!
-//! let password_hash = Yescrypt.hash_password(password)?;
+//! let password_hash = yescrypt.hash_password(password)?;
 //! assert!(password_hash.as_str().starts_with("$y$"));
 //!
 //! // verify password is correct for the given hash
-//! Yescrypt.verify_password(password, &password_hash)?;
+//! yescrypt.verify_password(password, &password_hash)?;
 //! # Ok(())
 //! # }
 //! ```

--- a/yescrypt/src/mcf.rs
+++ b/yescrypt/src/mcf.rs
@@ -19,12 +19,21 @@ const YESCRYPT_BASE64: Base64 = Base64::Crypt;
 /// yescrypt password hashing type which can produce and verify strings in Modular Crypt Format
 /// (MCF) which begin with `$y$`
 ///
-/// This is a ZST which impls traits from the [`password-hash`][`password_hash`] crate, notably
-/// the [`PasswordHasher`], [`PasswordVerifier`], and [`CustomizedPasswordHasher`] traits.
+/// This type impls traits from the [`password-hash`][`password_hash`] crate, notably the
+/// [`PasswordHasher`], [`PasswordVerifier`], and [`CustomizedPasswordHasher`] traits.
 ///
 /// See the toplevel documentation for a code example.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Yescrypt;
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Yescrypt {
+    /// Default parameters to use when hashing passwords.
+    params: Params,
+}
+
+impl From<Params> for Yescrypt {
+    fn from(params: Params) -> Self {
+        Self { params }
+    }
+}
 
 impl CustomizedPasswordHasher<PasswordHash> for Yescrypt {
     type Params = Params;
@@ -72,7 +81,7 @@ impl CustomizedPasswordHasher<PasswordHash> for Yescrypt {
 
 impl PasswordHasher<PasswordHash> for Yescrypt {
     fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
-        self.hash_password_customized(password, salt, None, None, Params::default())
+        self.hash_password_customized(password, salt, None, None, self.params)
     }
 }
 

--- a/yescrypt/tests/mcf.rs
+++ b/yescrypt/tests/mcf.rs
@@ -64,7 +64,7 @@ fn compute_reference_strings() {
         let params = Params::new(flags, 1 << N_log2, r, p).unwrap();
         let salt = &EXAMPLE_SALT[..(16 - (i as usize & 15))];
 
-        let actual_hash = Yescrypt
+        let actual_hash = Yescrypt::default()
             .hash_password_with_params(EXAMPLE_PASSWD, salt, params)
             .unwrap();
 
@@ -75,12 +75,14 @@ fn compute_reference_strings() {
 /// `yescrypt_verify()` tests
 #[test]
 fn verify_reference_strings() {
+    let yescrypt = Yescrypt::default();
+
     for &hash in EXAMPLE_HASHES {
         let hash = PasswordHashRef::new(hash).unwrap();
-        assert_eq!(Yescrypt.verify_password(EXAMPLE_PASSWD, hash), Ok(()));
+        assert_eq!(yescrypt.verify_password(EXAMPLE_PASSWD, hash), Ok(()));
 
         assert_eq!(
-            Yescrypt.verify_password(b"bogus", hash),
+            yescrypt.verify_password(b"bogus", hash),
             Err(Error::PasswordInvalid)
         );
     }


### PR DESCRIPTION
Support for configuring the default `Params` to use when computing new Modular Crypt Format (MCF) hashes from a given password and salt