### PR TITLE
bcrypt-pbkdf + password-auth: remove/disable `std` features

### DIFF
--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -25,9 +25,8 @@ zeroize = { version = "1", default-features = false, optional = true }
 hex-literal = "1"
 
 [features]
-default = ["alloc", "std"]
+default = ["alloc"]
 alloc = []
-std = []
 zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -13,8 +13,6 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 mod errors;
 

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -26,8 +26,8 @@ pbkdf2 = { version = "0.13.0-rc.7", optional = true, default-features = false, f
 scrypt = { version = "0.12.0-rc.6", optional = true, default-features = false, features = ["phc"] }
 
 [features]
-default = ["argon2", "std"]
-std = []
+default = ["argon2"]
+std = [] # no-op, but we can't remove it because it would be a breaking change
 wasm_js = ["getrandom/wasm_js"]
 
 [package.metadata.docs.rs]

--- a/password-auth/src/lib.rs
+++ b/password-auth/src/lib.rs
@@ -18,8 +18,6 @@
 )]
 
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 mod errors;
 


### PR DESCRIPTION
These features are literally doing nothing other than linking `std`. They seem to be vestiges of `std::error::Error`.

- Removes the feature from `bcrypt-pbkdf` completely
- Makes it a no-op in `password-auth`, but doesn't remove it because it would be a breaking change and it's a post-1.0 crate