### PR TITLE
avoid u64 overflow in yescrypt prehash work-factor check

### DIFF
--- a/yescrypt/src/lib.rs
+++ b/yescrypt/src/lib.rs
@@ -93,7 +93,7 @@ pub fn yescrypt(passwd: &[u8], salt: &[u8], params: &Params, out: &mut [u8]) -> 
     if params.mode.is_rw()
         && params.p >= 1
         && params.n / u64::from(params.p) >= 0x100
-        && params.n / u64::from(params.p) * u64::from(params.r) >= 0x20000
+        && u128::from(params.n / u64::from(params.p)) * u128::from(params.r) >= 0x20000
     {
         let mut prehash_params = *params;
         prehash_params.n >>= 6;


### PR DESCRIPTION
yescrypt() gates pre-hashing on `N / p * r >= 0x20000` computed in u64. For rw-mode params, N and r aren't bounded here (the rw `Params` validator checks neither N nor r*p), so a parsed `$y$` hash with large N and r overflows the multiply and panics in debug builds at lib.rs:96. The check just below at line 127 already uses the division form to dodge this; widen the prehash operands to u128 to match.