### PR TITLE
Add impls for `kdf::{Kdf, Pbkdf}`

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -36,7 +36,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --no-default-features
-      - run: cargo build --target ${{ matrix.target }} --no-default-features --features password-hash
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features kdf
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features password-hash
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features zeroize
 
@@ -73,6 +73,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo test --no-default-features
+      - run: cargo test --no-default-features --features kdf
       - run: cargo test --no-default-features --features password-hash
       - run: cargo test
       - run: cargo test --all-features

--- a/.github/workflows/balloon-hash.yml
+++ b/.github/workflows/balloon-hash.yml
@@ -35,6 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features kdf
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features password-hash
 
   minimal-versions:
@@ -56,7 +57,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --release
-      - run: cargo test --release --no-default-features --features alloc
-      - run: cargo test --release --no-default-features --features alloc,zeroize
-      - run: cargo test --release --all-features
+      - run: cargo test
+      - run: cargo test --no-default-features --features alloc
+      - run: cargo test --no-default-features --features alloc,zeroize
+      - run: cargo test --no-default-features --features kdf
+      - run: cargo test --all-features
+      - run: cargo test --all-features --release

--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -56,5 +56,11 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset
+      - run: cargo hack check --feature-powerset --no-dev-deps
+      - run: cargo hack test --feature-powerset --exclude-features default,getrandom,hmac,kdf,password-hash,rand_core
+      - run: cargo test --no-default-features --features getrandom
+      - run: cargo test --no-default-features --features hmac
+      - run: cargo test --no-default-features --features kdf
+      - run: cargo test --no-default-features --features password-hash
+      - run: cargo test --no-default-features --features rand_core
       - run: cargo test --all-features --release

--- a/.github/workflows/scrypt.yml
+++ b/.github/workflows/scrypt.yml
@@ -35,6 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features kdf
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features password-hash
 
   minimal-versions:
@@ -42,7 +43,7 @@ jobs:
     if: false
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -59,5 +60,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - run: cargo test --no-default-features
       - run: cargo test
-      - run: cargo test --all-features
-      - run: cargo doc --no-default-features
+      - run: cargo test --no-default-features --features kdf
+      - run: cargo test --no-default-features --features mcf
+      - run: cargo test --no-default-features --features phc
+      - run: cargo test --all-features --release
+      - run: cargo test --all-features --release

--- a/.github/workflows/yescrypt.yml
+++ b/.github/workflows/yescrypt.yml
@@ -24,6 +24,27 @@ jobs:
     with:
       working-directory: ${{ github.workflow }}
 
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v6
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features kdf
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features password-hash
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "blake2",
  "cpufeatures",
  "hex-literal",
+ "kdf",
  "password-hash",
  "rayon",
  "zeroize",
