### PR TITLE
pbkdf2: apply workspace-level lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-consts = true
+allow-unwrap-in-tests = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,45 @@ exclude = ["benches", "fuzz"]
 [profile.dev]
 opt-level = 2
 
+[workspace.lints.clippy]
+borrow_as_ptr = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+checked_conversions = "warn"
+doc_markdown = "warn"
+from_iter_instead_of_collect = "warn"
+implicit_saturating_sub = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+needless_range_loop = "allow"
+ptr_as_ptr = "warn"
+redundant_closure_for_method_calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unwrap_used = "warn"
+
+[workspace.lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+
 [patch.crates-io]
 argon2 = { path = "./argon2" }
 pbkdf2 = { path = "./pbkdf2" }

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -42,5 +42,8 @@ phc = ["password-hash/phc", "sha2"]
 rand_core = ["password-hash/rand_core"]
 sha2 = ["hmac", "dep:sha2"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/pbkdf2/README.md
+++ b/pbkdf2/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: PBKDF2
+# [RustCrypto]: PBKDF2
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -40,7 +40,8 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/password-hashes/workflows/pbkdf2/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/password-hashes/actions?query=workflow%3Apbkdf2
 
-[//]: # (general links)
+[//]: # (links)
 
+[RustCrypto]: https://github.com/RustCrypto
 [1]: https://en.wikipedia.org/wiki/PBKDF2
 [2]: https://datatracker.ietf.org/doc/html/rfc2898

--- a/pbkdf2/src/algorithm.rs
+++ b/pbkdf2/src/algorithm.rs
@@ -47,12 +47,16 @@ impl Algorithm {
     pub const RECOMMENDED: Self = Self::Pbkdf2Sha256;
 
     /// Parse an [`Algorithm`] from the provided string.
+    ///
+    /// # Errors
+    /// If the provided algorithm `id` is not known/supported.
     #[cfg(feature = "password-hash")]
     pub fn new(id: impl AsRef<str>) -> password_hash::Result<Self> {
         id.as_ref().parse()
     }
 
     /// Get the Modular Crypt Format algorithm identifier for this algorithm.
+    #[must_use]
     pub const fn to_str(self) -> &'static str {
         match self {
             #[cfg(feature = "sha2")]

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -155,6 +155,9 @@ where
 ///     .expect("HMAC can be initialized with any key length");
 /// assert_eq!(buf, hex!("669cfe52482116fda1aa2cbe409b2f56c8e45637"));
 /// ```
+///
+/// # Errors
+/// Returns `InvalidLength` if the length of `password` is unsupported by `PRF`.
 #[inline]
 pub fn pbkdf2<PRF>(
     password: &[u8],
@@ -169,6 +172,7 @@ where
     let prf = PRF::new_from_slice(password)?;
 
     for (i, chunk) in res.chunks_mut(n).enumerate() {
+        #[allow(clippy::cast_possible_truncation, reason = "TODO")]
         pbkdf2_body(i as u32, chunk, &prf, salt, rounds);
     }
 
@@ -186,6 +190,9 @@ where
 ///     .expect("HMAC can be initialized with any key length");
 /// assert_eq!(res, hex!("669cfe52482116fda1aa2cbe409b2f56c8e45637"));
 /// ```
+///
+/// # Errors
+/// Returns `InvalidLength` if the length of `password` is unsupported by `PRF`.
 #[inline]
 pub fn pbkdf2_array<PRF, const N: usize>(
     password: &[u8],
@@ -213,6 +220,7 @@ where
 /// assert_eq!(buf, hex!("669cfe52482116fda1aa2cbe409b2f56c8e45637"));
 /// ```
 #[cfg(feature = "hmac")]
+#[allow(clippy::missing_panics_doc, reason = "condition should not occur")]
 pub fn pbkdf2_hmac<D: EagerHash>(password: &[u8], salt: &[u8], rounds: u32, res: &mut [u8]) {
     pbkdf2::<hmac::Hmac<D>>(password, salt, rounds, res)
         .expect("HMAC can be initialized with any key length");
@@ -232,6 +240,7 @@ pub fn pbkdf2_hmac<D: EagerHash>(password: &[u8], salt: &[u8], rounds: u32, res:
 /// );
 /// ```
 #[cfg(feature = "hmac")]
+#[must_use]
 pub fn pbkdf2_hmac_array<D: EagerHash, const N: usize>(
     password: &[u8],
     salt: &[u8],
@@ -310,6 +319,7 @@ impl Pbkdf2 {
 #[cfg(feature = "sha2")]
 impl Pbkdf2 {
     /// Initialize [`Pbkdf2`] with default parameters.
+    #[must_use]
     pub const fn new(algorithm: Algorithm, params: Params) -> Self {
         Self { algorithm, params }
     }

--- a/pbkdf2/src/mcf.rs
+++ b/pbkdf2/src/mcf.rs
@@ -124,8 +124,8 @@ impl PasswordVerifier<PasswordHashRef> for Pbkdf2 {
     }
 }
 
-// TODO(tarcieri): tests for SHA-1
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::Pbkdf2;
     use mcf::PasswordHashRef;

--- a/pbkdf2/src/params.rs
+++ b/pbkdf2/src/params.rs
@@ -63,6 +63,7 @@ impl Params {
     };
 
     /// Recommended PBKDF2 parameters for the selected algorithm.
+    #[must_use]
     pub const fn recommended_for(algorithm: Algorithm) -> Self {
         let rounds = match algorithm {
             Algorithm::Pbkdf2Sha256 => Self::RECOMMENDED_ROUNDS,
@@ -76,12 +77,20 @@ impl Params {
     }
 
     /// Create new params with the given number of rounds.
+    ///
+    /// # Errors
+    /// If the number of rounds is less than [`Params::MIN_ROUNDS`].
     #[cfg(feature = "password-hash")]
     pub const fn new(rounds: u32) -> Result<Self> {
         Self::new_with_output_len(rounds, Self::RECOMMENDED_OUTPUT_LENGTH)
     }
 
     /// Create new params with a customized output length.
+    ///
+    /// # Errors
+    /// - If the number of rounds is less than [`Params::MIN_ROUNDS`].
+    /// - If `output_len` is shorter than [`Params::MIN_OUTPUT_LENGTH`].
+    /// - If `output_len` is longer than [`Params::MAX_OUTPUT_LENGTH`].
     #[cfg(feature = "password-hash")]
     pub const fn new_with_output_len(rounds: u32, output_len: usize) -> Result<Self> {
         if rounds < Self::MIN_ROUNDS
@@ -95,11 +104,13 @@ impl Params {
     }
 
     /// Get the number of rounds.
+    #[must_use]
     pub const fn rounds(self) -> u32 {
         self.rounds
     }
 
     /// Get the output length.
+    #[must_use]
     pub const fn output_len(self) -> usize {
         self.output_len
     }
@@ -141,7 +152,7 @@ impl TryFrom<u32> for Params {
 impl TryFrom<&ParamsString> for Params {
     type Error = Error;
 
-    fn try_from(params_string: &ParamsString) -> password_hash::Result<Self> {
+    fn try_from(params_string: &ParamsString) -> Result<Self> {
         let mut rounds = Params::RECOMMENDED_ROUNDS;
         let mut output_len = Params::RECOMMENDED_OUTPUT_LENGTH;
 
@@ -179,7 +190,7 @@ impl TryFrom<&ParamsString> for Params {
 impl TryFrom<&phc::PasswordHash> for Params {
     type Error = Error;
 
-    fn try_from(hash: &phc::PasswordHash) -> password_hash::Result<Self> {
+    fn try_from(hash: &phc::PasswordHash) -> Result<Self> {
         if hash.version.is_some() {
             return Err(Error::Version);
         }
@@ -200,7 +211,7 @@ impl TryFrom<&phc::PasswordHash> for Params {
 impl TryFrom<Params> for ParamsString {
     type Error = Error;
 
-    fn try_from(params: Params) -> password_hash::Result<ParamsString> {
+    fn try_from(params: Params) -> Result<ParamsString> {
         Self::try_from(&params)
     }
 }
@@ -209,10 +220,11 @@ impl TryFrom<Params> for ParamsString {
 impl TryFrom<&Params> for ParamsString {
     type Error = Error;
 
-    fn try_from(input: &Params) -> password_hash::Result<ParamsString> {
+    fn try_from(input: &Params) -> Result<ParamsString> {
         let mut output = ParamsString::new();
+        let output_len = Decimal::try_from(input.output_len).map_err(|_| Error::OutputSize)?;
 
-        for (name, value) in [("i", input.rounds), ("l", input.output_len as Decimal)] {
+        for (name, value) in [("i", input.rounds), ("l", output_len)] {
             output
                 .add_decimal(name, value)
                 .map_err(|_| Error::ParamInvalid { name })?;

--- a/pbkdf2/tests/pbkdf2.rs
+++ b/pbkdf2/tests/pbkdf2.rs
@@ -1,4 +1,7 @@
+//! Integration tests.
+
 #![cfg(feature = "hmac")]
+#![allow(clippy::unwrap_used)]
 
 use belt_hash::BeltHash;
 use hex_literal::hex;
@@ -23,8 +26,7 @@ macro_rules! test {
     };
 }
 
-/// Test vectors from RFC 6070:
-/// https://www.rfc-editor.org/rfc/rfc6070
+/// Test vectors from RFC 6070: <https://www.rfc-editor.org/rfc/rfc6070>
 #[test]
 fn pbkdf2_rfc6070() {
     test!(
@@ -40,8 +42,7 @@ fn pbkdf2_rfc6070() {
     );
 }
 
-/// Test vectors from R 50.1.111-2016:
-/// https://tc26.ru/standard/rs/Р%2050.1.111-2016.pdf
+/// Test vectors from R 50.1.111-2016: <https://tc26.ru/standard/rs/Р%2050.1.111-2016.pdf>
 #[test]
 fn pbkdf2_streebog() {
     test!(
@@ -84,7 +85,7 @@ fn pbkdf2_streebog() {
 }
 
 /// Test vector from STB 34.101.45-2013 (page 33):
-/// https://apmi.bsu.by/assets/files/std/bign-spec294.pdf
+/// <https://apmi.bsu.by/assets/files/std/bign-spec294.pdf>
 #[test]
 fn pbkdf2_belt() {
     test!(


### PR DESCRIPTION
Adds the workspace-level config from RustCrypto/utils#1411 to this repo and applies it to `pbkdf2`.