### PR TITLE
scrypt: enable and fix workspace-level lints

### DIFF
--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -36,5 +36,8 @@ phc = ["password-hash/phc"]
 rand_core = ["password-hash/rand_core"]
 parallel = ["dep:rayon"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/scrypt/README.md
+++ b/scrypt/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: scrypt
+# [RustCrypto]: scrypt
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -7,7 +7,7 @@
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 
-Pure Rust implementation of the [scrypt key derivation function][1], a sequential memory hard
+Pure Rust implementation of the [scrypt key derivation function][scrypt], a sequential memory hard
 function which can also be used for password hashing.
 
 ## License
@@ -38,6 +38,7 @@ dual licensed as above, without any additional terms or conditions.
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 
-[//]: # (general links)
+[//]: # (links)
 
-[1]: https://www.tarsnap.com/scrypt.html
+[RustCrypto]: https://github.com/RustCrypto
+[scrypt]: https://www.tarsnap.com/scrypt.html

--- a/scrypt/src/block_mix.rs
+++ b/scrypt/src/block_mix.rs
@@ -3,22 +3,29 @@ cfg_if::cfg_if! {
         mod pivot;
         mod simd128;
         pub(crate) use simd128::{scrypt_block_mix, shuffle_in, shuffle_out};
+
+        #[cfg(test)]
+        #[path = "block_mix/soft.rs"]
+        mod soft_test;
     } else if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "sse2"))] {
         mod pivot;
         mod sse2;
         pub(crate) use sse2::{scrypt_block_mix, shuffle_in, shuffle_out};
+
+        #[cfg(test)]
+        #[path = "block_mix/soft.rs"]
+        mod soft_test;
     } else {
         mod soft;
         pub(crate) use soft::scrypt_block_mix;
 
         pub(crate) fn shuffle_in(_input: &mut [u8]) {}
         pub(crate) fn shuffle_out(_input: &mut [u8]) {}
+
+        #[cfg(test)]
+        use soft as soft_test;
     }
 }
