### PR TITLE
Bump dependency requirements in `Cargo.toml`s

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -15,6 +15,7 @@ extend-ignore-re = [
 ]
 
 [default.extend-words]
+consts = "consts"
 "GOST" = "GOST"
 # Variable name in yescrypt
 "clen" = "clen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 dependencies = [
  "base64ct",
  "blake2",
@@ -30,7 +30,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "balloon-hash"
-version = "0.5.0-rc.4"
+version = "0.5.0-rc.5"
 dependencies = [
  "crypto-bigint",
  "digest",
@@ -50,7 +50,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.6"
 dependencies = [
  "blowfish",
  "hex-literal",
@@ -67,9 +67,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941a75a90169bf5eceb17f40ab25f5f1077006996eb52f4e9d036a7ac378db68"
+checksum = "c56883a45783acff1ccdf0903f38b8688363e633d3c9a199c2063f0cc946832b"
 dependencies = [
  "belt-block",
  "digest",
@@ -83,9 +83,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683ccc88fb953fc7caf1cca3cbba79efc2c2d5968ab312cb92baa6594e3e854d"
+checksum = "d52965399b470437fc7f4d4b51134668dbc96573fea6f1b83318a420e4605745"
 dependencies = [
  "digest",
 ]
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecfb049d43f70154a8a232d709710dc7350bda1fa7d0e539a252f0938adad8e"
+checksum = "e68258100c60364f089766a8de37b8382136bab19abe6086627dfb324cf095c7"
 dependencies = [
  "byteorder",
  "cipher",
@@ -129,9 +129,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
+checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -149,6 +149,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpubits"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a8c0210fa48ba3ea04ac1e9c6e72ae66009db3b1f1745635d4ff2e58eaadd0"
 
 [[package]]
 name = "cpufeatures"
@@ -186,10 +192,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.21"
+version = "0.7.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
+checksum = "cba9eeeb213f7fd29353032f71f7c173e5f6d95d85151cb3a47197b0ea7e8be7"
 dependencies = [
+ "cpubits",
  "ctutils",
  "hybrid-array",
  "num-traits",
@@ -197,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "hybrid-array",
 ]
@@ -215,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -287,9 +294,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9956e202a691c5c86c60303a421f66f93f44b29433407b7c43cf2bebadc750e"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
  "digest",
 ]
@@ -402,7 +409,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "password-auth"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 dependencies = [
  "argon2",
  "getrandom",
@@ -413,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b64c3c87d737f723456e6e399adcb471e5446f42ba3d1e4f50a81d894b274"
+checksum = "5fa9e3d1c7b6f3e230b60fa44adc855cb8e24eede37236621f2cc1940d95564f"
 dependencies = [
  "getrandom",
  "phc",
@@ -424,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.8"
+version = "0.13.0-rc.9"
 dependencies = [
  "belt-hash",
  "digest",
@@ -486,9 +493,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -538,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.9"
+version = "0.12.0-rc.10"
 dependencies = [
  "cfg-if",
  "kdf",
@@ -601,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "sha-crypt"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "base64ct",
  "mcf",
@@ -612,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -623,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -634,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a06ec57c92c6db98fc783bf712353fce33bf13f93104eb8bc9b2700e90526b"
+checksum = "8f02c29e9fbd46b3493c2d1b8038d738480a56d25edc0ec0acc27f796a125a89"
 dependencies = [
  "digest",
 ]
@@ -869,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "yescrypt"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "hex-literal",
  "hmac",

--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argon2"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 description = """
 Pure Rust implementation of the Argon2 password hashing function with support
 for the Argon2d, Argon2i, and Argon2id algorithmic variants
@@ -18,12 +18,12 @@ rust-version = "1.85"
 
 [dependencies]
 base64ct = "1.7"
-blake2 = { version = "0.11.0-rc.3", default-features = false }
+blake2 = { version = "0.11.0-rc.5", default-features = false }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }
 rayon = { version = "1.7", optional = true }
-password-hash = { version = "0.6.0-rc.11", optional = true, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.12", optional = true, features = ["phc"] }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balloon-hash"
-version = "0.5.0-rc.4"
+version = "0.5.0-rc.5"
 description = "Pure Rust implementation of the Balloon password hashing function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,18 +14,18 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.4", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["hybrid-array"] }
+digest = { version = "0.11.0-rc.11", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.25", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }
-password-hash = { version = "0.6.0-rc.11", optional = true, default-features = false, features = ["phc"] }
+password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false, features = ["phc"] }
 rayon = { version = "1.7", optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = "0.11.0-rc.3"
+sha2 = "0.11.0-rc.5"
 
 [features]
 default = ["alloc", "getrandom", "password-hash"]

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.6"
 description = "bcrypt-pbkdf password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,9 +14,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-blowfish = { version = "0.10.0-rc.2", features = ["bcrypt"] }
-pbkdf2 = { version = "0.13.0-rc.8", default-features = false }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+blowfish = { version = "0.10.0-rc.3", features = ["bcrypt"] }
+pbkdf2 = { version = "0.13.0-rc.9", default-features = false }
+sha2 = { version = "0.11.0-rc.5", default-features = false }
 
 # optional features
 zeroize = { version = "1", default-features = false, optional = true }

--- a/bcrypt-pbkdf/src/lib.rs
+++ b/bcrypt-pbkdf/src/lib.rs
@@ -23,7 +23,7 @@ use sha2::{
     Digest, Sha512,
     digest::{
         FixedOutput, MacMarker, Output, OutputSizeUser, Update,
-        crypto_common::{Key, KeyInit, KeySizeUser},
+        common::{Key, KeyInit, KeySizeUser},
         typenum::U32,
     },
 };

--- a/password-auth/Cargo.toml
+++ b/password-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-auth"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 description = """
 Password authentication library with a focus on simplicity and ease-of-use,
 including support for Argon2, PBKDF2, and scrypt password hashing algorithms
@@ -18,12 +18,12 @@ rust-version = "1.85"
 
 [dependencies]
 getrandom = { version = "0.4.0-rc.0", default-features = false }
-password-hash = { version = "0.6.0-rc.11", features = ["alloc", "getrandom", "phc"] }
+password-hash = { version = "0.6.0-rc.12", features = ["alloc", "getrandom", "phc"] }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.6", optional = true, default-features = false, features = ["alloc", "password-hash"] }
-pbkdf2 = { version = "0.13.0-rc.8", optional = true, default-features = false, features = ["phc"] }
-scrypt = { version = "0.12.0-rc.9", optional = true, default-features = false, features = ["phc"] }
+argon2 = { version = "0.6.0-rc.7", optional = true, default-features = false, features = ["alloc", "password-hash"] }
+pbkdf2 = { version = "0.13.0-rc.9", optional = true, default-features = false, features = ["phc"] }
+scrypt = { version = "0.12.0-rc.10", optional = true, default-features = false, features = ["phc"] }
 
 [features]
 default = ["argon2"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbkdf2"
-version = "0.13.0-rc.8"
+version = "0.13.0-rc.9"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic implementation of PBKDF2"
@@ -17,20 +17,20 @@ rust-version = "1.85"
 digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
-hmac = { version = "0.13.0-rc.3", optional = true, default-features = false }
+hmac = { version = "0.13.0-rc.5", optional = true, default-features = false }
 kdf = { version = "0.1", optional = true }
 mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["base64"] }
-password-hash = { version = "0.6.0-rc.11", default-features = false, optional = true }
-sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
-sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
+password-hash = { version = "0.6.0-rc.12", default-features = false, optional = true }
+sha1 = { version = "0.11.0-rc.5", default-features = false, optional = true }
+sha2 = { version = "0.11.0-rc.5", default-features = false, optional = true }
 
 [dev-dependencies]
-hmac = "0.13.0-rc.3"
+belt-hash = "0.2.0-rc.5"
+hmac = "0.13.0-rc.5"
 hex-literal = "1"
-sha1 = "0.11.0-rc.3"
-sha2 = "0.11.0-rc.3"
-streebog = "0.11.0-rc.3"
-belt-hash = "0.2.0-rc.3"
+sha1 = "0.11.0-rc.5"
+sha2 = "0.11.0-rc.5"
+streebog = "0.11.0-rc.5"
 
 [features]
 default = ["hmac"]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt"
-version = "0.12.0-rc.9"
+version = "0.12.0-rc.10"
 description = "Scrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,15 +15,15 @@ rust-version = "1.85"
 
 [dependencies]
 cfg-if = "1.0"
-pbkdf2 = { version = "0.13.0-rc.8", path = "../pbkdf2" }
+pbkdf2 = { version = "0.13.0-rc.9", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.5", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }
 mcf = { version = "0.6.0-rc.3", optional = true }
-password-hash = { version = "0.6.0-rc.11", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-crypt"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 description = """
 Pure Rust implementation of the SHA-crypt password hashing algorithm based on SHA-256/SHA-512
 as implemented by the POSIX crypt C library, including support for generating and verifying password
@@ -18,12 +18,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.5", default-features = false }
 base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["alloc", "base64"] }
-password-hash = { version = "0.6.0-rc.11", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [features]

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yescrypt"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 description = "Pure Rust implementation of the yescrypt password-based key derivation function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,16 +14,16 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = { version = "0.13.0-rc.3", default-features = false }
-pbkdf2 = { version = "0.13.0-rc.8", default-features = false, features = ["hmac"] }
+hmac = { version = "0.13.0-rc.5", default-features = false }
+pbkdf2 = { version = "0.13.0-rc.9", default-features = false, features = ["hmac"] }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.5", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }
 mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["alloc", "base64"] }
-password-hash = { version = "0.6.0-rc.11", optional = true, default-features = false }
+password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Includes `rand_core` v0.10 and `getrandom` v0.4 upgrades.

Bumps the following dependency requirements:
- `belt-hash` v0.2.0-rc.5
- `blake2` v0.11.0-rc.5
- `blowfish` v0.10.0-rc.3
- `crypto-bigint` v0.7.0-rc.25
- `digest` v0.11.0-rc.11
- `hmac` v0.13.0-rc.5
- `password-hash` v0.6.0-rc.12
- `sha1` v0.11.0-rc.5
- `sha2` v0.11.0-rc.5
- `streebog` v0.11.0-rc.5

Cuts the following releases:
- `argon2` v0.6.0-rc.7
- `balloon-hash` v0.5.0-rc.5
- `bcrypt-pbkdf` v0.11.0-rc.6
- `password-auth` v1.1.0-rc.2
- `pbkdf2` v0.13.0-rc.9
- `scrypt` v0.12.0-rc.10
- `sha-crypt` v0.6.0-rc.4
- `yescrypt` v0.1.0-rc.5