### PR TITLE
scrypt: remove `Display`/`FromStr` impls from `Params`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.9"
+version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d7cb93fb02e6e7941e867799a770d9eb67ce70751a84a9e826e92ecad6aadc"
+checksum = "80b7795f59c339f0458e0213b31e01f45de7f061bdfc52857386f457d94c2cb8"
 dependencies = [
  "getrandom",
  "phc",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -23,7 +23,7 @@ blake2 = { version = "0.11.0-rc.3", default-features = false }
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
 rayon = { version = "1.7", optional = true }
-password-hash = { version = "0.6.0-rc.9", optional = true, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.10", optional = true, features = ["phc"] }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -19,7 +19,7 @@ crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = [
 
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
-password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false, features = ["phc"] }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
 

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 getrandom = { version = "0.4.0-rc.0", default-features = false }
-password-hash = { version = "0.6.0-rc.9", features = ["alloc", "getrandom", "phc"] }
+password-hash = { version = "0.6.0-rc.10", features = ["alloc", "getrandom", "phc"] }
 
 # optional dependencies
 argon2 = { version = "0.6.0-rc.5", optional = true, default-features = false, features = ["alloc", "password-hash"] }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -20,7 +20,7 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 hmac = { version = "0.13.0-rc.3", optional = true, default-features = false }
 kdf = { version = "0.1.0-pre.1", optional = true }
 mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["base64"] }
-password-hash = { version = "0.6.0-rc.9", default-features = false, optional = true }
+password-hash = { version = "0.6.0-rc.10", default-features = false, optional = true }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -23,7 +23,7 @@ rayon = { version = "1.11", optional = true }
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
 mcf = { version = "0.6.0-rc.2", optional = true }
-password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -1,13 +1,7 @@
 use crate::errors::InvalidParams;
 
 #[cfg(feature = "phc")]
-use {
-    core::{
-        fmt::{self, Display},
-        str::FromStr,
-    },
-    password_hash::{Error, phc},
-};
+use password_hash::{Error, phc};
 
 #[cfg(all(feature = "phc", doc))]
 use password_hash::PasswordHasher;
@@ -170,25 +164,6 @@ impl Params {
 impl Default for Params {
     fn default() -> Params {
         Params::RECOMMENDED
-    }
-}
-
-#[cfg(feature = "phc")]
-impl Display for Params {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        phc::ParamsString::try_from(self)
-            .map_err(|_| fmt::Error)?
-            .fmt(f)
-    }
-}
-
-#[cfg(feature = "phc")]
-impl FromStr for Params {
-    type Err = Error;
-
-    fn from_str(s: &str) -> password_hash::Result<Self> {
-        let params_string = phc::ParamsString::from_str(s).map_err(|_| Error::ParamsInvalid)?;
-        Self::try_from(&params_string)
     }
 }
 

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -23,7 +23,7 @@ base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 mcf = { version = "0.6.0-rc.2", optional = true, default-features = false, features = ["alloc", "base64"] }
-password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -23,7 +23,7 @@ subtle = { version = "2", default-features = false }
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
 mcf = { version = "0.6.0-rc.2", optional = true, default-features = false, features = ["alloc", "base64"] }
-password-hash = { version = "0.6.0-rc.9", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Also bumps `password-hash` to v0.6.0-rc.10, which permits these bounds.

They were previously impl'd using the PHC params syntax, but now that we've added MCF support (#806) there isn't one-true-serialization that actually makes sense to use.

In such a case, I think it's best not to impl `Display`/`FromStr` but instead use format-specific inherent methods and impls for format-specific types (like `phc::ParamsString`).