### PR TITLE
pbkdf2: have `Pbkdf2::new` take algorithm/params args

### DIFF
--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -69,8 +69,8 @@
 //!     Pbkdf2
 //! };
 //!
-//! let pbkdf2 = Pbkdf2::new(); // Uses `Params::RECOMMENDED`
-//! let password = b"hunter42"; // Bad password; don't actually use!
+//! let pbkdf2 = Pbkdf2::default(); // Uses `Algorithm::default()` and `Params::RECOMMENDED`
+//! let password = b"hunter2"; // Bad password; don't actually use!
 //!
 //! // Hash password to PHC string ($pbkdf2-sha256$...)
 //! let password_hash = pbkdf2.hash_password(password)?.to_string();

--- a/pbkdf2/src/phc.rs
+++ b/pbkdf2/src/phc.rs
@@ -22,22 +22,26 @@ pub struct Pbkdf2 {
 
 impl Pbkdf2 {
     /// Initialize [`Pbkdf2`] with default parameters.
-    pub const fn new() -> Self {
-        Self::new_with_params(Params::RECOMMENDED)
+    pub const fn new(algorithm: Algorithm, params: Params) -> Self {
+        Self { algorithm, params }
     }
+}
 
-    /// Initialize [`Pbkdf2`] with the provided parameters.
-    pub const fn new_with_params(params: Params) -> Self {
+impl From<Algorithm> for Pbkdf2 {
+    fn from(algorithm: Algorithm) -> Self {
         Self {
-            algorithm: Algorithm::RECOMMENDED,
-            params,
+            algorithm,
+            params: Params::default(),
         }
     }
 }
 
 impl From<Params> for Pbkdf2 {
     fn from(params: Params) -> Self {
-        Self::new_with_params(params)
+        Self {
+            algorithm: Algorithm::default(),
+            params,
+        }
     }
 }
 

--- a/pbkdf2/tests/phc.rs
+++ b/pbkdf2/tests/phc.rs
@@ -28,7 +28,7 @@ fn hash_with_default_algorithm() {
         output_length: 40,
     };
 
-    let hash = Pbkdf2::new()
+    let hash = Pbkdf2::default()
         .hash_password_customized(PASSWORD, SALT, None, None, params)
         .unwrap();
 


### PR DESCRIPTION
Changes this constructor to allow it to customize both the algorithm and params, leaving `From` impls for `Algorithm` and `Params` as the way to customize one or the other while using defaults for the one not explicitly specified.