@@ -28,6 +29,7 @@ dependencies = [
  "crypto-bigint",
  "digest",
  "hex-literal",
+ "kdf",
  "password-hash",
  "rayon",
  "sha2",
@@ -275,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "kdf"
+version = "0.1.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4852c654c9650d06a4293146ead04bedcf29861dc0de1115ca1492b7a27c50aa"
+
+[[package]]
 name = "libc"
 version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +342,7 @@ dependencies = [
  "digest",
  "hex-literal",
  "hmac",
+ "kdf",
  "mcf",
  "password-hash",
  "sha1",
@@ -434,6 +443,7 @@ name = "scrypt"
 version = "0.12.0-rc.8"
 dependencies = [
  "cfg-if",
+ "kdf",
  "mcf",
  "password-hash",
  "pbkdf2",
@@ -580,6 +590,7 @@ version = "0.1.0-rc.3"
 dependencies = [
  "hex-literal",
  "hmac",
+ "kdf",
  "mcf",
  "password-hash",
  "pbkdf2",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -21,6 +21,7 @@ base64ct = "1.7"
 blake2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional dependencies
+kdf = { version = "0.1.0-pre.1", optional = true }
 rayon = { version = "1.7", optional = true }
 password-hash = { version = "0.6.0-rc.9", optional = true, features = ["phc"] }
 zeroize = { version = "1", default-features = false, optional = true }
@@ -35,6 +36,7 @@ hex-literal = "1"
 default = ["alloc", "getrandom", "password-hash"]
 alloc = ["password-hash?/alloc"]
 
+kdf = ["alloc", "dep:kdf"]
 getrandom = ["password-hash/getrandom"]
 parallel = ["dep:rayon"]
 password-hash = ["dep:password-hash"]

--- a/argon2/src/error.rs
+++ b/argon2/src/error.rs
@@ -60,6 +60,15 @@ pub enum Error {
     OutOfMemory,
 }
 
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::B64Encoding(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -90,6 +99,13 @@ impl From<base64ct::Error> for Error {
     }
 }
 
+#[cfg(feature = "kdf")]
+impl From<Error> for kdf::Error {
+    fn from(_err: Error) -> kdf::Error {
+        kdf::Error
+    }
+}
+
 #[cfg(feature = "password-hash")]
 impl From<Error> for password_hash::Error {
     fn from(err: Error) -> password_hash::Error {
@@ -111,15 +127,6 @@ impl From<Error> for password_hash::Error {
             }
             Error::TimeTooSmall => password_hash::Error::ParamInvalid { name: "t" },
             Error::VersionInvalid => password_hash::Error::Version,
-        }
-    }
-}
-
-impl core::error::Error for Error {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::B64Encoding(err) => Some(err),
-            _ => None,
         }
     }
 }

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -148,6 +148,8 @@ pub use crate::{
     version::Version,
 };
 
+#[cfg(feature = "kdf")]
+pub use kdf::{self, Kdf, Pbkdf};
 #[cfg(feature = "password-hash")]
 pub use {
     crate::algorithm::{ARGON2D_IDENT, ARGON2I_IDENT, ARGON2ID_IDENT},
@@ -607,6 +609,17 @@ impl<'key> Argon2<'key> {
         Ok(())
     }
 }
+
+#[cfg(feature = "kdf")]
+impl Kdf for Argon2<'_> {
+    fn derive_key(&self, password: &[u8], salt: &[u8], out: &mut [u8]) -> kdf::Result<()> {
+        self.hash_password_into(password, &salt, out)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "kdf")]
+impl Pbkdf for Argon2<'_> {}
 
 #[cfg(all(feature = "alloc", feature = "password-hash"))]
 impl CustomizedPasswordHasher<PasswordHash> for Argon2<'_> {

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -18,6 +18,7 @@ digest = { version = "0.11.0-rc.4", default-features = false }
 crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies
+kdf = { version = "0.1.0-pre.1", optional = true }
 password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false, features = ["phc"] }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
@@ -30,6 +31,7 @@ sha2 = "0.11.0-rc.3"
 default = ["alloc", "getrandom", "password-hash"]
 alloc = ["password-hash/alloc"]
 
+kdf = ["alloc", "dep:kdf"]
 getrandom = ["password-hash/getrandom"]
 parallel = ["dep:rayon"]
 password-hash = ["dep:password-hash"]

--- a/balloon-hash/src/error.rs
+++ b/balloon-hash/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     },
 }
 
+impl core::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -40,6 +42,13 @@ impl fmt::Display for Error {
                 write!(f, "unexpected output size, expected {expected} bytes")
             }
         }
+    }
+}
+
+#[cfg(feature = "kdf")]
+impl From<Error> for kdf::Error {
+    fn from(_err: Error) -> kdf::Error {
+        kdf::Error
     }
 }
 
@@ -56,5 +65,3 @@ impl From<Error> for password_hash::Error {
         }
     }
 }
-
-impl core::error::Error for Error {}

