### PR TITLE
argon2: enable and fix workspace-level lints

### DIFF
--- a/argon2/Cargo.toml
+++ b/argon2/Cargo.toml
@@ -43,6 +43,45 @@ password-hash = ["dep:password-hash"]
 rand_core = ["password-hash/rand_core"]
 zeroize = ["dep:zeroize"]
 
+[lints.clippy]
+borrow_as_ptr = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+checked_conversions = "warn"
+doc_markdown = "warn"
+from_iter_instead_of_collect = "warn"
+implicit_saturating_sub = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+needless_range_loop = "allow"
+ptr_as_ptr = "warn"
+redundant_closure_for_method_calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unwrap_used = "warn"
+
+[lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(test_large_ram)']

--- a/argon2/README.md
+++ b/argon2/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Argon2
+# [RustCrypto]: Argon2
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -53,6 +53,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
+[RustCrypto]: https://github.com/RustCrypto
 [Argon2]: https://en.wikipedia.org/wiki/Argon2
 [key derivation function]: https://en.wikipedia.org/wiki/Key_derivation_function
 [Password Hashing Competition]: https://www.password-hashing.net/

--- a/argon2/src/algorithm.rs
+++ b/argon2/src/algorithm.rs
@@ -50,11 +50,15 @@ pub enum Algorithm {
 
 impl Algorithm {
     /// Parse an [`Algorithm`] from the provided string.
+    ///
+    /// # Errors
+    /// Returns [`Error::AlgorithmInvalid`] if `id` is not a valid Argon2 algorithm identifier.
     pub fn new(id: impl AsRef<str>) -> Result<Self> {
         id.as_ref().parse()
     }
 
     /// Get the identifier string for this PBKDF2 [`Algorithm`].
+    #[must_use]
     pub const fn as_str(&self) -> &'static str {
         match self {
             Algorithm::Argon2d => "argon2d",
@@ -65,6 +69,7 @@ impl Algorithm {
 
     /// Get the [`Ident`] that corresponds to this Argon2 [`Algorithm`].
     #[cfg(feature = "password-hash")]
+    #[must_use]
     pub const fn ident(&self) -> Ident {
         match self {
             Algorithm::Argon2d => ARGON2D_IDENT,

--- a/argon2/src/blake2b_long.rs
+++ b/argon2/src/blake2b_long.rs
@@ -17,7 +17,7 @@ pub fn blake2b_long(inputs: &[&[u8]], out: &mut [u8]) -> Result<()> {
     }
 
     let len_bytes = u32::try_from(out.len())
-        .map(|v| v.to_le_bytes())
+        .map(u32::to_le_bytes)
         .map_err(|_| Error::OutputTooLong)?;
 
     // Use blake2b directly if the output is small enough.

--- a/argon2/src/block.rs
+++ b/argon2/src/block.rs
@@ -55,6 +55,7 @@ impl Block {
     pub const SIZE: usize = 1024;
 
     /// Returns a Block initialized with zeros.
+    #[must_use]
     pub const fn new() -> Self {
         Self([0u64; Self::SIZE / 8])
     }

--- a/argon2/src/lib.rs
+++ b/argon2/src/lib.rs
@@ -237,6 +237,7 @@ impl fmt::Debug for Argon2<'_> {
 
 impl<'key> Argon2<'key> {
     /// Create a new Argon2 context.
+    #[must_use]
     pub fn new(algorithm: Algorithm, version: Version, params: Params) -> Self {
         Self {
             algorithm,
@@ -249,6 +250,9 @@ impl<'key> Argon2<'key> {
     }
 
     /// Create a new Argon2 context.
+    ///
+    /// # Errors
+    /// Returns [`Error::SecretTooLong`] in the event `secret` is too long.
     pub fn new_with_secret(
         secret: &'key [u8],
         algorithm: Algorithm,
@@ -270,6 +274,13 @@ impl<'key> Argon2<'key> {
     }
 
     /// Hash a password and associated parameters into the provided output buffer.
+    ///
+    /// # Errors
+    /// - Returns [`Error::PwdTooLong`] if `pwd` is longer than `MAX_PWD_LEN`.
+    /// - Returns [`Error::SaltTooShort`] if `salt` is shorter than `MIN_SALT_LEN`.
+    /// - Returns [`Error::SaltTooLong`] if `salt` is longer than `MAX_SALT_LEN`.
+    /// - Returns [`Error::OutputTooShort`] if `out` is too short.
+    /// - Returns [`Error::OutputTooLong`] if `out` is too long.
     #[cfg(feature = "alloc")]
     pub fn hash_password_into(&self, pwd: &[u8], salt: &[u8], out: &mut [u8]) -> Result<()> {
         let blocks_len = self.params.block_count();
@@ -286,6 +297,13 @@ impl<'key> Argon2<'key> {
     ///   to have it allocated for them.
     /// - `no_std` users on "heapless" targets can use an array of the [`Block`] type
     ///   to stack allocate this buffer.
+    ///
+    /// # Errors
+    /// - Returns [`Error::PwdTooLong`] if `pwd` is longer than `MAX_PWD_LEN`.
+    /// - Returns [`Error::SaltTooShort`] if `salt` is shorter than `MIN_SALT_LEN`.
+    /// - Returns [`Error::SaltTooLong`] if `salt` is longer than `MAX_SALT_LEN`.
+    /// - Returns [`Error::OutputTooShort`] if `out` is too short.
+    /// - Returns [`Error::OutputTooLong`] if `out` is too long.
     pub fn hash_password_into_with_memory(
         &self,
         pwd: &[u8],
@@ -306,7 +324,6 @@ impl<'key> Argon2<'key> {
 
         // Hashing all inputs
         let initial_hash = self.initial_hash(pwd, salt, out);
-
         self.fill_blocks(memory_blocks.as_mut(), initial_hash)?;
         self.finalize(memory_blocks.as_mut(), out)
     }
@@ -316,6 +333,11 @@ impl<'key> Argon2<'key> {
     /// This method omits the calculation of a hash and can be used when only the
     /// filled memory is required. It is not necessary to call this method
     /// before calling any of the hashing functions.
+    ///
+    /// # Errors
+    /// - Returns [`Error::PwdTooLong`] if `pwd` is longer than `MAX_PWD_LEN`.
+    /// - Returns [`Error::SaltTooShort`] if `salt` is shorter than `MIN_SALT_LEN`.
+    /// - Returns [`Error::SaltTooLong`] if `salt` is longer than `MAX_SALT_LEN`.
     pub fn fill_memory(
         &self,
         pwd: &[u8],
@@ -325,7 +347,6 @@ impl<'key> Argon2<'key> {
         Self::verify_inputs(pwd, salt)?;
 
         let initial_hash = self.initial_hash(pwd, salt, &[]);
-
         self.fill_blocks(memory_blocks.as_mut(), initial_hash)
     }
 
@@ -521,6 +542,7 @@ impl<'key> Argon2<'key> {
     }
 
     /// Get default configured [`Params`].
+    #[must_use]
     pub const fn params(&self) -> &Params {
         &self.params
     }
@@ -540,7 +562,7 @@ impl<'key> Argon2<'key> {
         let mut blockhash_bytes = [0u8; Block::SIZE];
 
         for (chunk, v) in blockhash_bytes.chunks_mut(8).zip(blockhash.iter()) {
-            chunk.copy_from_slice(&v.to_le_bytes())
+            chunk.copy_from_slice(&v.to_le_bytes());
         }
 
         blake2b_long(&[&blockhash_bytes], out)?;

--- a/argon2/src/memory.rs
+++ b/argon2/src/memory.rs
@@ -8,6 +8,8 @@
 //! > length of q/SL. Segments of the same slice can be computed in parallel and do not reference
 //! > blocks from each other. All other blocks can be referenced.
 
+#![allow(clippy::unnecessary_safety_comment)]
+
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 

--- a/argon2/src/params.rs
+++ b/argon2/src/params.rs
@@ -1,5 +1,8 @@
 //! Argon2 password hash parameters.
 
+#![allow(missing_copy_implementations, reason = "unnecessary")]
+#![allow(clippy::doc_markdown, reason = "false positive")]
+
 use crate::{Algorithm, Argon2, Error, Result, SYNC_POINTS, Version};
 use base64ct::{Base64Unpadded as B64, Encoding};
 use core::str::FromStr;
@@ -107,6 +110,16 @@ impl Params {
     /// - `t_cost`: number of iterations. Between 1 and (2^32)-1.
     /// - `p_cost`: degree of parallelism. Between 1 and (2^24)-1.
     /// - `output_len`: size of the KDF output in bytes. Default 32.
+    ///
+    /// # Errors
+    /// - Returns [`Error::MemoryTooLittle`] if `m_cost` is smaller than [`Params::MIN_M_COST`].
+    /// - Returns [`Error::ThreadsTooFew`] if `p_cost` is smaller than [`Params::MIN_P_COST`].
+    /// - Returns [`Error::ThreadsTooMany`] if `p_cost` is larger than [`Params::MAX_P_COST`].
+    /// - Returns [`Error::TimeTooSmall`] if `t_cost` is smaller than [`Params::MIN_T_COST`].
+    /// - Returns [`Error::OutputTooShort`] if `output_len` is smaller than
+    ///   [`Params::MIN_OUTPUT_LEN`].
+    /// - Returns [`Error::OutputTooLong`] if `output_len` is larger than
+    ///   [`Params::MAX_OUTPUT_LEN`].
     pub const fn new(
         m_cost: u32,
         t_cost: u32,
@@ -160,6 +173,7 @@ impl Params {
     /// Memory size, expressed in kibibytes. Between 8\*`p_cost` and (2^32)-1.
     ///
     /// Value is an integer in decimal (1 to 10 digits).
+    #[must_use]
     pub const fn m_cost(&self) -> u32 {
         self.m_cost
     }
@@ -167,6 +181,7 @@ impl Params {
     /// Number of iterations. Between 1 and (2^32)-1.
     ///
     /// Value is an integer in decimal (1 to 10 digits).
+    #[must_use]
     pub const fn t_cost(&self) -> u32 {
         self.t_cost
     }
@@ -174,6 +189,7 @@ impl Params {
     /// Degree of parallelism. Between 1 and (2^24)-1.
     ///
     /// Value is an integer in decimal (1 to 3 digits).
+    #[must_use]
     pub const fn p_cost(&self) -> u32 {
         self.p_cost
     }
@@ -189,6 +205,7 @@ impl Params {
     /// On top of that, this field is not longer part of the Argon2 standard
     /// (see: <https://github.com/P-H-C/phc-winner-argon2/pull/173>), and should
     /// not be used for any non-legacy work.
+    #[must_use]
     pub fn keyid(&self) -> &[u8] {
         self.keyid.as_bytes()
     }
@@ -200,11 +217,13 @@ impl Params {
     /// This field is not longer part of the argon2 standard
     /// (see: <https://github.com/P-H-C/phc-winner-argon2/pull/173>), and should
     /// not be used for any non-legacy work.
+    #[must_use]
     pub fn data(&self) -> &[u8] {
         self.data.as_bytes()
     }
 
     /// Length of the output (in bytes).
+    #[must_use]
     pub const fn output_len(&self) -> Option<usize> {
         self.output_len
     }
@@ -222,7 +241,7 @@ impl Params {
 
     /// Get the segment length given the configured `m_cost` and `p_cost`.
     ///
-    /// Minimum memory_blocks = 8*`L` blocks, where `L` is the number of lanes.
+    /// Minimum `memory_blocks` = 8*`L` blocks, where `L` is the number of lanes.
     pub(crate) const fn segment_length(&self) -> usize {
         let m_cost = self.m_cost as usize;
 
@@ -236,6 +255,7 @@ impl Params {
     }
 
     /// Get the number of blocks required given the configured `m_cost` and `p_cost`.
+    #[must_use]
     pub const fn block_count(&self) -> usize {
         self.segment_length() * self.lanes() * SYNC_POINTS
     }
@@ -265,12 +285,13 @@ macro_rules! param_buf {
 
             #[doc = "Create a new"]
             #[doc = $name]
-            #[doc = "from a slice."]
+            #[doc = "from a slice.\n"]
+            #[doc = "# Errors"]
+            #[doc = concat!("Returns [`", stringify!($error), "`] in event the provided slice is too long.")]
             pub fn new(slice: &[u8]) -> Result<Self> {
                 let mut bytes = [0u8; Self::MAX_LEN];
                 let len = slice.len();
                 bytes.get_mut(..len).ok_or($error)?.copy_from_slice(slice);
-
                 Ok(Self { bytes, len })
             }
 
@@ -282,11 +303,12 @@ macro_rules! param_buf {
 
             #[doc = "Decode"]
             #[doc = $name]
-            #[doc = " from a B64 string"]
+            #[doc = " from a B64 string.\n"]
+            #[doc = "# Errors"]
+            #[doc = "Returns [`Error::B64Encoding`] if the providing string couldn't be decoded as B64." ]
             pub fn from_b64(s: &str) -> Result<Self> {
                 let mut bytes = [0u8; Self::MAX_LEN];
                 let len = B64::decode(s, &mut bytes)?.len();
-
                 Ok(Self { bytes, len })
             }
 
@@ -490,6 +512,7 @@ pub struct ParamsBuilder {
 
 impl ParamsBuilder {
     /// Create a new builder with the default parameters.
+    #[must_use]
     pub const fn new() -> Self {
         Self::DEFAULT
     }
@@ -534,6 +557,10 @@ impl ParamsBuilder {
     ///
     /// This performs validations to ensure that the given parameters are valid
     /// and compatible with each other, and will return an error if they are not.
+    ///
+    /// # Errors
+    /// Propagates errors from [`Params::new`]. See error documentation for that function for
+    /// additional information.
     pub const fn build(&self) -> Result<Params> {
         let mut params = match Params::new(self.m_cost, self.t_cost, self.p_cost, self.output_len) {
             Ok(params) => params,
@@ -552,9 +579,14 @@ impl ParamsBuilder {
     }
 
     /// Create a new [`Argon2`] context using the provided algorithm/version.
+    ///
+    /// # Errors
+    /// Propagates errors from [`Params::new`]. See error documentation for that function for
+    /// additional information.
     pub fn context(&self, algorithm: Algorithm, version: Version) -> Result<Argon2<'_>> {
         Ok(Argon2::new(algorithm, version, self.build()?))
     }
+
     /// Default parameters (recommended).
     pub const DEFAULT: ParamsBuilder = {
         let params = Params::DEFAULT;

--- a/argon2/tests/kat.rs
+++ b/argon2/tests/kat.rs
@@ -5,6 +5,7 @@
 //! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-argon2/>
 
 #![cfg(all(feature = "alloc", feature = "password-hash"))]
+#![allow(clippy::unwrap_used, reason = "tests")]
 
 // TODO(tarcieri): test full set of vectors from the reference implementation:
 // https://github.com/P-H-C/phc-winner-argon2/blob/master/src/test.c


### PR DESCRIPTION
Since there's already a `cfg(test_large_ram)` this copies the workspace-level lints into `argon2/Cargo.toml`, however in future Rust versions it should be possible to use both `lints.workspace = true` and additional customization.