### PR TITLE
Bump `mcf` to v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,9 +379,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mcf"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423dc04b93e27ab6399fd28615305105c1621cebb78cbe24f64cb942d440733a"
+checksum = "2044bdbade272ded4a1529324f4f30ca7b0c5b496541f2a9095bbd1c9d03cb06"
 dependencies = [
  "base64ct",
 ]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -19,7 +19,7 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 # optional dependencies
 hmac = { version = "0.13.0-rc.5", optional = true, default-features = false }
 kdf = { version = "0.1", optional = true }
-mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["base64"] }
+mcf = { version = "0.6", optional = true, default-features = false, features = ["base64"] }
 password-hash = { version = "0.6.0-rc.12", default-features = false, optional = true }
 sha1 = { version = "0.11.0-rc.5", default-features = false, optional = true }
 sha2 = { version = "0.11.0-rc.5", default-features = false, optional = true }

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -22,7 +22,7 @@ rayon = { version = "1.11", optional = true }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }
-mcf = { version = "0.6.0-rc.3", optional = true }
+mcf = { version = "0.6", optional = true }
 password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = { version = "0.11.0-rc.5", default-features = false }
 base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "0.6", optional = true, default-features = false, features = ["alloc", "base64"] }
 password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -22,7 +22,7 @@ subtle = { version = "2", default-features = false }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }
-mcf = { version = "0.6.0-rc.3", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "0.6", optional = true, default-features = false, features = ["alloc", "base64"] }
 password-hash = { version = "0.6.0-rc.12", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Release PR: RustCrypto/formats#2253