-
-#[cfg(test)]
-#[path = "block_mix/soft.rs"]
-mod soft_test;
 
 #[cfg(test)]
 mod tests {
@@ -26,17 +33,24 @@ mod tests {
 
     #[test]
     fn test_scrypt_block_mix_abcd_against_soft() {
-        let mut input: [u8; 128] = core::array::from_fn(|i| i as u8);
+        let mut input: [u8; 128] = core::array::from_fn(|i| u8::try_from(i).unwrap());
+
         for _round in 0..10 {
             let mut output = [0u8; 128];
 
             let mut expected0 = [0u8; 128];
             let mut expected1 = [0u8; 128]; // check shuffle_out is a correct inverse of shuffle_in
+
+            #[allow(unused_qualifications, reason = "might be imported for `soft`")]
             soft_test::scrypt_block_mix(&input, &mut expected0);
+
             shuffle_in(&mut input);
             scrypt_block_mix(&input, &mut output);
             shuffle_out(&mut input);
+
+            #[allow(unused_qualifications, reason = "might be imported for `soft`")]
             soft_test::scrypt_block_mix(&input, &mut expected1);
+
             shuffle_out(&mut output);
             assert_eq!(
                 expected0, expected1,

--- a/scrypt/src/block_mix/pivot.rs
+++ b/scrypt/src/block_mix/pivot.rs
@@ -1,7 +1,7 @@
 /// Permute Salsa20 block to diagonal order
 pub(crate) const PIVOT_ABCD: [usize; 16] = [0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11];
 
-/// Inverse of PIVOT_ABCD
+/// Inverse of `PIVOT_ABCD`.
 pub(crate) const INVERSE_PIVOT_ABCD: [usize; 16] = const {
     let mut index = [0; 16];
     let mut i = 0;

--- a/scrypt/src/block_mix/soft.rs
+++ b/scrypt/src/block_mix/soft.rs
@@ -1,13 +1,25 @@
-/// Execute the BlockMix operation
-/// input - the input vector. The length must be a multiple of 128.
-/// output - the output vector. Must be the same length as input.
-pub(crate) fn scrypt_block_mix(input: &[u8], output: &mut [u8]) {
-    use salsa20::{
-        SalsaCore,
-        cipher::{StreamCipherCore, typenum::U4},
-    };
+//! Portable software implementation.
 
-    type Salsa20_8 = SalsaCore<U4>;
+#![allow(clippy::unwrap_used, reason = "switch to `as_chunks` when MSRV 1.88")]
+
+use salsa20::{
+    SalsaCore,
+    cipher::{StreamCipherCore, typenum::U4},
+};
+
+type Salsa20_8 = SalsaCore<U4>;
+
+/// Execute the `BlockMix` operation.
+///
+/// - `input`: the input vector. The length must be a multiple of 128.
+/// - `output`: the output vector. Must be the same length as input.
+pub(crate) fn scrypt_block_mix(input: &[u8], output: &mut [u8]) {
+    debug_assert_eq!(input.len() % 128, 0, "input must be a multiple of 128");
+    debug_assert_eq!(
+        output.len(),
+        input.len(),
+        "output must be same length as input"
+    );
 
     let mut x = [0u8; 64];
     x.copy_from_slice(&input[input.len() - 64..]);

--- a/scrypt/src/block_mix/sse2.rs
+++ b/scrypt/src/block_mix/sse2.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, reason = "switch to `as_chunks` when MSRV 1.88")]
+
 use crate::block_mix::pivot::{INVERSE_PIVOT_ABCD, PIVOT_ABCD};
 
 pub(crate) fn shuffle_in(b: &mut [u8]) {
@@ -24,6 +26,7 @@ pub(crate) fn shuffle_out(b: &mut [u8]) {
     }
 }
 
+#[allow(clippy::undocumented_unsafe_blocks, reason = "TODO")]
 pub(crate) fn scrypt_block_mix(input: &[u8], output: &mut [u8]) {
     #[cfg(target_arch = "x86")]
     use core::arch::x86::*;

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -81,14 +81,16 @@ use password_hash::{CustomizedPasswordHasher, PasswordHasher, PasswordVerifier};
 /// # Arguments
 /// - `password` - The password to process as a byte vector
 /// - `salt` - The salt value to use as a byte vector
-/// - `params` - The ScryptParams to use
+/// - `params` - The `ScryptParams` to use
 /// - `output` - The resulting derived key is returned in this byte vector.
 ///   **WARNING: Make sure to compare this value in constant time!**
 ///
-/// # Return
-/// `Ok(())` if calculation is successful and `Err(InvalidOutputLen)` if
-/// `output` does not satisfy the following condition:
-/// `output.len() > 0 && output.len() <= (2^32 - 1) * 32`.
+/// # Errors
+/// Returns [`errors::InvalidOutputLen`] if `output` does not satisfy the following condition:
+///
+/// ```text
+/// output.len() > 0 && output.len() <= (2^32 - 1) * 32
+/// ```
 ///
 /// # Note about output lengths
 /// The output size is determined entirely by size of the `output` parameter.
@@ -164,6 +166,7 @@ pub struct Scrypt {
 #[cfg(any(feature = "kdf", feature = "mcf", feature = "phc"))]
 impl Scrypt {
     /// Initialize [`Scrypt`] with default parameters.
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             params: Params::RECOMMENDED,
@@ -171,6 +174,7 @@ impl Scrypt {
     }
 
     /// Initialize [`Scrypt`] with the provided parameters.
+    #[must_use]
     pub const fn new_with_params(params: Params) -> Self {
         Self { params }
     }

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -54,27 +54,33 @@ impl Params {
     /// - `log_n` must be less than `64`
     /// - `r` must be greater than `0` and less than or equal to `4294967295`
     /// - `p` must be greater than `0` and less than `4294967295`
+    ///
+    /// # Errors
+    /// Returns [`InvalidParams`] if one of the parameters is incorrect.
     pub fn new(log_n: u8, r: u32, p: u32) -> Result<Params, InvalidParams> {
         let cond1 = (log_n as usize) < usize::BITS as usize;
         let cond2 = size_of::<usize>() >= size_of::<u32>();
-        let cond3 = r <= usize::MAX as u32 && p < usize::MAX as u32;
+        let cond3 = usize::try_from(r).is_ok() && usize::try_from(p).is_ok();
         if !(r > 0 && p > 0 && cond1 && (cond2 || cond3)) {
             return Err(InvalidParams);
         }
 
-        let r = r as usize;
-        let p = p as usize;
-
-        let n: usize = 1 << log_n;
+        let n = 1usize << log_n;
 
         // check that r * 128 doesn't overflow
-        let r128 = r.checked_mul(128).ok_or(InvalidParams)?;
+        let r128 = usize::try_from(r)
+            .map_err(|_| InvalidParams)?
+            .checked_mul(128)
+            .ok_or(InvalidParams)?;
 
         // check that n * r * 128 doesn't overflow
         r128.checked_mul(n).ok_or(InvalidParams)?;
 
         // check that p * r * 128 doesn't overflow
-        r128.checked_mul(p).ok_or(InvalidParams)?;
+        usize::try_from(p)
+            .ok()
+            .and_then(|p| r128.checked_mul(p))
+            .ok_or(InvalidParams)?;
 
         // Note: RFC 7914 requires `n < 2^(128 * r / 8)`, i.e. `log_n < r * 16`,
         // but this upper bound is based on an error in the RFC where a bit count
@@ -96,8 +102,8 @@ impl Params {
 
         Ok(Params {
             log_n,
-            r: r as u32,
-            p: p as u32,
+            r,
+            p,
             #[cfg(feature = "password-hash")]
             len: None,
         })
@@ -112,6 +118,9 @@ impl Params {
     /// The allowed values for `len` are between 10 bytes (80 bits) and 64 bytes inclusive.
     /// These lengths come from the [PHC string format specification](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md)
     /// because they are intended for use with password hash strings.
+    ///
+    /// # Errors
+    /// Returns [`InvalidParams`] if one of the parameters is incorrect.
     #[cfg(feature = "phc")]
     pub fn new_with_output_len(
         log_n: u8,
@@ -130,6 +139,7 @@ impl Params {
 
     /// Deprecated: recommended values according to the OWASP cheat sheet.
     #[deprecated(since = "0.12.0", note = "use Params::RECOMMENDED instead")]
+    #[must_use]
     pub const fn recommended() -> Params {
         Self::RECOMMENDED
     }
@@ -138,6 +148,7 @@ impl Params {
     ///
     /// Memory and CPU usage scale linearly with `N`. If you need `N`, use
     /// [`Params::n`] instead.
+    #[must_use]
     pub const fn log_n(&self) -> u8 {
         self.log_n
     }
@@ -146,6 +157,7 @@ impl Params {
     ///
     /// This method returns 2 to the power of [`Params::log_n`]. Memory and CPU
     /// usage scale linearly with `N`.
+    #[must_use]
     pub const fn n(&self) -> u64 {
         1 << self.log_n
     }
@@ -154,11 +166,13 @@ impl Params {
     ///
     /// scrypt iterates 2*r times. Memory and CPU time scale linearly
     /// with this parameter.
+    #[must_use]
     pub const fn r(&self) -> u32 {
         self.r
     }
 
     /// `p` parameter: parallelization.
+    #[must_use]
     pub const fn p(&self) -> u32 {
         self.p
     }
@@ -217,11 +231,7 @@ impl TryFrom<&phc::PasswordHash> for Params {
 
         let mut params = Params::try_from(&hash.params)?;
 
-        params.len = Some(
-            hash.hash
-                .map(|out| out.len())
-                .unwrap_or(Self::RECOMMENDED_LEN),
-        );
+        params.len = Some(hash.hash.map_or(Self::RECOMMENDED_LEN, |out| out.len()));
 
         Ok(params)
     }
@@ -244,7 +254,7 @@ impl TryFrom<&Params> for phc::ParamsString {
         let mut output = phc::ParamsString::new();
 
         for (name, value) in [
-            ("ln", input.log_n as phc::Decimal),
+            ("ln", phc::Decimal::from(input.log_n)),
             ("r", input.r),
             ("p", input.p),
         ] {

--- a/scrypt/src/romix.rs
+++ b/scrypt/src/romix.rs
@@ -1,4 +1,4 @@
-/// Execute the ROMix operation in-place.
+/// Execute the `ROMix` operation in-place.
 /// b - the data to operate on
 /// v - a temporary variable to store the vector V
 /// t - a temporary variable to store the result of the xor
@@ -11,8 +11,12 @@ pub(crate) fn scrypt_ro_mix(b: &mut [u8], v: &mut [u8], t: &mut [u8], n: usize) 
         let mask = n - 1;
         // This cast is safe since we're going to get the value mod n (which is a power of 2), so we
         // don't have to care about truncating any of the high bits off
-        //let result = (LittleEndian::read_u32(&x[x.len() - 64..x.len() - 60]) as usize) & mask;
-        let t = u32::from_le_bytes(x[x.len() - 64..x.len() - 60].try_into().unwrap());
+        let t = u32::from_le_bytes(
+            x[x.len() - 64..x.len() - 60]
+                .try_into()
+                .expect("incorrect length"),
+        );
+
         (t as usize) & mask
     }
 

--- a/scrypt/tests/mod.rs
+++ b/scrypt/tests/mod.rs
@@ -1,3 +1,5 @@
+//! Integration tests.
+
 use scrypt::{Params, scrypt};
 
 struct Test {


### PR DESCRIPTION
Enables and fixes the workspace-level lints added in #884, which is a standard configuration we're using across repositories