### PR TITLE
argon2: add regression test for RustCrypto/traits#2352

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,8 +421,7 @@ dependencies = [
 [[package]]
 name = "password-hash"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbd25f71dd5249dba9ed843d52500c8757a25511560d01a94f4abf56b52a1d5"
+source = "git+https://github.com/RustCrypto/traits#2501d4f5454caaf2a22de6ccc33467b9c3282260"
 dependencies = [
  "getrandom",
  "phc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ opt-level = 2
 argon2 = { path = "./argon2" }
 pbkdf2 = { path = "./pbkdf2" }
 scrypt = { path = "./scrypt" }
+
+password-hash = { git = "https://github.com/RustCrypto/traits" }

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -709,7 +709,10 @@ impl From<&Params> for Argon2<'_> {
 #[cfg(all(test, feature = "alloc", feature = "password-hash"))]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use crate::{Algorithm, Argon2, CustomizedPasswordHasher, Params, PasswordHasher, Version};
+    use crate::{
+        Algorithm, Argon2, CustomizedPasswordHasher, Params, PasswordHasher, PasswordVerifier,
+        Version,
+    };
 
     /// Example password only: don't use this as a real password!!!
     const EXAMPLE_PASSWORD: &[u8] = b"hunter42";
@@ -755,5 +758,18 @@ mod tests {
                 value,
             );
         }
+    }
+
+    #[test]
+    fn non_default_output_len_round_trip_should_verify() {
+        let params = Params::new(8, 1, 1, Some(16)).unwrap();
+        let hash = Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+            .hash_password_with_salt(EXAMPLE_PASSWORD, EXAMPLE_SALT)
+            .unwrap();
+
+        assert_eq!(
+            Argon2::default().verify_password(EXAMPLE_PASSWORD, &hash),
+            Ok(())
+        );
     }
 }


### PR DESCRIPTION
This adds a test that non-default output lengths are correctly supported which was implemented in RustCrypto/traits#2370