### PR TITLE
sha-crypt: add `ShaCrypt::SHA256` and `ShaCrypt::SHA512`

### DIFF
--- a/sha-crypt/src/mcf.rs
+++ b/sha-crypt/src/mcf.rs
@@ -23,8 +23,14 @@ pub struct ShaCrypt {
 }
 
 impl ShaCrypt {
+    /// SHA-crypt configured with SHA-256 as the default.
+    pub const SHA256: Self = Self::new(Algorithm::Sha256Crypt, Params::RECOMMENDED);
+
+    /// SHA-crypt configured with SHA-512 as the default.
+    pub const SHA512: Self = Self::new(Algorithm::Sha512Crypt, Params::RECOMMENDED);
+
     /// Create a new password hasher with customized algorithm and params.
-    pub fn new(algorithm: Algorithm, params: Params) -> Self {
+    pub const fn new(algorithm: Algorithm, params: Params) -> Self {
         Self { algorithm, params }
     }
 }

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -18,8 +18,13 @@ pub struct Params {
 }
 
 impl Params {
-    /// Default number of rounds.
-    pub const ROUNDS_DEFAULT: u32 = 5_000;
+    /// Recommended parameters.
+    pub const RECOMMENDED: Self = Self {
+        rounds: Self::RECOMMENDED_ROUNDS,
+    };
+
+    /// Recommended number of rounds.
+    pub const RECOMMENDED_ROUNDS: u32 = 5_000;
 
     /// Minimum number of rounds allowed.
     pub const ROUNDS_MIN: u32 = 1_000;
@@ -38,9 +43,7 @@ impl Params {
 
 impl Default for Params {
     fn default() -> Self {
-        Params {
-            rounds: Self::ROUNDS_DEFAULT,
-        }
+        Params::RECOMMENDED
     }
 }
 


### PR DESCRIPTION
Associated constants which are each configured using the default recommended `Parameters` but the respective SHA-family algorithm