### PR TITLE
Bump `digest` dependency to v0.11

### DIFF
--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.11", default-features = false }
+digest = { version = "0.11", default-features = false }
 crypto-bigint = { version = "0.7.0-rc.25", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+digest = { version = "0.11", features = ["mac"] }
 
 # optional dependencies
 hmac = { version = "0.13.0-rc.5", optional = true, default-features = false }


### PR DESCRIPTION
Release PR: RustCrypto/traits#2300