### PR TITLE
Bump `hmac` dependency to v0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.6"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60017b071c523c9e5a55dd1253582bff6150c5e96a7e8511e419de1ab5ee97f9"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 digest = { version = "0.11", features = ["mac"] }
 
 # optional dependencies
-hmac = { version = "0.13.0-rc.6", optional = true, default-features = false }
+hmac = { version = "0.13", optional = true, default-features = false }
 kdf = { version = "0.1", optional = true }
 mcf = { version = "0.6", optional = true, default-features = false, features = ["base64"] }
 password-hash = { version = "0.6", default-features = false, optional = true }
@@ -25,7 +25,7 @@ sha2 = { version = "0.11.0-rc.5", default-features = false, optional = true }
 
 [dev-dependencies]
 belt-hash = "0.2.0-rc.5"
-hmac = "0.13.0-rc.6"
+hmac = "0.13"
 hex-literal = "1"
 sha1 = "0.11.0-rc.5"
 sha2 = "0.11.0-rc.5"

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 ctutils = "0.4"
-hmac = { version = "0.13.0-rc.6", default-features = false }
+hmac = { version = "0.13", default-features = false }
 pbkdf2 = { version = "0.13.0-rc.10", default-features = false, features = ["hmac"] }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.5", default-features = false }


### PR DESCRIPTION
Release PR: RustCrypto/MACs#263