--- a/balloon-hash/tests/balloon.rs
+++ b/balloon-hash/tests/balloon.rs
@@ -64,7 +64,7 @@ fn test_vectors() {
 
         assert_eq!(
             balloon
-                .hash_with_memory(test_vector.password, test_vector.salt, &mut memory)
+                .hash_password_with_memory(test_vector.password, test_vector.salt, &mut memory)
                 .unwrap()
                 .as_slice(),
             test_vector.output,

--- a/balloon-hash/tests/balloon_m.rs
+++ b/balloon-hash/tests/balloon_m.rs
@@ -100,7 +100,7 @@ fn test_vectors() {
 
         assert_eq!(
             balloon
-                .hash_with_memory(test_vector.password, test_vector.salt, &mut memory)
+                .hash_password_with_memory(test_vector.password, test_vector.salt, &mut memory)
                 .unwrap()
                 .as_slice(),
             test_vector.output,

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -18,6 +18,7 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
 hmac = { version = "0.13.0-rc.3", optional = true, default-features = false }
+kdf = { version = "0.1.0-pre.1", optional = true }
 mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["base64"] }
 password-hash = { version = "0.6.0-rc.9", default-features = false, optional = true }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
@@ -34,10 +35,14 @@ belt-hash = "0.2.0-rc.3"
 [features]
 default = ["hmac"]
 alloc = ["mcf?/alloc", "password-hash?/alloc"]
+
+kdf = ["sha2", "dep:kdf"]
 getrandom = ["password-hash/getrandom"]
-mcf = ["hmac", "sha2", "dep:password-hash", "dep:mcf"]
-phc = ["hmac", "password-hash/phc", "sha2"]
+mcf = ["sha2", "password-hash", "dep:mcf"]
+phc = ["password-hash/phc", "sha2"]
 rand_core = ["password-hash/rand_core"]
+sha1 = ["hmac", "dep:sha1"]
+sha2 = ["hmac", "dep:sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pbkdf2/src/algorithm.rs
+++ b/pbkdf2/src/algorithm.rs
@@ -1,11 +1,9 @@
-use core::{
-    fmt::{self, Display},
-    str::FromStr,
-};
-use password_hash::Error;
+use core::fmt::{self, Display};
 
 #[cfg(feature = "phc")]
 use password_hash::phc::Ident;
+#[cfg(feature = "password-hash")]
+use {core::str::FromStr, password_hash::Error};
 
 /// PBKDF2 variants.
 ///
@@ -13,14 +11,16 @@ use password_hash::phc::Ident;
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum Algorithm {
-    /// PBKDF2 SHA1
+    /// PBKDF2-HMAC-SHA1 a.k.a. `$pbkdf2`
     #[cfg(feature = "sha1")]
     Pbkdf2Sha1,
 
-    /// PBKDF2 SHA-256
+    /// PBKDF2-HMAC-SHA-256 a.k.a. `$pbkdf2-sha256`
+    #[cfg(feature = "sha2")]
     Pbkdf2Sha256,
 
-    /// PBKDF2 SHA-512
+    /// PBKDF2-HMAC-SHA-512 a.k.a. `$pbkdf2-sha512`
+    #[cfg(feature = "sha2")]
     Pbkdf2Sha512,
 }
 
@@ -30,9 +30,11 @@ impl Algorithm {
     pub const PBKDF2_SHA1_ID: &'static str = "pbkdf2";
 
     /// PBKDF2 (SHA-256) algorithm identifier
+    #[cfg(feature = "sha2")]
     pub const PBKDF2_SHA256_ID: &'static str = "pbkdf2-sha256";
 
     /// PBKDF2 (SHA-512) algorithm identifier
+    #[cfg(feature = "sha2")]
     pub const PBKDF2_SHA512_ID: &'static str = "pbkdf2-sha512";
 
     /// PBKDF2 (SHA-1) algorithm identifier
@@ -53,9 +55,11 @@ impl Algorithm {
     /// > internal hash function of HMAC-SHA-256.
     ///
     /// [OWASP cheat sheet]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+    #[cfg(feature = "sha2")]
     pub const RECOMMENDED: Self = Self::Pbkdf2Sha256;
 
     /// Parse an [`Algorithm`] from the provided string.
+    #[cfg(feature = "password-hash")]
     pub fn new(id: impl AsRef<str>) -> password_hash::Result<Self> {
         id.as_ref().parse()
     }
@@ -65,7 +69,9 @@ impl Algorithm {
         match self {
             #[cfg(feature = "sha1")]
             Algorithm::Pbkdf2Sha1 => Self::PBKDF2_SHA1_ID,
+            #[cfg(feature = "sha2")]
             Algorithm::Pbkdf2Sha256 => Self::PBKDF2_SHA256_ID,
+            #[cfg(feature = "sha2")]
             Algorithm::Pbkdf2Sha512 => Self::PBKDF2_SHA512_ID,
         }
     }
@@ -77,6 +83,7 @@ impl AsRef<str> for Algorithm {
     }
 }
 
+#[cfg(feature = "sha2")]
 impl Default for Algorithm {
     fn default() -> Self {
         Self::RECOMMENDED
@@ -89,6 +96,7 @@ impl Display for Algorithm {
     }
 }
 
+#[cfg(feature = "password-hash")]
 impl FromStr for Algorithm {
     type Err = Error;
 
@@ -109,6 +117,7 @@ impl From<Algorithm> for Ident {
     }
 }
 
+#[cfg(feature = "password-hash")]
 impl<'a> TryFrom<&'a str> for Algorithm {
     type Error = Error;
 
@@ -116,7 +125,9 @@ impl<'a> TryFrom<&'a str> for Algorithm {
         match name {
             #[cfg(feature = "sha1")]
             Self::PBKDF2_SHA1_ID => Ok(Algorithm::Pbkdf2Sha1),
+            #[cfg(feature = "sha2")]
             Self::PBKDF2_SHA256_ID => Ok(Algorithm::Pbkdf2Sha256),
+            #[cfg(feature = "sha2")]
             Self::PBKDF2_SHA512_ID => Ok(Algorithm::Pbkdf2Sha512),
             _ => Err(Error::Algorithm),
         }

--- a/pbkdf2/src/params.rs
+++ b/pbkdf2/src/params.rs
@@ -1,11 +1,12 @@
-use core::{
-    fmt::{self, Display},
-    str::FromStr,
-};
-use password_hash::{Error, Result};
+use core::fmt::{self, Display};
 
 #[cfg(feature = "phc")]
 use password_hash::phc::{self, Decimal, ParamsString};
+#[cfg(feature = "password-hash")]
+use {
+    core::str::FromStr,
+    password_hash::{Error, Result},
+};
 
 /// PBKDF2 params
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -49,11 +50,13 @@ impl Params {
     };
 
     /// Create new params with the given number of rounds.
+    #[cfg(feature = "password-hash")]
     pub const fn new(rounds: u32) -> Result<Self> {
         Self::new_with_output_len(rounds, Self::RECOMMENDED_OUTPUT_LENGTH)
     }
 
     /// Create new params with a customized output length.
+    #[cfg(feature = "password-hash")]
     pub const fn new_with_output_len(rounds: u32, output_len: usize) -> Result<Self> {
         if rounds < Self::MIN_ROUNDS
             || output_len < Self::MIN_OUTPUT_LENGTH
@@ -88,6 +91,7 @@ impl Display for Params {
     }
 }
 
+#[cfg(feature = "password-hash")]
 impl FromStr for Params {
     type Err = Error;
 
@@ -98,6 +102,7 @@ impl FromStr for Params {
     }
 }
 
+#[cfg(feature = "password-hash")]
 impl TryFrom<u32> for Params {
     type Error = Error;
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
+kdf = { version = "0.1.0-pre.1", optional = true }
 mcf = { version = "0.6.0-rc.2", optional = true }
 password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
@@ -29,7 +30,8 @@ subtle = { version = "2", optional = true, default-features = false }
 alloc = ["password-hash?/alloc"]
 
 getrandom = ["password-hash", "password-hash/getrandom"]
-mcf = ["alloc", "password-hash", "dep:mcf", "dep:subtle"]
+kdf = ["alloc", "dep:kdf"]
+mcf = ["alloc", "phc", "dep:mcf", "dep:subtle"]
 phc = ["password-hash/phc"]
 rand_core = ["password-hash/rand_core"]
 parallel = ["dep:rayon"]

--- a/scrypt/src/errors.rs
+++ b/scrypt/src/errors.rs
@@ -16,6 +16,13 @@ impl fmt::Display for InvalidOutputLen {
 
 impl core::error::Error for InvalidOutputLen {}
 
+#[cfg(feature = "kdf")]
+impl From<InvalidOutputLen> for kdf::Error {
+    fn from(_err: InvalidOutputLen) -> kdf::Error {
+        kdf::Error
+    }
+}
+
 impl fmt::Display for InvalidParams {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("invalid scrypt parameters")

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -62,6 +62,8 @@ pub mod phc;
 
 pub use crate::params::Params;
 
+#[cfg(feature = "kdf")]
+pub use kdf::{self, Kdf, Pbkdf};
 #[cfg(feature = "password-hash")]
 pub use password_hash;
 
@@ -146,14 +148,14 @@ fn romix_parallel(nr128: usize, r128: usize, n: usize, b: &mut [u8]) {
 /// This type holds the default parameters to use when computing password hashes.
 ///
 /// See the toplevel documentation for a code example.
-#[cfg(any(feature = "mcf", feature = "phc"))]
+#[cfg(any(feature = "kdf", feature = "mcf", feature = "phc"))]
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Scrypt {
     /// Default parameters to use.
     params: Params,
 }
 
-#[cfg(any(feature = "mcf", feature = "phc"))]
+#[cfg(any(feature = "kdf", feature = "mcf", feature = "phc"))]
 impl Scrypt {
     /// Initialize [`Scrypt`] with default parameters.
     pub const fn new() -> Self {
@@ -168,9 +170,20 @@ impl Scrypt {
     }
 }
 
-#[cfg(any(feature = "mcf", feature = "phc"))]
+#[cfg(any(feature = "kdf", feature = "mcf", feature = "phc"))]
 impl From<Params> for Scrypt {
     fn from(params: Params) -> Self {
         Self::new_with_params(params)
     }
 }
+
+#[cfg(feature = "kdf")]
+impl Kdf for Scrypt {
+    fn derive_key(&self, password: &[u8], salt: &[u8], out: &mut [u8]) -> kdf::Result<()> {
+        scrypt(password, salt, &self.params, out)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "kdf")]
+impl Pbkdf for Scrypt {}

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -6,10 +6,7 @@ use {
         fmt::{self, Display},
         str::FromStr,
     },
-    password_hash::{
-        Error,
-        phc::{Decimal, Output, ParamsString, PasswordHash},
-    },
+    password_hash::{Error, phc},
 };
 
 #[cfg(all(feature = "phc", doc))]
@@ -125,7 +122,7 @@ impl Params {
         p: u32,
         len: usize,
     ) -> Result<Params, InvalidParams> {
-        if !(Output::MIN_LENGTH..=Output::MAX_LENGTH).contains(&len) {
+        if !(phc::Output::MIN_LENGTH..=phc::Output::MAX_LENGTH).contains(&len) {
             return Err(InvalidParams);
         }
 
@@ -179,7 +176,9 @@ impl Default for Params {
 #[cfg(feature = "phc")]
 impl Display for Params {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        ParamsString::try_from(self).map_err(|_| fmt::Error)?.fmt(f)
+        phc::ParamsString::try_from(self)
+            .map_err(|_| fmt::Error)?
+            .fmt(f)
     }
 }
 
@@ -188,16 +187,16 @@ impl FromStr for Params {
     type Err = Error;
 
     fn from_str(s: &str) -> password_hash::Result<Self> {
-        let params_string = ParamsString::from_str(s).map_err(|_| Error::ParamsInvalid)?;
+        let params_string = phc::ParamsString::from_str(s).map_err(|_| Error::ParamsInvalid)?;
         Self::try_from(&params_string)
     }
 }
 
 #[cfg(feature = "phc")]
-impl TryFrom<&ParamsString> for Params {
+impl TryFrom<&phc::ParamsString> for Params {
     type Error = Error;
 
-    fn try_from(params: &ParamsString) -> password_hash::Result<Self> {
+    fn try_from(params: &phc::ParamsString) -> password_hash::Result<Self> {
         let mut log_n = Self::RECOMMENDED_LOG_N;
         let mut r = Self::RECOMMENDED_R;
         let mut p = Self::RECOMMENDED_P;
@@ -230,10 +229,10 @@ impl TryFrom<&ParamsString> for Params {
 }
 
 #[cfg(feature = "phc")]
-impl TryFrom<&PasswordHash> for Params {
+impl TryFrom<&phc::PasswordHash> for Params {
     type Error = Error;
 
-    fn try_from(hash: &PasswordHash) -> password_hash::Result<Self> {
+    fn try_from(hash: &phc::PasswordHash) -> password_hash::Result<Self> {
         if hash.version.is_some() {
             return Err(Error::Version);
         }
@@ -251,23 +250,23 @@ impl TryFrom<&PasswordHash> for Params {
 }
 
 #[cfg(feature = "phc")]
-impl TryFrom<Params> for ParamsString {
+impl TryFrom<Params> for phc::ParamsString {
     type Error = Error;
 
-    fn try_from(params: Params) -> Result<ParamsString, Error> {
+    fn try_from(params: Params) -> Result<phc::ParamsString, Error> {
         Self::try_from(&params)
     }
 }
 
 #[cfg(feature = "phc")]
-impl TryFrom<&Params> for ParamsString {
+impl TryFrom<&Params> for phc::ParamsString {
     type Error = Error;
 
-    fn try_from(input: &Params) -> Result<ParamsString, Error> {
-        let mut output = ParamsString::new();
+    fn try_from(input: &Params) -> Result<phc::ParamsString, Error> {
+        let mut output = phc::ParamsString::new();
 
         for (name, value) in [
-            ("ln", input.log_n as Decimal),
+            ("ln", input.log_n as phc::Decimal),
             ("r", input.r),
             ("p", input.p),
         ] {

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
+kdf = { version = "0.1.0-pre.1", optional = true }
 mcf = { version = "0.6.0-rc.2", optional = true, default-features = false, features = ["alloc", "base64"] }
 password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false }
 
@@ -30,6 +31,7 @@ hex-literal = "1"
 [features]
 default = ["getrandom"]
 getrandom = ["password-hash", "password-hash/getrandom"]
+kdf = ["dep:kdf"]
 rand_core = ["password-hash/rand_core"]
 password-hash = ["dep:mcf", "dep:password-hash"]
 

--- a/yescrypt/src/error.rs
+++ b/yescrypt/src/error.rs
@@ -37,6 +37,13 @@ impl From<TryFromIntError> for Error {
     }
 }
 
+#[cfg(feature = "kdf")]
+impl From<Error> for kdf::Error {
+    fn from(_: Error) -> Self {
+        kdf::Error
+    }
+}
+
 #[cfg(feature = "password-hash")]
 impl From<Error> for password_hash::Error {
     fn from(err: Error) -> Self {

--- a/yescrypt/src/mcf.rs
+++ b/yescrypt/src/mcf.rs
@@ -2,7 +2,7 @@
 
 pub use mcf::{PasswordHash, PasswordHashRef};
 
-use crate::{Params, yescrypt};
+use crate::{Params, Yescrypt, yescrypt};
 use alloc::vec;
 use mcf::Base64;
 use password_hash::{
@@ -15,25 +15,6 @@ const YESCRYPT_MCF_ID: &str = "y";
 
 /// Base64 variant used by yescrypt.
 const YESCRYPT_BASE64: Base64 = Base64::Crypt;
-
-/// yescrypt password hashing type which can produce and verify strings in Modular Crypt Format
-/// (MCF) which begin with `$y$`
-///
-/// This type impls traits from the [`password-hash`][`password_hash`] crate, notably the
-/// [`PasswordHasher`], [`PasswordVerifier`], and [`CustomizedPasswordHasher`] traits.
-///
-/// See the toplevel documentation for a code example.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub struct Yescrypt {
-    /// Default parameters to use when hashing passwords.
-    params: Params,
-}
-
-impl From<Params> for Yescrypt {
-    fn from(params: Params) -> Self {
-        Self { params }
-    }
-}
 
 impl CustomizedPasswordHasher<PasswordHash> for Yescrypt {
     type Params = Params;


### PR DESCRIPTION
For the password hash algorithms that already have a `struct` where we can impl traits (i.e. any with a `password-hash`/`phc`/`mcf` feature) adds feature-gated impls of the traits from the new `kdf` crate.

The `Kdf` trait provides a generic API, and `Pbkdf` is a marker trait for password-based KDFs where a password can be used as a secret input.