### PR TITLE
balloon-hash: bump `crypto-bigint` to v0.7

### DIFF
--- a/balloon-hash/Cargo.toml
+++ b/balloon-hash/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = { version = "0.11", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.25", default-features = false, features = ["hybrid-array"] }
+crypto-bigint = { version = "0.7", default-features = false, features = ["hybrid-array"] }
 
 # optional dependencies
 kdf = { version = "0.1", optional = true }


### PR DESCRIPTION
Release PR: RustCrypto/crypto-bigint#1218