### PR TITLE
Revert "pbkdf2: have `minimal-versions` run `cargo check`"

### DIFF
--- a/.github/workflows/pbkdf2.yml
+++ b/.github/workflows/pbkdf2.yml
@@ -40,7 +40,6 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-      stable-cmd: cargo hack check --feature-powerset --no-dev-deps
       working-directory: ${{ github.workflow }}
 
   test:


### PR DESCRIPTION
This reverts commit cb4867eaa3fdc04c1c5cd87d4dc0cbcbcb2efce2  (#830).

This is now the upstream default: RustCrypto/actions#56