### PR TITLE
widen s_cost * p_cost to usize when sizing parallel memory

### DIFF
--- a/balloon-hash/src/balloon.rs
+++ b/balloon-hash/src/balloon.rs
@@ -49,7 +49,7 @@ where
     let output_xor = {
         use rayon::iter::{ParallelBridge, ParallelIterator};
 
-        if memory_blocks.len() < (params.s_cost.get() * params.p_cost.get()) as usize {
+        if memory_blocks.len() < params.s_cost.get() as usize * params.p_cost.get() as usize {
             return Err(Error::MemoryTooLittle);
         }
 

--- a/balloon-hash/src/lib.rs
+++ b/balloon-hash/src/lib.rs
@@ -132,7 +132,7 @@ where
         #[cfg(not(feature = "parallel"))]
         let mut memory = alloc::vec![Array::default(); self.params.s_cost.get() as usize];
         #[cfg(feature = "parallel")]
-        let mut memory = alloc::vec![Array::default(); (self.params.s_cost.get() * self.params.p_cost.get()) as usize];
+        let mut memory = alloc::vec![Array::default(); self.params.s_cost.get() as usize * self.params.p_cost.get() as usize];
 
         self.hash_password_into_with_memory(pwd, salt, &mut memory, output)?;
         #[cfg(feature = "zeroize")]


### PR DESCRIPTION
With the parallel feature, hash_password_into and balloon_m size the per-thread memory as s_cost * p_cost evaluated in u32 and only then cast to usize. Both come from NonZeroU32 params and can be parsed from a hash string, so a product reaching 2^32 wraps: release builds get an undersized (often zero-length) buffer and a passing MemoryTooLittle check, debug builds panic on the multiply. Casting each operand to usize first computes the real size on 64-bit targets.