### PR TITLE
pbkdf2: use `Base64::Pbkdf2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt-pbkdf"
@@ -283,8 +283,7 @@ checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 [[package]]
 name = "mcf"
 version = "0.6.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872721b0f376d4b3b2f4064d69a52aff03e7cddb1fd32c5cb0517edf08faff5e"
+source = "git+https://github.com/RustCrypto/formats?branch=base64ct%2Fpbkdf2-alphabet#a2b37fd6975e49ecdee08d640d6258f4b0f488c7"
 dependencies = [
  "base64ct",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ opt-level = 2
 argon2 = { path = "./argon2" }
 pbkdf2 = { path = "./pbkdf2" }
 scrypt = { path = "./scrypt" }
+
+mcf = { git = "https://github.com/RustCrypto/formats", branch = "base64ct/pbkdf2-alphabet" }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -94,9 +94,6 @@
 //! ```
 
 #[cfg(feature = "mcf")]
-extern crate alloc;
-
-#[cfg(feature = "mcf")]
 pub mod mcf;
 #[cfg(feature = "phc")]
 pub mod phc;


### PR DESCRIPTION
Use support for PBKDF2's special Base64 alphabet now natively implemented in the `base64ct` and `mcf` crates in
RustCrypto/formats#2168.