### PR TITLE
sha-crypt: `no_alloc` support

### DIFF
--- a/sha-crypt/Cargo.toml
+++ b/sha-crypt/Cargo.toml
@@ -19,15 +19,17 @@ rust-version = "1.85"
 
 [dependencies]
 sha2 = { version = "0.11", default-features = false }
-base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
+base64ct = { version = "1.8", default-features = false }
 
 # optional dependencies
 ctutils = { version = "0.4", optional = true }
-mcf = { version = "0.6", optional = true, default-features = false, features = ["alloc", "base64"] }
+mcf = { version = "0.6", optional = true, default-features = false, features = ["base64"] }
 password-hash = { version = "0.6", optional = true, default-features = false }
 
 [features]
-default = ["password-hash"]
+default = ["alloc", "password-hash"]
+alloc = ["base64ct/alloc", "mcf?/alloc"]
+
 getrandom = ["password-hash/getrandom", "password-hash"]
 rand_core = ["password-hash/rand_core"]
 password-hash = ["dep:ctutils", "dep:mcf", "dep:password-hash"]

--- a/sha-crypt/src/lib.rs
+++ b/sha-crypt/src/lib.rs
@@ -28,10 +28,6 @@
 //! # }
 //! ```
 
-// TODO(tarcieri): heapless support
-#[macro_use]
-extern crate alloc;
-
 mod errors;
 mod params;
 
