### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "base64ct",
  "blake2",
@@ -24,7 +24,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "balloon-hash"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -44,7 +44,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.7"
+version = "0.13.0-rc.8"
 dependencies = [
  "belt-hash",
  "digest",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.8"
+version = "0.12.0-rc.9"
 dependencies = [
  "cfg-if",
  "kdf",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "base64ct",
  "mcf",
@@ -586,7 +586,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "yescrypt"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 dependencies = [
  "hex-literal",
  "hmac",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 blowfish = { version = "0.10.0-rc.2", features = ["bcrypt"] }
-pbkdf2 = { version = "0.13.0-rc.7", default-features = false }
+pbkdf2 = { version = "0.13.0-rc.8", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 
 # optional features

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -21,9 +21,9 @@ getrandom = { version = "0.4.0-rc.0", default-features = false }
 password-hash = { version = "0.6.0-rc.10", features = ["alloc", "getrandom", "phc"] }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.5", optional = true, default-features = false, features = ["alloc", "password-hash"] }
-pbkdf2 = { version = "0.13.0-rc.7", optional = true, default-features = false, features = ["phc"] }
-scrypt = { version = "0.12.0-rc.6", optional = true, default-features = false, features = ["phc"] }
+argon2 = { version = "0.6.0-rc.6", optional = true, default-features = false, features = ["alloc", "password-hash"] }
+pbkdf2 = { version = "0.13.0-rc.8", optional = true, default-features = false, features = ["phc"] }
+scrypt = { version = "0.12.0-rc.9", optional = true, default-features = false, features = ["phc"] }
 
 [features]
 default = ["argon2"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-rc.7"
+version = "0.13.0-rc.8"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.8"
+version = "0.12.0-rc.9"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,14 +15,14 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-pbkdf2 = { version = "0.13.0-rc.7", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.8", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
-mcf = { version = "0.6.0-rc.2", optional = true }
+mcf = { version = "0.6.0-rc.3", optional = true }
 password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = """
 Pure Rust implementation of the SHA-crypt password hashing algorithm based on SHA-256/SHA-512
 as implemented by the POSIX crypt C library, including support for generating and verifying password
@@ -22,7 +22,7 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-mcf = { version = "0.6.0-rc.2", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["alloc", "base64"] }
 password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yescrypt"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 description = "Pure Rust implementation of the yescrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,14 +15,14 @@ rust-version = "1.85"
 
 [dependencies]
 hmac = { version = "0.13.0-rc.3", default-features = false }
-pbkdf2 = { version = "0.13.0-rc.7", default-features = false, features = ["hmac"] }
+pbkdf2 = { version = "0.13.0-rc.8", default-features = false, features = ["hmac"] }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
-mcf = { version = "0.6.0-rc.2", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["alloc", "base64"] }
 password-hash = { version = "0.6.0-rc.10", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Releases the following:
- `argon2` v0.6.0-rc.6
- `balloon-hash` v0.5.0-rc.4
- `bcrypt-pbkdf` v0.11.0-rc.3
- `pbkdf2` v0.13.0-rc.8
- `scrypt` v0.12.0-rc.9
- `sha-crypt` v0.6.0-rc.3
- `yescrypt` v0.1.0-rc.4