### PR TITLE
Bump `sha1`, `sha2`, and `streebog` to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.6.0-rc.8"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "hex-literal",
  "kdf",
  "password-hash",
@@ -155,15 +155,6 @@ name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -628,31 +619,31 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f02c29e9fbd46b3493c2d1b8038d738480a56d25edc0ec0acc27f796a125a89"
+checksum = "942b8aca83a17a387b90643abe15430abd0aabc91d6db511e85827e7060746ef"
 dependencies = [
  "digest",
 ]

--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -25,7 +25,7 @@ zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = "0.11.0-rc.5"
+sha2 = "0.11"
 
 [features]
 default = ["alloc", "getrandom", "password-hash"]

--- a/bcrypt-pbkdf/Cargo.toml
+++ b/bcrypt-pbkdf/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 [dependencies]
 blowfish = { version = "0.10.0-rc.3", features = ["bcrypt"] }
 pbkdf2 = { version = "0.13.0-rc.10", default-features = false }
-sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 
 # optional features
 zeroize = { version = "1", default-features = false, optional = true }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -21,15 +21,15 @@ hmac = { version = "0.13", optional = true, default-features = false }
 kdf = { version = "0.1", optional = true }
 mcf = { version = "0.6", optional = true, default-features = false, features = ["base64"] }
 password-hash = { version = "0.6", default-features = false, optional = true }
-sha2 = { version = "0.11.0-rc.5", default-features = false, optional = true }
+sha2 = { version = "0.11", default-features = false, optional = true }
 
 [dev-dependencies]
 belt-hash = "0.2.0-rc.5"
 hmac = "0.13"
 hex-literal = "1"
-sha1 = "0.11.0-rc.5"
-sha2 = "0.11.0-rc.5"
-streebog = "0.11.0-rc.5"
+sha1 = "0.11"
+sha2 = "0.11"
+streebog = "0.11"
 
 [features]
 default = ["hmac"]

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 cfg-if = "1.0"
 pbkdf2 = { version = "0.13.0-rc.10", path = "../pbkdf2" }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 rayon = { version = "1.11", optional = true }
 
 # optional dependencies

--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies

--- a/yescrypt/Cargo.toml
+++ b/yescrypt/Cargo.toml
@@ -18,7 +18,7 @@ ctutils = "0.4"
 hmac = { version = "0.13", default-features = false }
 pbkdf2 = { version = "0.13.0-rc.10", default-features = false, features = ["hmac"] }
 salsa20 = { version = "0.11.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }


### PR DESCRIPTION
Release PRs:
- `sha1`: RustCrypto/hashes#810
- `sha2`: RustCrypto/hashes#806
- `streebog`: RustCrypto/hashes#812