### PR TITLE
pbkdf2: have `minimal-versions` run `cargo check`

### DIFF
--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -3,6 +3,7 @@ name: pbkdf2
 on:
   pull_request:
     paths:
+      - ".github/workflows/pbkdf2.yml"
       - "pbkdf2/**"
       - "Cargo.*"
   push:
@@ -39,6 +40,7 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
+      stable-cmd: cargo hack check --feature-powerset --no-dev-deps
       working-directory: ${{ github.workflow }}
 
   test:


### PR DESCRIPTION
The `pbkdf2` crate has a lot of features which leads to a combinatorial explosion in `cargo hack` with `--feature-powerset`.

On the last CI run, `minimal-versions` took 20 minutes:

https://github.com/RustCrypto/password-hashes/actions/runs/21318294427/job/61364340801?pr=829

This switches the `stable-cmd` from using `cargo hack test` to `cargo hack check`, which should still check all feature combinations build in a minimal versions scenario but be significantly faster than trying to test every possible feature combination.

This is the recommended way to use `cargo hack` according to its developers:

https://github.com/taiki-e/cargo-hack?tab=readme-ov-file#usage