### PR TITLE
sha-crypt: enable and fix workspace-level lints

### DIFF
--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -32,5 +32,8 @@ getrandom = ["password-hash/getrandom", "password-hash"]
 rand_core = ["password-hash/rand_core"]
 password-hash = ["dep:ctutils", "dep:mcf", "dep:password-hash"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/sha-crypt/README.md
+++ b/sha-crypt/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: SHA-crypt password hash
+# [RustCrypto]: SHA-crypt password hash
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -7,11 +7,11 @@
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 
-Pure Rust implementation of the [SHA-crypt password hash based on SHA-256/SHA-512][1],
-a legacy password hashing scheme supported by the [POSIX crypt C library][2].
+Pure Rust implementation of the [SHA-crypt password hash based on SHA-256/SHA-512][SHA-crypt],
+a legacy password hashing scheme supported by the [POSIX crypt C library][crypt].
 
-Password hashes using this algorithm start with `$5$` or `$6$` when encoded
-using the [Modular Crypt Format][3].
+Password hashes using this algorithm start with `$5$` or `$6$` when encoded using the
+[Modular Crypt Format (MCF)][MCF].
 
 ## License
 
@@ -41,8 +41,9 @@ dual licensed as above, without any additional terms or conditions.
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 
-[//]: # (general links)
+[//]: # (links)
 
-[1]: https://www.akkadia.org/drepper/SHA-crypt.txt
-[2]: https://en.wikipedia.org/wiki/Crypt_(C)
-[3]: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html
+[RustCrypto]: https://github.com/RustCrypto
+[SHA-crypt]: https://www.akkadia.org/drepper/SHA-crypt.txt
+[crypt]: https://en.wikipedia.org/wiki/Crypt_(C)
+[MCF]: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html

--- a/sha-crypt/src/algorithm.rs
+++ b/sha-crypt/src/algorithm.rs
@@ -30,11 +30,15 @@ impl Algorithm {
     const RECOMMENDED: Self = Self::Sha512Crypt;
 
     /// Parse an [`Algorithm`] from the provided string.
+    ///
+    /// # Errors
+    /// Returns [`Error::Algorithm`] if `id` is not `5` (SHA-256) or `6` (SHA-512).
     pub fn new(id: impl AsRef<str>) -> password_hash::Result<Self> {
         id.as_ref().parse()
     }
 
     /// Get the Modular Crypt Format algorithm identifier for this algorithm.
+    #[must_use]
     pub const fn to_str(self) -> &'static str {
         match self {
             Algorithm::Sha256Crypt => Self::SHA256_CRYPT_IDENT,

--- a/sha-crypt/src/errors.rs
+++ b/sha-crypt/src/errors.rs
@@ -9,7 +9,7 @@ use crate::Params;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Error {
     /// Parameters are invalid (e.g. parse error)
     ParamsInvalid,

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -71,6 +71,7 @@ pub const BLOCK_SIZE_SHA512: usize = 64;
 /// - `params`: the parameters to use
 ///
 ///   **WARNING: Make sure to compare this value in constant time!**
+#[must_use]
 pub fn sha256_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_SIZE_SHA256] {
     let pw_len = password.len();
 
@@ -160,6 +161,7 @@ pub fn sha256_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 /// - `params` - The parameters to use
 ///
 ///   **WARNING: Make sure to compare this value in constant time!**
+#[must_use]
 pub fn sha512_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_SIZE_SHA512] {
     let pw_len = password.len();
 
@@ -281,7 +283,7 @@ fn sha256_crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SH
     }
 
     // 12.
-    hasher.finalize().as_slice().try_into().unwrap()
+    hasher.finalize().into()
 }
 
 fn sha512_crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SHA512] {
@@ -324,7 +326,7 @@ fn sha512_crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SH
     }
 
     // 12.
-    hasher.finalize().as_slice().try_into().unwrap()
+    hasher.finalize().into()
 }
 
 fn produce_byte_seq(len: usize, fill_from: &[u8]) -> Vec<u8> {

--- a/sha-crypt/src/mcf.rs
+++ b/sha-crypt/src/mcf.rs
@@ -30,6 +30,7 @@ impl ShaCrypt {
     pub const SHA512: Self = Self::new(Algorithm::Sha512Crypt, Params::RECOMMENDED);
 
     /// Create a new password hasher with customized algorithm and params.
+    #[must_use]
     pub const fn new(algorithm: Algorithm, params: Params) -> Self {
         Self { algorithm, params }
     }
@@ -141,7 +142,7 @@ impl PasswordVerifier<PasswordHashRef> for ShaCrypt {
 }
 
 impl PasswordVerifier<str> for ShaCrypt {
-    fn verify_password(&self, password: &[u8], hash: &str) -> password_hash::Result<()> {
+    fn verify_password(&self, password: &[u8], hash: &str) -> Result<()> {
         // TODO(tarcieri): better mapping from `mcf::Error` and `password_hash::Error`?
         let hash = PasswordHashRef::new(hash).map_err(|_| Error::EncodingInvalid)?;
         self.verify_password(password, hash)
@@ -168,32 +169,38 @@ impl From<Params> for ShaCrypt {
 
 /// SHA-256-crypt core function: uses an algorithm-specific transposition table.
 fn sha256_crypt_core(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_SIZE_SHA256] {
-    let output = super::sha256_crypt(password, salt, params);
-    let transposition_table = [
+    const TRANSPOSITION_TABLE: [usize; 32] = [
         20, 10, 0, 11, 1, 21, 2, 22, 12, 23, 13, 3, 14, 4, 24, 5, 25, 15, 26, 16, 6, 17, 7, 27, 8,
         28, 18, 29, 19, 9, 30, 31,
     ];
 
-    let mut transposed = [0u8; BLOCK_SIZE_SHA256];
-    for (i, &ti) in transposition_table.iter().enumerate() {
-        transposed[i] = output[ti as usize];
-    }
-
-    transposed
+    transpose(
+        &super::sha256_crypt(password, salt, params),
+        &TRANSPOSITION_TABLE,
+    )
 }
 
 /// SHA-512-crypt core function: uses an algorithm-specific transposition table.
 fn sha512_crypt_core(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_SIZE_SHA512] {
-    let output = super::sha512_crypt(password, salt, params);
-    let transposition_table = [
+    const TRANSPOSITION_TABLE: [usize; 64] = [
         42, 21, 0, 1, 43, 22, 23, 2, 44, 45, 24, 3, 4, 46, 25, 26, 5, 47, 48, 27, 6, 7, 49, 28, 29,
         8, 50, 51, 30, 9, 10, 52, 31, 32, 11, 53, 54, 33, 12, 13, 55, 34, 35, 14, 56, 57, 36, 15,
         16, 58, 37, 38, 17, 59, 60, 39, 18, 19, 61, 40, 41, 20, 62, 63,
     ];
 
-    let mut transposed = [0u8; BLOCK_SIZE_SHA512];
+    transpose(
+        &super::sha512_crypt(password, salt, params),
+        &TRANSPOSITION_TABLE,
+    )
+}
+
+/// Perform a transposition.
+#[inline]
+fn transpose<const N: usize>(bytes: &[u8], transposition_table: &[usize]) -> [u8; N] {
+    let mut transposed = [0u8; N];
+
     for (i, &ti) in transposition_table.iter().enumerate() {
-        transposed[i] = output[ti as usize];
+        transposed[i] = bytes[ti];
     }
 
     transposed

--- a/sha-crypt/src/params.rs
+++ b/sha-crypt/src/params.rs
@@ -33,6 +33,10 @@ impl Params {
     pub const ROUNDS_MAX: u32 = 999_999_999;
 
     /// Create new algorithm parameters.
+    ///
+    /// # Errors
+    /// Returns [`Error::RoundsInvalid`] if `rounds` is outside the range [`Params::ROUNDS_MIN`]
+    /// to [`Params::ROUNDS_MAX`] inclusive.
     pub fn new(rounds: u32) -> Result<Params> {
         match rounds {
             Self::ROUNDS_MIN..=Self::ROUNDS_MAX => Ok(Params { rounds }),

--- a/sha-crypt/tests/mcf.rs
+++ b/sha-crypt/tests/mcf.rs
@@ -1,3 +1,5 @@
+//! Modular Crypt Format (MCF) integration tests.
+
 #![cfg(feature = "password-hash")]
 
 use base64ct::{Base64ShaCrypt, Encoding};
@@ -104,7 +106,7 @@ fn hash_sha256_crypt() {
         }
     }
 
-    assert!(any)
+    assert!(any);
 }
 
 #[test]
@@ -124,7 +126,7 @@ fn hash_sha512_crypt() {
         }
     }
 
-    assert!(any)
+    assert!(any);
 }
 
 #[test]


### PR DESCRIPTION
Enables and fixes the workspace-level lints added in #884, which is a standard configuration we're using across repositories