### PR TITLE
pbkdf2: heapless MCF hash verification support

### DIFF
--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -55,6 +55,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features
-      - run: cargo test
-      - run: cargo test --all-features
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset
+      - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,8 +282,9 @@ checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "mcf"
-version = "0.6.0-rc.2"
-source = "git+https://github.com/RustCrypto/formats?branch=base64ct%2Fpbkdf2-alphabet#a2b37fd6975e49ecdee08d640d6258f4b0f488c7"
+version = "0.6.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "423dc04b93e27ab6399fd28615305105c1621cebb78cbe24f64cb942d440733a"
 dependencies = [
  "base64ct",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,3 @@ opt-level = 2
 argon2 = { path = "./argon2" }
 pbkdf2 = { path = "./pbkdf2" }
 scrypt = { path = "./scrypt" }
-
-mcf = { git = "https://github.com/RustCrypto/formats", branch = "base64ct/pbkdf2-alphabet" }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.85"
 digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
-hmac = { version = "0.13.0-rc.3", default-features = false, optional = true }
-mcf = { version = "0.6.0-rc.2", optional = true }
+hmac = { version = "0.13.0-rc.3", optional = true, default-features = false }
+mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["base64"] }
 password-hash = { version = "0.6.0-rc.8", default-features = false, optional = true }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
@@ -33,8 +33,9 @@ belt-hash = "0.2.0-rc.3"
 
 [features]
 default = ["hmac"]
+alloc = ["mcf?/alloc", "password-hash?/alloc"]
 getrandom = ["password-hash/getrandom"]
-mcf = ["hmac", "password-hash/alloc", "dep:mcf", "sha2"]
+mcf = ["hmac", "sha2", "dep:password-hash", "dep:mcf"]
 phc = ["hmac", "password-hash/phc", "sha2"]
 rand_core = ["password-hash/rand_core"]
 

--- a/pbkdf2/src/params.rs
+++ b/pbkdf2/src/params.rs
@@ -2,12 +2,10 @@ use core::{
     fmt::{self, Display},
     str::FromStr,
 };
+use password_hash::{Error, Result};
 
 #[cfg(feature = "phc")]
-use password_hash::{
-    Error, Result,
-    phc::{self, Decimal, ParamsString},
-};
+use password_hash::phc::{self, Decimal, ParamsString};
 
 /// PBKDF2 params
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Adds an `alloc` feature which is needed to enable MCF hashing functionality.

The `PasswordVerifier<mcf::PasswordHashRef>` impl now works without any dependency on liballoc.