@@ -49,12 +45,14 @@ pub use crate::{
 pub use {
     crate::{
         algorithm::Algorithm,
-        mcf::{PasswordHash, PasswordHashRef, ShaCrypt},
+        mcf::{PasswordHashRef, ShaCrypt},
     },
     password_hash::{self, CustomizedPasswordHasher, PasswordHasher, PasswordVerifier},
 };
 
-use alloc::vec::Vec;
+#[cfg(all(feature = "password-hash", feature = "alloc"))]
+pub use ::mcf::PasswordHash;
+
 use sha2::{Digest, Sha256, Sha512};
 
 /// Block size for SHA-256-crypt.
@@ -97,7 +95,7 @@ pub fn sha256_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 
     // 16.
     // Create byte sequence P.
-    let p_vec = produce_byte_seq(pw_len, &dp);
+    // NOTE: deferred until below and computed on-the-fly. See `hash_byte_seq(pw_len...`)
 
     // 17.
     hasher_alt = Sha256::default();
@@ -114,7 +112,7 @@ pub fn sha256_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 
     // 20.
     // Create byte sequence S.
-    let s_vec = produce_byte_seq(salt_len, &ds);
+    // NOTE: deferred until below and computed on-the-fly. See `hash_byte_seq(salt_len...`)
 
     let mut digest_c = digest_a;
     // Repeatedly run the collected hash value through SHA256 to burn
@@ -125,26 +123,26 @@ pub fn sha256_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 
         // Add key or last result
         if (i & 1) != 0 {
-            hasher.update(&p_vec);
+            hash_byte_seq(pw_len, &dp, &mut hasher);
         } else {
             hasher.update(digest_c);
         }
 
         // Add salt for numbers not divisible by 3
         if i % 3 != 0 {
-            hasher.update(&s_vec);
+            hash_byte_seq(salt_len, &ds, &mut hasher);
         }
 
         // Add key for numbers not divisible by 7
         if i % 7 != 0 {
-            hasher.update(&p_vec);
+            hash_byte_seq(pw_len, &dp, &mut hasher);
         }
 
         // Add key or last result
         if (i & 1) != 0 {
             hasher.update(digest_c);
         } else {
-            hasher.update(&p_vec);
+            hash_byte_seq(pw_len, &dp, &mut hasher);
         }
 
         digest_c.clone_from_slice(&hasher.finalize());
@@ -187,7 +185,7 @@ pub fn sha512_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 
     // 16.
     // Create byte sequence P.
-    let p_vec = produce_byte_seq(pw_len, &dp);
+    // NOTE: deferred until below and computed on-the-fly. See `hash_byte_seq(pw_len...`)
 
     // 17.
     hasher_alt = Sha512::default();
@@ -204,7 +202,7 @@ pub fn sha512_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 
     // 20.
     // Create byte sequence S.
-    let s_vec = produce_byte_seq(salt_len, &ds);
+    // NOTE: deferred until below and computed on-the-fly. See `hash_byte_seq(salt_len...`)
 
     let mut digest_c = digest_a;
     // Repeatedly run the collected hash value through SHA512 to burn
@@ -215,26 +213,26 @@ pub fn sha512_crypt(password: &[u8], salt: &[u8], params: Params) -> [u8; BLOCK_
 
         // Add key or last result
         if (i & 1) != 0 {
-            hasher.update(&p_vec);
+            hash_byte_seq(pw_len, &dp, &mut hasher);
         } else {
             hasher.update(digest_c);
         }
 
         // Add salt for numbers not divisible by 3
         if i % 3 != 0 {
-            hasher.update(&s_vec);
+            hash_byte_seq(salt_len, &ds, &mut hasher);
         }
 
         // Add key for numbers not divisible by 7
         if i % 7 != 0 {
-            hasher.update(&p_vec);
+            hash_byte_seq(pw_len, &dp, &mut hasher);
         }
 
         // Add key or last result
         if (i & 1) != 0 {
             hasher.update(digest_c);
         } else {
-            hasher.update(&p_vec);
+            hash_byte_seq(pw_len, &dp, &mut hasher);
         }
 
         digest_c.clone_from_slice(&hasher.finalize());
@@ -329,15 +327,10 @@ fn sha512_crypt_intermediate(password: &[u8], salt: &[u8]) -> [u8; BLOCK_SIZE_SH
     hasher.finalize().into()
 }
 
-fn produce_byte_seq(len: usize, fill_from: &[u8]) -> Vec<u8> {
+fn hash_byte_seq<D: Digest>(len: usize, fill_from: &[u8], digest: &mut D) {
     let bs = fill_from.len();
-    let mut seq: Vec<u8> = vec![0; len];
-    let mut offset: usize = 0;
     for _ in 0..(len / bs) {
-        seq[offset..offset + bs].clone_from_slice(fill_from);
-        offset += bs;
+        digest.update(fill_from);
     }
-    let from_slice = &fill_from[..(len % bs)];
-    seq[offset..offset + (len % bs)].clone_from_slice(from_slice);
-    seq
+    digest.update(&fill_from[..(len % bs)]);
 }

--- a/sha-crypt/src/mcf.rs
+++ b/sha-crypt/src/mcf.rs
@@ -1,14 +1,18 @@
 //! Implementation of the `password-hash` crate API.
 
-pub use mcf::{PasswordHash, PasswordHashRef};
+pub use mcf::PasswordHashRef;
 
 use crate::{BLOCK_SIZE_SHA256, BLOCK_SIZE_SHA512, Params, algorithm::Algorithm};
-use base64ct::{Base64ShaCrypt, Encoding};
 use core::str::FromStr;
 use ctutils::CtEq;
 use mcf::Base64;
-use password_hash::{
-    CustomizedPasswordHasher, Error, PasswordHasher, PasswordVerifier, Result, Version,
+use password_hash::{Error, PasswordVerifier, Result};
+
+#[cfg(feature = "alloc")]
+use {
+    base64ct::{Base64ShaCrypt, Encoding},
+    mcf::PasswordHash,
+    password_hash::{CustomizedPasswordHasher, PasswordHasher, Version},
 };
 
 /// SHA-crypt type for use with the [`PasswordHasher`] and [`PasswordVerifier`] traits, which can
@@ -36,6 +40,7 @@ impl ShaCrypt {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl CustomizedPasswordHasher<PasswordHash> for ShaCrypt {
     type Params = Params;
 
@@ -83,12 +88,14 @@ impl CustomizedPasswordHasher<PasswordHash> for ShaCrypt {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl PasswordHasher<PasswordHash> for ShaCrypt {
     fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
         self.hash_password_customized(password, salt, None, None, self.params)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl PasswordVerifier<PasswordHash> for ShaCrypt {
     fn verify_password(&self, password: &[u8], hash: &PasswordHash) -> Result<()> {
         self.verify_password(password, hash.as_password_hash_ref())
@@ -113,10 +120,11 @@ impl PasswordVerifier<PasswordHashRef> for ShaCrypt {
         let salt = next.as_str().as_bytes();
 
         // decode expected password hash
+        let mut buf = [0u8; BLOCK_SIZE_SHA512];
         let expected = fields
             .next()
             .ok_or(Error::EncodingInvalid)?
-            .decode_base64(Base64::Crypt)
+            .decode_base64_into(Base64::Crypt, &mut buf)
             .map_err(|_| Error::EncodingInvalid)?;
 
         // should be the last field
@@ -127,10 +135,10 @@ impl PasswordVerifier<PasswordHashRef> for ShaCrypt {
         let is_valid = match alg {
             Algorithm::Sha256Crypt => sha256_crypt_core(password, salt, params)
                 .as_ref()
-                .ct_eq(&expected),
+                .ct_eq(expected),
             Algorithm::Sha512Crypt => sha512_crypt_core(password, salt, params)
                 .as_ref()
-                .ct_eq(&expected),
+                .ct_eq(expected),
         };
 
         if (!is_valid).into() {

--- a/sha-crypt/tests/mcf.rs
+++ b/sha-crypt/tests/mcf.rs
@@ -1,6 +1,6 @@
 //! Modular Crypt Format (MCF) integration tests.
 
-#![cfg(feature = "password-hash")]
+#![cfg(all(feature = "alloc", feature = "password-hash"))]
 
 use base64ct::{Base64ShaCrypt, Encoding};
 use mcf::PasswordHash;


### PR DESCRIPTION
Removes the last superfluous use of `Vec`, replacing it with a function that computes what inputs should be provided to a hash function which is updated on-the-fly.

This gives us baseline `no_alloc` which can be used with the free function-based API and can even be used to verify MCF hashes.