### PR TITLE
widen r * p to u64 in scrypt params bounds check

### DIFF
--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -96,7 +96,7 @@ impl Params {
         // check: p <= ((2^32-1) * 32) / (128 * r)
         // It takes a bit of re-arranging to get the check above into this form,
         // but it is indeed the same.
-        if r * p >= 0x4000_0000 {
+        if u64::from(r) * u64::from(p) >= 0x4000_0000 {
             return Err(InvalidParams);
         }
 


### PR DESCRIPTION
Noticed the final guard in `Params::new` computes `r * p` in u32, but both come from a parsed PHC hash string and the earlier checked_mul guards only bound the usize products. On 64-bit, r=65536 p=65536 reaches this line: the u32 multiply wraps to 0, so `r * p >= 0x4000_0000` is false and scrypt accepts params it must reject (debug builds panic on the overflow instead). Widen both operands to u64 before the compare.