### PR TITLE
avoid usize overflow when sizing scratch buffers in yescrypt_body

### DIFF
--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -130,9 +130,9 @@ fn yescrypt_body(
         return Err(Error::Params);
     }
 
-    let mut v = vec![0; 32 * (r as usize) * usize::try_from(n)?];
-    let mut b = vec![0; 32 * (r as usize) * (p as usize)];
-    let mut xy = vec![0; 64 * (r as usize)];
+    let mut v = vec![0; usize::try_from(32 * u64::from(r) * n)?];
+    let mut b = vec![0; usize::try_from(32 * u64::from(r) * u64::from(p))?];
+    let mut xy = vec![0; usize::try_from(64 * u64::from(r))?];
 
     let mut passwd = passwd;
     let mut sha256 = [0u8; 32];


### PR DESCRIPTION
The scratch buffers in `yescrypt_body` are sized with `32 * (r as usize) * (n as usize)` and friends. r/n/p come from a parsed `$y$` hash, and on 32-bit targets that multiply wraps even though the u64 validation just above passes: classic-mode n=65536, r=32768 makes `32*r*n` reach 2^36, wrapping to 0 so V becomes `vec![0; 0]` and `smix1` writes past it (debug builds panic on the overflow). Compute the lengths in u64, already bounded by the checks, and convert with `usize::try_from` like the existing n cast.